### PR TITLE
SDL2 #include path issue

### DIFF
--- a/examples/common/entry/entry_sdl.cpp
+++ b/examples/common/entry/entry_sdl.cpp
@@ -11,7 +11,7 @@
 #	define SDL_MAIN_HANDLED
 #endif // BX_PLATFORM_WINDOWS
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <bgfxplatform.h>
 
 #include <stdio.h>

--- a/include/bgfxplatform.h
+++ b/include/bgfxplatform.h
@@ -106,7 +106,7 @@ namespace bgfx
 // If SDL.h is included before bgfxplatform.h we can enable SDL window
 // interop convenience code.
 
-#	include <SDL2/SDL_syswm.h>
+#	include <SDL_syswm.h>
 
 namespace bgfx
 {

--- a/scripts/example-common.lua
+++ b/scripts/example-common.lua
@@ -29,6 +29,12 @@ project ("example-common")
 		includedirs {
 			"$(SDL2_DIR)/include",
 		}
+		if not os.is("windows") then
+			includedirs {
+				"/usr/include/SDL2",
+				"/usr/local/include/SDL2"
+			}
+		end
 	end
 
 	configuration { "mingw* or vs2008" }


### PR DESCRIPTION
I noticed bgfx is including SDL2 headers by `#include<SDL2/SDL_*.h>`. 

But I think `#include <SDL_*.h>` is better. Because SDL2 compiled library for windows is not have `include/SDL2` directory and pkg-config returns `/usr/include/SDL2` for include path. In addition, `README.md` and `scripts/example-common.lua` seems created for `#include <SDL_*.h>`.

:sushi: 