### PR TITLE
Fix for convexFill crash when path fillCount is 0

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -620,6 +620,7 @@ namespace
 
 		for (i = 0; i < npaths; i++)
 		{
+			if (paths[i].fillCount == 0) continue;
 			bgfx::setProgram(gl->prog);
 			bgfx::setState(gl->state);
 			bgfx::setVertexBuffer(&gl->tvb);


### PR DESCRIPTION
In our situation, the crash happened due to the view dimensions being reset to 0x0 after minimizing the window. This translated to fillCount of a path ending up at 0, which makes `fan` crash as it computes number of tris to -2 of fillCount. Since `numTris` is unsigned, this could lead to terrible things, but luckily it crashes soon.

There might be a cleaner fix for this further up the call stack, but this is a good solution in the meanwhile.
