### PR TITLE
bgfx genie scripts: use path.join to compose paths

### DIFF
--- a/scripts/bgfx.lua
+++ b/scripts/bgfx.lua
@@ -29,8 +29,8 @@ function bgfxProject(_name, _kind, _defines)
 		end
 
 		includedirs {
-			BGFX_DIR .. "3rdparty",
-			BGFX_DIR .. "../bx/include",
+			path.join(BGFX_DIR, "3rdparty"),
+			path.join(BGFX_DIR, "../bx/include"),
 		}
 
 		defines {
@@ -69,7 +69,7 @@ function bgfxProject(_name, _kind, _defines)
 
 		configuration { "xcode4 or osx or ios*" }
 			files {
-				BGFX_DIR .. "src/**.mm",
+				path.join(BGFX_DIR, "src/**.mm"),
 			}
 
 		configuration { "osx" }
@@ -80,7 +80,7 @@ function bgfxProject(_name, _kind, _defines)
 		configuration { "not nacl" }
 			includedirs {
 				--nacl has GLES2 headers modified...
-				BGFX_DIR .. "3rdparty/khronos",
+				path.join(BGFX_DIR, "3rdparty/khronos"),
 			}
 
 		configuration { "x64", "vs* or mingw*" }
@@ -91,17 +91,17 @@ function bgfxProject(_name, _kind, _defines)
 		configuration {}
 
 		includedirs {
-			BGFX_DIR .. "include",
+			path.join(BGFX_DIR, "include"),
 		}
 
 		files {
-			BGFX_DIR .. "include/**.h",
-			BGFX_DIR .. "src/**.cpp",
-			BGFX_DIR .. "src/**.h",
+			path.join(BGFX_DIR, "include/**.h"),
+			path.join(BGFX_DIR, "src/**.cpp"),
+			path.join(BGFX_DIR, "src/**.h"),
 		}
 
 		excludes {
-			BGFX_DIR .. "src/**.bin.h",
+			path.join(BGFX_DIR, "src/**.bin.h"),
 		}
 
 		configuration {}

--- a/scripts/example-common.lua
+++ b/scripts/example-common.lua
@@ -8,18 +8,18 @@ project ("example-common")
 	kind "StaticLib"
 
 	includedirs {
-		BX_DIR .. "include",
-		BGFX_DIR .. "include",
-		BGFX_DIR .. "3rdparty",
+		path.join(BX_DIR, "include"),
+		path.join(BGFX_DIR, "include"),
+		path.join(BGFX_DIR, "3rdparty"),
 	}
 
 	files {
-		BGFX_DIR .. "3rdparty/ib-compress/**.cpp",
-		BGFX_DIR .. "3rdparty/ib-compress/**.h",
-		BGFX_DIR .. "3rdparty/ocornut-imgui/**.cpp",
-		BGFX_DIR .. "3rdparty/ocornut-imgui/**.h",
-		BGFX_DIR .. "examples/common/**.cpp",
-		BGFX_DIR .. "examples/common/**.h",
+		path.join(BGFX_DIR, "3rdparty/ib-compress/**.cpp"),
+		path.join(BGFX_DIR, "3rdparty/ib-compress/**.h"),
+		path.join(BGFX_DIR, "3rdparty/ocornut-imgui/**.cpp"),
+		path.join(BGFX_DIR, "3rdparty/ocornut-imgui/**.h"),
+		path.join(BGFX_DIR, "examples/common/**.cpp"),
+		path.join(BGFX_DIR, "examples/common/**.h"),
 	}
 
 	if _OPTIONS["with-sdl"] then

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -45,16 +45,16 @@ solution "bgfx"
 	language "C++"
 	startproject "example-00-helloworld"
 
-BGFX_DIR = (path.getabsolute("..") .. "/")
-local BGFX_BUILD_DIR = (BGFX_DIR .. ".build/")
-local BGFX_THIRD_PARTY_DIR = (BGFX_DIR .. "3rdparty/")
-BX_DIR = (BGFX_DIR .. "../bx/")
+BGFX_DIR = path.getabsolute("..")
+local BGFX_BUILD_DIR = path.join(BGFX_DIR, ".build")
+local BGFX_THIRD_PARTY_DIR = path.join(BGFX_DIR, "3rdparty")
+BX_DIR = path.getabsolute(path.join(BGFX_DIR, "../bx"))
 
 defines {
 	"BX_CONFIG_ENABLE_MSVC_LEVEL4_WARNINGS=1"
 }
 
-dofile (BX_DIR .. "scripts/toolchain.lua")
+dofile (path.join(BX_DIR, "scripts/toolchain.lua"))
 if not toolchain(BGFX_BUILD_DIR, BGFX_THIRD_PARTY_DIR) then
 	return -- no action specified
 end
@@ -80,19 +80,19 @@ function exampleProject(_name)
 
 	-- don't output debugdir for winphone builds
 	if "winphone81" ~= _OPTIONS["vs"] then
-		debugdir (BGFX_DIR .. "examples/runtime/")
+		debugdir (path.join(BGFX_DIR, "examples/runtime"))
 	end
 
 	includedirs {
-		BX_DIR .. "include",
-		BGFX_DIR .. "include",
-		BGFX_DIR .. "3rdparty",
-		BGFX_DIR .. "examples/common",
+		path.join(BX_DIR, "include"),
+		path.join(BGFX_DIR, "include"),
+		path.join(BGFX_DIR, "3rdparty"),
+		path.join(BGFX_DIR, "examples/common"),
 	}
 
 	files {
-		BGFX_DIR .. "examples/" .. _name .. "/**.cpp",
-		BGFX_DIR .. "examples/" .. _name .. "/**.h",
+		path.join(BGFX_DIR, "examples", _name, "**.cpp"),
+		path.join(BGFX_DIR, "examples", _name, "**.h"),
 	}
 
 	links {
@@ -120,10 +120,10 @@ function exampleProject(_name)
 		}
 
 		configuration { "x32" }
-			libdirs { "$(OVR_DIR)/LibOVR/Lib/Win32/" .. _ACTION }
+			libdirs { path.join("$(OVR_DIR)/LibOVR/Lib/Win32", _ACTION) }
 
 		configuration { "x64" }
-			libdirs { "$(OVR_DIR)/LibOVR/Lib/x64/" .. _ACTION }
+			libdirs { path.join("$(OVR_DIR)/LibOVR/Lib/x64", _ACTION) }
 
 		configuration { "x32", "Debug" }
 			links { "libovrd" }
@@ -177,8 +177,8 @@ function exampleProject(_name)
 			"/ignore:4264" -- LNK4264: archiving object file compiled with /ZW into a static library; note that when authoring Windows Runtime types it is not recommended to link with a static library that contains Windows Runtime metadata
 		}
 		-- WinRT targets need their own output directories are build files stomp over each other
-		targetdir (BGFX_BUILD_DIR .. "arm_" .. _ACTION .. "/bin/" .. _name)
-		objdir (BGFX_BUILD_DIR .. "arm_" .. _ACTION .. "/obj/" .. _name)
+		targetdir (path.join(BGFX_BUILD_DIR, "arm_" .. _ACTION, "bin", _name))
+		objdir (path.join(BGFX_BUILD_DIR, "arm_" .. _ACTION, "obj", _name))
 
 	configuration { "mingw-clang" }
 		kind "ConsoleApp"
@@ -236,7 +236,7 @@ function exampleProject(_name)
 
 	configuration { "osx" }
 		files {
-			BGFX_DIR .. "examples/common/**.mm",
+			path.join(BGFX_DIR, "examples/common/**.mm"),
 		}
 		links {
 			"Cocoa.framework",
@@ -246,7 +246,7 @@ function exampleProject(_name)
 	configuration { "ios*" }
 		kind "ConsoleApp"
 		files {
-			BGFX_DIR .. "examples/common/**.mm",
+			path.join(BGFX_DIR, "examples/common/**.mm"),
 		}
 		linkoptions {
 			"-framework CoreFoundation",
@@ -259,7 +259,7 @@ function exampleProject(_name)
 	configuration { "xcode4", "ios" }
 		kind "WindowedApp"
 		files {
-			BGFX_DIR .. "examples/runtime/iOS-Info.plist"
+			path.join(BGFX_DIR, "examples/runtime/iOS-Info.plist"),
 		}
 
 	configuration { "qnx*" }

--- a/scripts/geometryc.lua
+++ b/scripts/geometryc.lua
@@ -8,21 +8,21 @@ project "geometryc"
 	kind "ConsoleApp"
 
 	includedirs {
-		BX_DIR   .. "include",
-		BGFX_DIR .. "include",
-		BGFX_DIR .. "3rdparty",
-		BGFX_DIR .. "examples/common",
+		path.join(BX_DIR, "include"),
+		path.join(BGFX_DIR, "include"),
+		path.join(BGFX_DIR, "3rdparty"),
+		path.join(BGFX_DIR, "examples/common"),
 	}
 
 	files {
-		BGFX_DIR .. "3rdparty/forsyth-too/**.cpp",
-		BGFX_DIR .. "3rdparty/forsyth-too/**.h",
-		BGFX_DIR .. "3rdparty/ib-compress/**.cpp",
-		BGFX_DIR .. "3rdparty/ib-compress/**.h",
-		BGFX_DIR .. "src/vertexdecl.**",
-		BGFX_DIR .. "tools/geometryc/**.cpp",
-		BGFX_DIR .. "tools/geometryc/**.h",
-		BGFX_DIR .. "examples/common/bounds.**",
+		path.join(BGFX_DIR, "3rdparty/forsyth-too/**.cpp"),
+		path.join(BGFX_DIR, "3rdparty/forsyth-too/**.h"),
+		path.join(BGFX_DIR, "3rdparty/ib-compress/**.cpp"),
+		path.join(BGFX_DIR, "3rdparty/ib-compress/**.h"),
+		path.join(BGFX_DIR, "src/vertexdecl.**"),
+		path.join(BGFX_DIR, "tools/geometryc/**.cpp"),
+		path.join(BGFX_DIR, "tools/geometryc/**.h"),
+		path.join(BGFX_DIR, "examples/common/bounds.**"),
 	}
 
 	configuration { "osx" }

--- a/scripts/makedisttex.lua
+++ b/scripts/makedisttex.lua
@@ -8,12 +8,12 @@ project "makedisttex"
 	kind "ConsoleApp"
 
 	includedirs {
-		BX_DIR .. "include",
-		BGFX_DIR .. "3rdparty",
+		path.join(BX_DIR, "include"),
+		path.join(BGFX_DIR, "3rdparty"),
 	}
 
 	files {
-		BGFX_DIR .. "3rdparty/edtaa3/**.cpp",
-		BGFX_DIR .. "3rdparty/edtaa3/**.h",
-		BGFX_DIR .. "tools/makedisttex.cpp",
+		path.join(BGFX_DIR, "3rdparty/edtaa3/**.cpp"),
+		path.join(BGFX_DIR, "3rdparty/edtaa3/**.h"),
+		path.join(BGFX_DIR, "tools/makedisttex.cpp"),
 	}

--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -7,16 +7,16 @@ project "shaderc"
 	uuid "f3cd2e90-52a4-11e1-b86c-0800200c9a66"
 	kind "ConsoleApp"
 
-	local GLSL_OPTIMIZER = (BGFX_DIR .. "3rdparty/glsl-optimizer/")
-	local FCPP_DIR = (BGFX_DIR .. "3rdparty/fcpp/")
+	local GLSL_OPTIMIZER = path.join(BGFX_DIR, "3rdparty/glsl-optimizer")
+	local FCPP_DIR = path.join(BGFX_DIR, "3rdparty/fcpp")
 
 	includedirs {
-		GLSL_OPTIMIZER .. "src",
+		path.join(GLSL_OPTIMIZER, "src"),
 	}
 
 	configuration { "vs*" }
 		includedirs {
-			GLSL_OPTIMIZER .. "src/glsl/msvc",
+			path.join(GLSL_OPTIMIZER, "src/glsl/msvc"),
 		}
 
 		defines { -- glsl-optimizer
@@ -43,7 +43,7 @@ project "shaderc"
 
 	configuration { "windows", "vs*" }
 		includedirs {
-			GLSL_OPTIMIZER .. "include/c99",
+			path.join(GLSL_OPTIMIZER, "include/c99"),
 		}
 
 	configuration { "windows" }
@@ -67,49 +67,49 @@ project "shaderc"
 	}
 
 	includedirs {
-		BX_DIR   .. "include",
-		BGFX_DIR .. "include",
+		path.join(BX_DIR, "include"),
+		path.join(BGFX_DIR, "include"),
 
 		FCPP_DIR,
 
-		GLSL_OPTIMIZER .. "include",
-		GLSL_OPTIMIZER .. "src/mesa",
-		GLSL_OPTIMIZER .. "src/mapi",
-		GLSL_OPTIMIZER .. "src/glsl",
+		path.join(GLSL_OPTIMIZER, "include"),
+		path.join(GLSL_OPTIMIZER, "src/mesa"),
+		path.join(GLSL_OPTIMIZER, "src/mapi"),
+		path.join(GLSL_OPTIMIZER, "src/glsl"),
 	}
 
 	files {
-		BGFX_DIR .. "tools/shaderc/**.cpp",
-		BGFX_DIR .. "tools/shaderc/**.h",
-		BGFX_DIR .. "src/vertexdecl.**",
+		path.join(BGFX_DIR, "tools/shaderc/**.cpp"),
+		path.join(BGFX_DIR, "tools/shaderc/**.h"),
+		path.join(BGFX_DIR, "src/vertexdecl.**"),
 
-		FCPP_DIR .. "**.h",
-		FCPP_DIR .. "cpp1.c",
-		FCPP_DIR .. "cpp2.c",
-		FCPP_DIR .. "cpp3.c",
-		FCPP_DIR .. "cpp4.c",
-		FCPP_DIR .. "cpp5.c",
-		FCPP_DIR .. "cpp6.c",
-		FCPP_DIR .. "cpp6.c",
+		path.join(FCPP_DIR, "**.h"),
+		path.join(FCPP_DIR, "cpp1.c"),
+		path.join(FCPP_DIR, "cpp2.c"),
+		path.join(FCPP_DIR, "cpp3.c"),
+		path.join(FCPP_DIR, "cpp4.c"),
+		path.join(FCPP_DIR, "cpp5.c"),
+		path.join(FCPP_DIR, "cpp6.c"),
+		path.join(FCPP_DIR, "cpp6.c"),
 
-		GLSL_OPTIMIZER .. "src/mesa/**.c",
-		GLSL_OPTIMIZER .. "src/glsl/**.cpp",
-		GLSL_OPTIMIZER .. "src/mesa/**.h",
-		GLSL_OPTIMIZER .. "src/glsl/**.c",
-		GLSL_OPTIMIZER .. "src/glsl/**.cpp",
-		GLSL_OPTIMIZER .. "src/glsl/**.h",
-		GLSL_OPTIMIZER .. "src/util/**.c",
-		GLSL_OPTIMIZER .. "src/util/**.h",
+		path.join(GLSL_OPTIMIZER, "src/mesa/**.c"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/**.cpp"),
+		path.join(GLSL_OPTIMIZER, "src/mesa/**.h"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/**.c"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/**.cpp"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/**.h"),
+		path.join(GLSL_OPTIMIZER, "src/util/**.c"),
+		path.join(GLSL_OPTIMIZER, "src/util/**.h"),
 	}
 
 	excludes {
-		GLSL_OPTIMIZER .. "src/glsl/glcpp/glcpp.c",
-		GLSL_OPTIMIZER .. "src/glsl/glcpp/tests/**",
-		GLSL_OPTIMIZER .. "src/glsl/glcpp/**.l",
-		GLSL_OPTIMIZER .. "src/glsl/glcpp/**.y",
-		GLSL_OPTIMIZER .. "src/glsl/ir_set_program_inouts.cpp",
-		GLSL_OPTIMIZER .. "src/glsl/main.cpp",
-		GLSL_OPTIMIZER .. "src/glsl/builtin_stubs.cpp",
+		path.join(GLSL_OPTIMIZER, "src/glsl/glcpp/glcpp.c"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/glcpp/tests/**"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/glcpp/**.l"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/glcpp/**.y"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/ir_set_program_inouts.cpp"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/main.cpp"),
+		path.join(GLSL_OPTIMIZER, "src/glsl/builtin_stubs.cpp"),
 	}
 
 	strip()

--- a/scripts/texturec.lua
+++ b/scripts/texturec.lua
@@ -8,15 +8,15 @@ project "texturec"
 	kind "ConsoleApp"
 
 	includedirs {
-		BX_DIR .. "include",
-		BGFX_DIR .. "include",
-		BGFX_DIR .. "src",
+		path.join(BX_DIR, "include"),
+		path.join(BGFX_DIR, "include"),
+		path.join(BGFX_DIR, "src"),
 	}
 
 	files {
-		BGFX_DIR .. "src/image.*",
-		BGFX_DIR .. "tools/texturec/**.cpp",
-		BGFX_DIR .. "tools/texturec/**.h",
+		path.join(BGFX_DIR, "src/image.*"),
+		path.join(BGFX_DIR, "tools/texturec/**.cpp"),
+		path.join(BGFX_DIR, "tools/texturec/**.h"),
 	}
 
 	links {


### PR DESCRIPTION
Using path.join instead of string concatenation makes the scripts more
OS-neutral. It also protects against missing or doubled "/" characters
in paths.