### PR TITLE
Trying fix osx 32bits

### DIFF
--- a/3rdparty/khronos/gl/glext.h
+++ b/3rdparty/khronos/gl/glext.h
@@ -465,8 +465,13 @@ GLAPI void APIENTRY glBlendEquation (GLenum mode);
 #ifndef GL_VERSION_1_5
 #define GL_VERSION_1_5 1
 #include <stddef.h>
+#if defined(__APPLE__) && defined(__i386__)
+typedef long GLsizeiptr;
+typedef long GLintptr;
+#else
 typedef ptrdiff_t GLsizeiptr;
 typedef ptrdiff_t GLintptr;
+#endif
 #define GL_BUFFER_SIZE                    0x8764
 #define GL_BUFFER_USAGE                   0x8765
 #define GL_QUERY_COUNTER_BITS             0x8864
@@ -4130,8 +4135,13 @@ GLAPI void APIENTRY glVertexBlendARB (GLint count);
 
 #ifndef GL_ARB_vertex_buffer_object
 #define GL_ARB_vertex_buffer_object 1
+#if defined(__APPLE__) && defined(__i386__)
+typedef long GLsizeiptrARB;
+typedef long GLintptrARB;
+#else
 typedef ptrdiff_t GLsizeiptrARB;
 typedef ptrdiff_t GLintptrARB;
+#endif
 #define GL_BUFFER_SIZE_ARB                0x8764
 #define GL_BUFFER_USAGE_ARB               0x8765
 #define GL_ARRAY_BUFFER_ARB               0x8892


### PR DESCRIPTION
When compile 32 bits version (osx-release32 or osx-debug32) fail with:
````
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: ../../osx32_clang/bin/libexample-commonDebug.a(entry_x11.o) has no symbols
==== Building bgfx (debug32) ====
Creating ../../osx32_clang/obj/x32/Debug/bgfx
glcontext_eagl.mm
glcontext_nsgl.mm
In file included from ../../../src/glcontext_nsgl.mm:9:
In file included from ../../../src/renderer_gl.h:39:
../../../3rdparty/khronos/gl/glext.h:468:19: fatal error: typedef redefinition with different types ('ptrdiff_t' (aka 'int') vs 'intptr_t' (aka 'long'))
typedef ptrdiff_t GLsizeiptr;
                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.10.sdk/System/Library/Frameworks/OpenGL.framework/Headers/gltypes.h:52:18: note: previous definition is here
typedef intptr_t GLsizeiptr;
                 ^
1 error generated.
make[2]: *** [../../osx32_clang/obj/x32/Debug/bgfx/src/glcontext_nsgl.o] Error 1
make[1]: *** [bgfx] Error 2
make: *** [osx-debug32] Error 2
````

64bits build compile fine.

This pull request is a workaround based on http://loomsdk.com/forums/loom-with-native-c/topics/can-t-build-native-sdk-on-os-x-yosemite