### PR TITLE
fix for intel graphics media accelerator card (GL 2.1)

### DIFF
--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -280,6 +280,22 @@ namespace bgfx
 			{ \
 				_func = (_proto)bx::dlsym(m_opengl32dll, #_func); \
 			} \
+		  if (_func == NULL) \
+			{ \
+			  _func = (_proto) wglGetProcAddress(#_func "ARB"); \
+	    } \
+			if (_func == NULL) \
+			{ \
+				_func = (_proto)bx::dlsym(m_opengl32dll, #_func "ARB"); \
+			} \
+		  if (_func == NULL) \
+			{ \
+			  _func = (_proto) wglGetProcAddress(#_func "EXT"); \
+	    } \
+			if (_func == NULL) \
+			{ \
+				_func = (_proto)bx::dlsym(m_opengl32dll, #_func "EXT"); \
+			} \
 			BGFX_FATAL(_optional || NULL != _func, Fatal::UnableToInitialize, "Failed to create OpenGL context. wglGetProcAddress(\"%s\")", #_func); \
 		}
 #	include "glimports.h"

--- a/src/glimports.h
+++ b/src/glimports.h
@@ -93,7 +93,7 @@ GL_IMPORT(false, PFNGLBINDRENDERBUFFERPROC,               glBindRenderbuffer);
 GL_IMPORT(false, PFNGLGENRENDERBUFFERSPROC,               glGenRenderbuffers);
 GL_IMPORT(false, PFNGLDELETERENDERBUFFERSPROC,            glDeleteRenderbuffers);
 GL_IMPORT(false, PFNGLRENDERBUFFERSTORAGEPROC,            glRenderbufferStorage);
-GL_IMPORT(false, PFNGLRENDERBUFFERSTORAGEMULTISAMPLEPROC, glRenderbufferStorageMultisample);
+GL_IMPORT( true, PFNGLRENDERBUFFERSTORAGEMULTISAMPLEPROC, glRenderbufferStorageMultisample);
 GL_IMPORT(false, PFNGLUNIFORM1IPROC,                      glUniform1i);
 GL_IMPORT(false, PFNGLUNIFORM1IVPROC,                     glUniform1iv);
 GL_IMPORT(false, PFNGLUNIFORM1FPROC,                      glUniform1f);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1231,6 +1231,7 @@ namespace bgfx
 					GL_CHECK(s_vertexAttribDivisor(loc, 0) );
 
 					uint32_t baseVertex = _baseVertex*_vertexDecl.m_stride + _vertexDecl.m_offset[attr];
+          // assert here: invalid enum HALF_FLOAT under opengl 2.1
 					GL_CHECK(glVertexAttribPointer(loc, num, s_attribType[type], normalized, _vertexDecl.m_stride, (void*)(uintptr_t)baseVertex) );
 				}
 				else


### PR DESCRIPTION
hello,

could you guys look into this?
i had to tweak the extension loader to get bgfx to work in a legacy video card (2.1). 
all examples are working now, but one. #14 is asserting because i dont think half_float is supported on 2.1

other than that, top notch :)
lib looks promising and very clean, congrats :D
keep up the good work
