### PR TITLE
small fix for linux and opengl 31

### DIFF
--- a/src/glcontext_glx.h
+++ b/src/glcontext_glx.h
@@ -9,6 +9,7 @@
 #if BX_PLATFORM_LINUX
 
 #	include <X11/Xlib.h>
+#	include <GL/glx.h>
 
 namespace bgfx
 {


### PR DESCRIPTION
fixed include file when compiling under linux with BGFX_CONFIG_RENDERER_OPENGL set to 31
