### PR TITLE
Build fix for OSX gmake

### DIFF
--- a/premake/bgfx.lua
+++ b/premake/bgfx.lua
@@ -30,7 +30,7 @@ project "bgfx"
 			BGFX_DIR .. "src/**.mm",
 		}
 
-	configuration { "vs* or linux or mingw" }
+	configuration { "vs* or linux or mingw or osx" }
 		includedirs {
 			--nacl has GLES2 headers modified...
 			BGFX_DIR .. "3rdparty/glext",

--- a/src/glcontext_nsgl.mm
+++ b/src/glcontext_nsgl.mm
@@ -80,7 +80,7 @@ namespace bgfx
 		[glView release];
 	}
 
-	void GlContext::resize(uint32_t _width, uint32_t _height)
+	void GlContext::resize(uint32_t _width, uint32_t _height, bool _vsync)
 	{
 	}
 


### PR DESCRIPTION
Outstanding issues:
- gmake binaries fail for unknown reason
- XCode projects not picking up bx/include/compat/osx for unknown reason.
