### PR TITLE
Deleting unused 'copylib' function

### DIFF
--- a/premake/bgfx.lua
+++ b/premake/bgfx.lua
@@ -77,6 +77,4 @@ function bgfxProject(_name, _uuid, _kind, _defines)
 		}
 
 		configuration {}
-
-		copyLib()
 end

--- a/premake/premake4.lua
+++ b/premake/premake4.lua
@@ -40,9 +40,6 @@ defines {
 dofile (BX_DIR .. "premake/toolchain.lua")
 toolchain(BGFX_BUILD_DIR, BGFX_THIRD_PARTY_DIR)
 
-function copyLib()
-end
-
 function exampleProject(_name, _uuid)
 
 	project ("example-" .. _name)


### PR DESCRIPTION
"copyLib()" never used, deleting it.
