### PR TITLE
Fixes vertex allocation in the bgfx nanovg backend

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -774,7 +774,7 @@ namespace
 	}
 	
 	// Next Largest Power of 2
-	unsigned int nlpo2(register unsigned int x)
+	static unsigned int nlpo2(register unsigned int x)
 	{
 		x |= (x >> 1);
 		x |= (x >> 2);


### PR DESCRIPTION
Vertex allocation would be insufficient if gl->nverts+n was bigger than the next power-of-two level. This change actually allocates the POT level that is sufficient for the required amount of vertices, not just twice the previous one.

Attached image of the bug caught red-handed.

![nanovg bgfx POT bug](https://cloud.githubusercontent.com/assets/1451391/4253888/52eeb674-3aa5-11e4-937d-1f38351b155e.png)
