### PR TITLE
Added possibility to override default tinystl allocator for 'example-com...

### DIFF
--- a/examples/common/bgfx_utils.cpp
+++ b/examples/common/bgfx_utils.cpp
@@ -5,6 +5,8 @@
 
 #include <string.h> // strlen
 
+#include "common.h"
+
 #include <tinystl/allocator.h>
 #include <tinystl/vector.h>
 #include <tinystl/string.h>

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -3,7 +3,26 @@
  * License: http://www.opensource.org/licenses/BSD-2-Clause
  */
 
+#ifndef COMMON_H_HEADER_GUARD
+#define COMMON_H_HEADER_GUARD
+
 #include <bx/timer.h>
 #include <bx/fpumath.h>
 
 #include "entry/entry.h"
+
+// For a custom tinystl allocator, define this and implement TinyStlCustomAllocator somewhere in the project.
+#ifndef COMMON_CONFIG_USE_TINYSTL_CUSTOM_ALLOCATOR
+#	define COMMON_CONFIG_USE_TINYSTL_CUSTOM_ALLOCATOR 0
+#endif // COMMON_CONFIG_USE_TINYSTL
+
+#if COMMON_CONFIG_USE_TINYSTL_CUSTOM_ALLOCATOR
+struct TinyStlCustomAllocator
+{
+	static void* static_allocate(size_t _bytes);
+	static void static_deallocate(void* _ptr, size_t /*_bytes*/);
+};
+#	define TINYSTL_ALLOCATOR TinyStlCustomAllocator
+#endif //COMMON_CONFIG_USE_TINYSTL_CUSTOM_ALLOCATOR
+
+#endif // COMMON_H_HEADER_GUARD

--- a/examples/common/entry/cmd.cpp
+++ b/examples/common/entry/cmd.cpp
@@ -10,6 +10,7 @@
 #include <bx/hash.h>
 #include <bx/tokenizecmd.h>
 
+#include "../common.h"
 #include "dbg.h"
 #include "cmd.h"
 

--- a/examples/common/entry/entry_windows.cpp
+++ b/examples/common/entry/entry_windows.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "entry_p.h"
+#include "../common.h"
 
 #if ENTRY_CONFIG_USE_NATIVE && BX_PLATFORM_WINDOWS
 

--- a/examples/common/entry/input.cpp
+++ b/examples/common/entry/input.cpp
@@ -5,6 +5,7 @@
 
 #include <memory.h>
 
+#include "../common.h"
 #include "entry_p.h"
 #include "input.h"
 


### PR DESCRIPTION
...mon' project.