### PR TITLE
Fixing crash on WP8 ARM

### DIFF
--- a/src/renderer.h
+++ b/src/renderer.h
@@ -12,12 +12,19 @@ namespace bgfx
 {
 	struct ViewState
 	{
+		ViewState() { }
 		ViewState(Frame* _render, bool _hmdEnabled)
-			: m_alphaRef(0.0f)
-			, m_invViewCached(UINT16_MAX)
-			, m_invProjCached(UINT16_MAX)
-			, m_invViewProjCached(UINT16_MAX)
 		{
+			reset(_render, _hmdEnabled);
+		}
+
+		void reset(Frame* _render, bool _hmdEnabled)
+		{
+			m_alphaRef = 0.0f;
+			m_invViewCached = UINT16_MAX;
+			m_invProjCached = UINT16_MAX;
+			m_invViewProjCached = UINT16_MAX;
+
 			m_view[0] = _render->m_view;
 			m_view[1] = m_viewTmp[1];
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -2459,6 +2459,7 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 		void* m_uniforms[BGFX_CONFIG_MAX_UNIFORMS];
 		Matrix4 m_predefinedUniforms[PredefinedUniform::Count];
 		UniformRegistry m_uniformReg;
+		ViewState m_viewState;
 
 		StateCacheT<ID3D11BlendState> m_blendStateCache;
 		StateCacheT<ID3D11DepthStencilState> m_depthStencilStateCache;
@@ -3305,7 +3306,8 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 		const bool hmdEnabled = m_ovr.isEnabled() || m_ovr.isDebug();
 		_render->m_hmdEnabled = hmdEnabled;
 
-		ViewState viewState(_render, hmdEnabled);
+		ViewState& viewState = m_viewState;
+		viewState.reset(_render, hmdEnabled);
 
 		bool wireframe = !!(_render->m_debug&BGFX_DEBUG_WIREFRAME);
 		bool scissorEnabled = false;


### PR DESCRIPTION
The ViewState struct is so big that it blows out the stack on ARM devices. This change promotes it to a member variable.