### PR TITLE
Fix for crash with too many lines / vertices

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -30,6 +30,8 @@
 
 #include <bgfx.h>
 
+#include <bx\bx.h>
+
 namespace
 {
 #include "vs_nanovg_fill.bin.h"
@@ -686,6 +688,14 @@ namespace
 		if (gl->ncalls > 0)
 		{
 			bgfx::allocTransientVertexBuffer(&gl->tvb, gl->nverts, s_nvgDecl);
+			
+			int allocated = gl->tvb.size/gl->tvb.stride;
+			
+			if (allocated < gl->nverts) {
+				gl->nverts = allocated;
+				BX_WARN(true, "Vertex number truncated due to transient vertex buffer overflow");
+			}
+			
 
 			memcpy(gl->tvb.data, gl->verts, gl->nverts * sizeof(struct NVGvertex) );
 


### PR DESCRIPTION
When a lot of lines are being drawn, this can overflow the vertex buffer, causing a crash in `nvgRenderFlush`. While the underlying code handles this case in an okay manner (truncating the vertex buffer instead of crashing), the `nvgRenderFlush` code is missing a check for this case, causing it to think it has more space than was allocated.

I tried to fix it with multiple buffers as mentioned in #160, however it seems more complex than it appears. This fix just makes it truncate the output according to the actual allocated amount of bytes in the vertex buffer, so it doesn't crash at least.
