### PR TITLE
Defining round function isn't required for vs2013 or newer.

### DIFF
--- a/examples/20-nanovg/nanovg.cpp
+++ b/examples/20-nanovg/nanovg.cpp
@@ -833,10 +833,12 @@ void freeDemoData(struct NVGcontext* vg, struct DemoData* data)
 		nvgDeleteImage(vg, data->images[i]);
 }
 
+#if _MSC_VER < 1800
 inline float round(float _f)
 {
 	return float(int(_f) );
 }
+#endif
 
 void drawParagraph(struct NVGcontext* vg, float x, float y, float width, float height, float mx, float my)
 {


### PR DESCRIPTION
This throws a compile error on vs2013 due to redefining the `round` function.

Avoid redefining it if we're running on a modern enough version of visual studio.
