### PR TITLE
Fixes error C4701 in renderer_d3d11.cpp on VC12 build

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -645,7 +645,7 @@ namespace bgfx { namespace d3d11
 			}
 
 			IDXGIDevice*  device = NULL;
-			IDXGIAdapter* adapter;
+			IDXGIAdapter* adapter = NULL;
 			hr = E_FAIL;
 			for (uint32_t ii = 0; ii < BX_COUNTOF(s_deviceIIDs) && FAILED(hr); ++ii)
 			{


### PR DESCRIPTION
Fixes this error on VC12/x64:
renderer_d3d11.cpp(687, 0): error C4701: potentially uninitialized local variable 'adapter' used

I assume the check on 677 will cause a bailout before a null / uninitialized adapter pointer could ever be used?