### PR TITLE
D3D11 constant buffer must align ByteWidth to 16 bytes

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -2647,7 +2647,7 @@ namespace bgfx { namespace d3d11
 		if (0 < size)
 		{
 			D3D11_BUFFER_DESC desc;
-			desc.ByteWidth = size;
+			desc.ByteWidth = (size + 0xf) & ~0xf;
 			desc.Usage = D3D11_USAGE_DEFAULT;
 			desc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 			desc.CPUAccessFlags = 0;


### PR DESCRIPTION
See remarks of:
https://msdn.microsoft.com/en-us/library/windows/desktop/ff476092(v=vs.85).aspx

Most PC drivers don't seem to enforce this, but it will
crash the xb1 implementation if fed an unaligned value.