### PR TITLE
glsl version

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -4073,7 +4073,7 @@ namespace bgfx { namespace gl
 					}
 					else
 					{
-						writeString(&writer, "#version 140\n");
+						writeStringf(&writer,"#version %d0\n",BGFX_CONFIG_RENDERER_OPENGL);
 					}
 
 					if (m_type == GL_FRAGMENT_SHADER)


### PR DESCRIPTION
When using bgfx with opengl version > 3.1, glsl #version is forced to 140 in shader code.
Can we use higher version (> 140) or better the same version as actual gl context ? like in this patch ?

I'm using glsl raw shaders with opengl 4.4 and I get some unsupported syntax errors if I don't use higher #version than 140.

thanks. 