### PR TITLE
Fixed compilation for MacOS with Xcode 5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,15 @@ Visual Studio 2008 IDE:
 
 	start .build/projects/vs2008/bgfx.sln
 
+Xcode 5 IDE:
+
+	start .build/projects/xcode4/bgfx.xcworkspace
+Due to [inability](http://industriousone.com/debugdir) to set working directory for an Xcode project from premake configuration file, it has to be set manually for each example project:
+
+1. Open *"Edit scheme..."* dialog for a given project.
+2. Select *"Run"* settings.
+3. Check *"Use custom working directory"* and enter following path: `${PROJECT_DIR}/../../../examples/runtime`.
+
 Linux 64-bit:
 
 	make linux-release64

--- a/examples/common/nanovg/fontstash.h
+++ b/examples/common/nanovg/fontstash.h
@@ -236,8 +236,15 @@ int fons__tt_getGlyphKernAdvance(struct FONSttFontImpl *font, int glyph1, int gl
 static void* fons__tmpalloc(size_t size, void* up);
 static void fons__tmpfree(void* ptr, void* up);
 #else
-#	include <malloc.h>
+
+#ifdef __APPLE__
+#   include <malloc/malloc.h>
+#else
+#   include <malloc.h>
+#endif //__APPLE__
+
 #	include <string.h>
+
 #endif // 0
 
 #include <stb_truetype/stb_truetype.h>

--- a/premake/bgfx.lua
+++ b/premake/bgfx.lua
@@ -42,7 +42,7 @@ function bgfxProject(_name, _uuid, _kind)
 				"gdi32",
 			}
 
-		configuration { "osx or ios*" }
+		configuration { "xcode4 or osx or ios*" }
 			files {
 				BGFX_DIR .. "src/**.mm",
 			}

--- a/premake/premake4.lua
+++ b/premake/premake4.lua
@@ -129,6 +129,20 @@ function exampleProject(_name, _uuid)
 --			"SDL2",
 		}
 
+	configuration { "xcode4" }
+		platforms {
+			"Universal"
+		}
+		files {
+			BGFX_DIR .. "examples/common/**.mm",
+		}
+		links {
+			"Cocoa.framework",
+			"Foundation.framework",
+			"OpenGL.framework",
+--			"SDL2",
+		}
+
 	configuration { "ios*" }
 		kind "ConsoleApp"
 		files {

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -22,6 +22,7 @@
 #			define GL_GLEXT_LEGACY
 #			include <GL/gl.h>
 #			undef GL_PROTOTYPES
+#           include <gl/glext.h>
 #		elif BX_PLATFORM_OSX
 #			define GL_GLEXT_LEGACY
 #			define long ptrdiff_t
@@ -32,11 +33,11 @@
 #			undef GL_VERSION_1_4
 #			undef GL_VERSION_1_5
 #			undef GL_VERSION_2_0
+#           include <OpenGl/glext.h>
 #		else
 #			include <GL/gl.h>
+#           include <gl/glext.h>
 #		endif // BX_PLATFORM_
-
-#		include <gl/glext.h>
 #	endif // BGFX_CONFIG_RENDERER_OPENGL >= 31
 
 #elif BGFX_CONFIG_RENDERER_OPENGLES
@@ -190,6 +191,10 @@ typedef uint64_t GLuint64;
 #ifndef GL_RGBA16UI
 #	define GL_RGBA16UI 0x8D76
 #endif // GL_RGBA16UI
+
+#ifndef GL_RGB565
+#	define GL_RGB565 0x8D62
+#endif // GL_RGB565
 
 #ifndef GL_COMPRESSED_RGB_S3TC_DXT1_EXT
 #	define GL_COMPRESSED_RGB_S3TC_DXT1_EXT 0x83F0
@@ -484,6 +489,18 @@ typedef uint64_t GLuint64;
 #	define GL_LOCATION 0x930E
 #endif // GL_LOCATION
 
+#ifndef GL_DEBUG_SEVERITY_MEDIUM_ARB
+#	define GL_DEBUG_SEVERITY_MEDIUM_ARB 0x9147
+#endif // GL_DEBUG_SEVERITY_MEDIUM_ARB
+
+#ifndef GL_PROGRAM_BINARY_RETRIEVABLE_HINT
+#	define GL_PROGRAM_BINARY_RETRIEVABLE_HINT 0x8257
+#endif // GL_PROGRAM_BINARY_RETRIEVABLE_HINT
+
+#ifndef GL_PROGRAM_BINARY_LENGTH
+#	define GL_PROGRAM_BINARY_LENGTH 0x8741
+#endif // GL_PROGRAM_BINARY_LENGTH
+
 #if BX_PLATFORM_NACL
 #	include "glcontext_ppapi.h"
 #elif BX_PLATFORM_WINDOWS
@@ -501,7 +518,11 @@ typedef uint64_t GLuint64;
 #endif // BGFX_USE_WGL
 
 #ifndef GL_APIENTRY
-#	define GL_APIENTRY APIENTRY
+#   if BX_PLATFORM_OSX
+#       define GL_APIENTRY
+#   else
+#       define GL_APIENTRY APIENTRY
+#   endif // BX_PLATFORM_OSX
 #endif // GL_APIENTRY
 
 #ifndef GL_APIENTRYP


### PR DESCRIPTION
Made several simple fixes in order to get all examples built on OS X 10.9.4 with Xcode 5.1.1
1. Unfortunately [you can't](http://industriousone.com/debugdir) set working directory for an Xcode project from premake configuration file, you have to do it manualy.
2. For reasons unknown [they moved](http://stackoverflow.com/a/5929887/1682275) `<malloc.h>` to `<malloc/malloc.h>`.
3. Forcing architecture type (x86/x64) is undesirable for Xcode. Xcode tries to select it automatically. If architecture is forced in the generated Xcode project, you have to select it manually because symbols (e.g. Cocoa) might be unavailable for particular architecture when linking. Making a _Universal_ build prevents from manual choosing of architecture.
4. They moved `<gl/glext.h>` to `<OpenGl/glext.h>` as well.
5. Some GL defines were missing.
6. `APIENTRY` is not defined on not-Windows platforms.

P.S. Please replace **start** with **open** in my README.md changes (damn copy-pasting):
`open .build/projects/xcode4/bgfx.xcworkspace`
