### PR TITLE
Stop hardcoding the GUID for ID3D11ShaderReflection.

### DIFF
--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -14,12 +14,6 @@
 #	define D3D_SVF_USED 2
 #endif // D3D_SVF_USED
 
-#ifndef IID_ID3D11ShaderReflection
-// In case MinGW is missing IID...
-static const GUID GUID_ID3D11ShaderReflection = { 0x0a233719, 0x3960, 0x4578, { 0x9d, 0x7c, 0x20, 0x3b, 0x8b, 0x1d, 0x9c, 0xc1 } };
-#	define IID_ID3D11ShaderReflection GUID_ID3D11ShaderReflection
-#endif // IID_ID3D11ShaderReflection
-
 struct CTHeader
 {
 	uint32_t Size;


### PR DESCRIPTION
This GUID changes depending on what version of the DirectX SDK you have. The GUID is defined in d3d11shader.h as a const global, not a preprocessor macro, so this #ifndef was clobbering it always. This caused DX11 shader compliation to fail when using the Windows 8.1 SDK.