### PR TITLE
Premake fix for BX_DIR and DXSDK library path

### DIFF
--- a/premake/premake4.lua
+++ b/premake/premake4.lua
@@ -36,7 +36,7 @@ BGFX_DIR = (path.getabsolute("..") .. "/")
 local BGFX_BUILD_DIR = (BGFX_DIR .. ".build/")
 local BGFX_THIRD_PARTY_DIR = (BGFX_DIR .. "3rdparty/")
 
-BX_DIR = (BGFX_DIR .. "/../../bx/")
+BX_DIR = (BGFX_DIR .. "../bx/")
 
 local XEDK = os.getenv("XEDK")
 if not XEDK then XEDK = "<you must install XBOX SDK>" end
@@ -141,13 +141,19 @@ configuration { "vs*" }
 configuration { "x32", "vs*" }
 	targetdir (BGFX_BUILD_DIR .. "win32_" .. _ACTION .. "/bin")
 	objdir (BGFX_BUILD_DIR .. "win32_" .. _ACTION .. "/obj")
-	libdirs { BGFX_THIRD_PARTY_DIR .. "lib/win32_" .. _ACTION }
+	libdirs {
+		BGFX_THIRD_PARTY_DIR .. "lib/win32_" .. _ACTION,
+		"$(DXSDK_DIR)/lib/x86",
+	}
 
 configuration { "x64", "vs*" }
 	defines { "_WIN64" }
 	targetdir (BGFX_BUILD_DIR .. "win64_" .. _ACTION .. "/bin")
 	objdir (BGFX_BUILD_DIR .. "win64_" .. _ACTION .. "/obj")
-	libdirs { BGFX_THIRD_PARTY_DIR .. "lib/win64_" .. _ACTION }
+	libdirs {
+		BGFX_THIRD_PARTY_DIR .. "lib/win64_" .. _ACTION,
+		"$(DXSDK_DIR)/lib/x64",
+	}
 
 configuration { "mingw" }
 	defines { "WIN32" }


### PR DESCRIPTION
1. Modified BX_DIR to match usage in bgfx.lua:7, this allows visual
   studio to correctly locate the compat/msvc directory.
2. Added DXSDK libdirs to 32/64-bit vs\* configurations so that visual
   studio can link with the appropriate DX libraries.
   NOTE: I added this to the vs-specific configuration, not the general
   windows configuration because I suspect that MINGW builds will use their
   own DX libraries.

I agree to comply with the BSD-2 clause license.
