### PR TITLE
Allow the max draw call count to go above 65k.

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -215,6 +215,12 @@ namespace stl
 #	define BGFX_RENDERER_OPENGL_NAME "OpenGL"
 #endif //
 
+#if BGFX_CONFIG_MAX_DRAW_CALLS < (64<<10)
+typedef uint16_t DrawCountType;
+#else
+typedef uint32_t DrawCountType;
+#endif
+
 namespace bgfx
 {
 #if BX_PLATFORM_ANDROID
@@ -1617,7 +1623,7 @@ namespace bgfx
 		uint8_t m_viewFlags[BGFX_CONFIG_MAX_VIEWS];
 
 		uint64_t m_sortKeys[BGFX_CONFIG_MAX_DRAW_CALLS+1];
-		uint16_t m_sortValues[BGFX_CONFIG_MAX_DRAW_CALLS+1];
+		DrawCountType m_sortValues[BGFX_CONFIG_MAX_DRAW_CALLS+1];
 		RenderItem m_renderItem[BGFX_CONFIG_MAX_DRAW_CALLS+1];
 		RenderDraw m_draw;
 		RenderCompute m_compute;
@@ -1627,9 +1633,9 @@ namespace bgfx
 
 		ConstantBuffer* m_constantBuffer;
 
-		uint16_t m_num;
-		uint16_t m_numRenderItems;
-		uint16_t m_numDropped;
+		DrawCountType m_num;
+		DrawCountType m_numRenderItems;
+		DrawCountType m_numDropped;
 
 		MatrixCache m_matrixCache;
 		RectCache m_rectCache;
@@ -3424,7 +3430,7 @@ namespace bgfx
 		Frame* m_submit;
 
 		uint64_t m_tempKeys[BGFX_CONFIG_MAX_DRAW_CALLS];
-		uint16_t m_tempValues[BGFX_CONFIG_MAX_DRAW_CALLS];
+		DrawCountType m_tempValues[BGFX_CONFIG_MAX_DRAW_CALLS];
 
 		VertexBuffer m_vertexBuffers[BGFX_CONFIG_MAX_VERTEX_BUFFERS];
 


### PR DESCRIPTION
For doing perf testing I wanted to see how many draw calls we could actually push, so I made some tweaks to allow the config to go above size of uint16_t.