### PR TITLE
Linux: fixed building of shared libraries

### DIFF
--- a/scripts/bgfx.lua
+++ b/scripts/bgfx.lua
@@ -25,6 +25,11 @@ function bgfxProject(_name, _kind, _defines)
 					"-shared",
 				}
 
+			configuration { "linux-*" }
+				buildoptions { 
+					"-fPIC",
+				}
+
 			configuration {}
 		end
 


### PR DESCRIPTION
On Linux one would get the following error:

    Linking bgfx-shared-lib
    /usr/bin/ld: ../../linux64_gcc/obj/x64/Debug/bgfx-shared-lib/src/image.o: relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC
    ../../linux64_gcc/obj/x64/Debug/bgfx-shared-lib/src/image.o: error adding symbols: Bad value
    collect2: error: ld returned 1 exit status

as object files are compiled without the -fPIC flag. This commit fixes it.