### PR TITLE
Use IDirect3DResource9* as the unified shader type

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1975,8 +1975,10 @@ namespace bgfx
 
 		if (fragment)
 		{
-			DX_CHECK(s_renderD3D11->m_device->CreatePixelShader(code, shaderSize, NULL, (ID3D11PixelShader**)&m_ptr) );
-			BGFX_FATAL(NULL != m_ptr, bgfx::Fatal::InvalidShader, "Failed to create fragment shader.");
+			ID3D11PixelShader* pixelShader;
+			DX_CHECK(s_renderD3D11->m_device->CreatePixelShader(code, shaderSize, NULL, &pixelShader);
+			BGFX_FATAL(NULL != pixelShader, bgfx::Fatal::InvalidShader, "Failed to create fragment shader.");
+			m_ptr = pixelShader;
 		}
 		else
 		{
@@ -1984,8 +1986,10 @@ namespace bgfx
 			m_code = alloc(shaderSize);
 			memcpy(m_code->data, code, shaderSize);
 
-			DX_CHECK(s_renderD3D11->m_device->CreateVertexShader(code, shaderSize, NULL, (ID3D11VertexShader**)&m_ptr) );
-			BGFX_FATAL(NULL != m_ptr, bgfx::Fatal::InvalidShader, "Failed to create vertex shader.");
+			ID3D11VertexShader* vertexShader;
+			DX_CHECK(s_renderD3D11->m_device->CreateVertexShader(code, shaderSize, NULL, &vertexShader);
+			BGFX_FATAL(NULL != vertexShader, bgfx::Fatal::InvalidShader, "Failed to create vertex shader.");
+			m_ptr = vertexShader;
 		}
 
 		bx::read(&reader, m_attrMask, sizeof(m_attrMask) );

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1735,13 +1735,17 @@ namespace bgfx
 
 		if (fragment)
 		{
-			DX_CHECK(s_renderD3D9->m_device->CreatePixelShader(code, (IDirect3DPixelShader9**)&m_ptr) );
-			BGFX_FATAL(NULL != m_ptr, bgfx::Fatal::InvalidShader, "Failed to create fragment shader.");
+			IDirect3DPixelShader9* pixelShader;
+			DX_CHECK(s_renderD3D9->m_device->CreatePixelShader(code, &pixelShader));
+			BGFX_FATAL(NULL != pixelShader, bgfx::Fatal::InvalidShader, "Failed to create fragment shader.");
+			m_ptr = pixelShader;
 		}
 		else
 		{
-			DX_CHECK(s_renderD3D9->m_device->CreateVertexShader(code, (IDirect3DVertexShader9**)&m_ptr) );
-			BGFX_FATAL(NULL != m_ptr, bgfx::Fatal::InvalidShader, "Failed to create vertex shader.");
+			IDirect3DVertexShader9* vertexShader;
+			DX_CHECK(s_renderD3D9->m_device->CreateVertexShader(code, &vertexShader));
+			BGFX_FATAL(NULL != vertexShader, bgfx::Fatal::InvalidShader, "Failed to create vertex shader.");
+			m_ptr = vertexShader;
 		}
 	}
 

--- a/src/renderer_d3d9.h
+++ b/src/renderer_d3d9.h
@@ -18,6 +18,7 @@
 typedef HRESULT (WINAPI *Direct3DCreate9ExFn)(UINT SDKVersion, IDirect3D9Ex**);
 #	endif // BGFX_CONFIG_RENDERER_DIRECT3D9EX
 typedef IDirect3D9* (WINAPI *Direct3DCreate9Fn)(UINT SDKVersion);
+typedef IUnknown DxShaderInterface;
 
 #elif BX_PLATFORM_XBOX360
 #	include <xgraphics.h>
@@ -27,6 +28,8 @@ typedef IDirect3D9* (WINAPI *Direct3DCreate9Fn)(UINT SDKVersion);
 #	define D3DERR_DEVICEREMOVED D3DERR_DEVICELOST // not supported on X360
 #	define D3DMULTISAMPLE_8_SAMPLES D3DMULTISAMPLE_4_SAMPLES
 #	define D3DMULTISAMPLE_16_SAMPLES D3DMULTISAMPLE_4_SAMPLES
+
+typedef IDirect3DResource9 DxShaderInterface;
 
 #	define D3DFMT_DF24 D3DFMT_D24FS8
 
@@ -239,7 +242,7 @@ namespace bgfx
 			DX_RELEASE(m_ptr, 0);
 		}
 
-		IUnknown* m_ptr;
+		DxShaderInterface* m_ptr;
 		ConstantBuffer* m_constantBuffer;
 		PredefinedUniform m_predefined[PredefinedUniform::Count];
 		uint8_t m_numPredefined;


### PR DESCRIPTION
Xbox360 shader types don't actually inherit from the IUnknown interface in the
type system. In fact, these types don't implement COM at all, and calling any
functions through this interface (such as Release) will segfault at runtime.
For Xbox360 we use IDirect3DResource9\* as a standin for IUnknown*

Also updated the creation code in the dx9/dx11 renderers to avoid the
reinterpret cast and instead rely on the compiler's automatic type conversion
process to identify these issues at compile time.
