### PR TITLE
Use NULL as instance when loading predefined icon/cursor

### DIFF
--- a/examples/common/entry/entry_windows.cpp
+++ b/examples/common/entry/entry_windows.cpp
@@ -160,11 +160,11 @@ namespace entry
 			wnd.cbSize = sizeof(wnd);
 			wnd.lpfnWndProc = DefWindowProc;
 			wnd.hInstance = instance;
-			wnd.hIcon = LoadIcon(instance, IDI_APPLICATION);
-			wnd.hCursor = LoadCursor(instance, IDC_ARROW);
+			wnd.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+			wnd.hCursor = LoadCursor(NULL, IDC_ARROW);
 			wnd.hbrBackground = (HBRUSH)GetStockObject(BLACK_BRUSH);
 			wnd.lpszClassName = "bgfx_letterbox";
-			wnd.hIconSm = LoadIcon(instance, IDI_APPLICATION);
+			wnd.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
 			RegisterClassExA(&wnd);
 
 			memset(&wnd, 0, sizeof(wnd) );
@@ -172,10 +172,10 @@ namespace entry
 			wnd.style = CS_HREDRAW | CS_VREDRAW;
 			wnd.lpfnWndProc = wndProc;
 			wnd.hInstance = instance;
-			wnd.hIcon = LoadIcon(instance, IDI_APPLICATION);
-			wnd.hCursor = LoadCursor(instance, IDC_ARROW);
+			wnd.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+			wnd.hCursor = LoadCursor(NULL, IDC_ARROW);
 			wnd.lpszClassName = "bgfx";
-			wnd.hIconSm = LoadIcon(instance, IDI_APPLICATION);
+			wnd.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
 			RegisterClassExA(&wnd);
 
 			HWND hwnd = CreateWindowA("bgfx_letterbox"


### PR DESCRIPTION
Per http://msdn.microsoft.com/en-us/library/windows/desktop/ms648391(v=vs.85).aspx

"To use one of the predefined cursors, the application must set the hInstance parameter to NULL and the lpCursorName parameter to one the following values."

When set to GetModuleHandle(NULL) these fail and return NULL. As WM_SETCURSOR isn't handled elsewhere the cursor isn't otherwise set and ends up being whatever something else set (generally the last thing the non-client area sets as the cursor moves into the client area).
