### PR TITLE
Create backbuffer RTVs honoring multisampling

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1496,7 +1496,10 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 				DX_CHECK(m_swapChain->GetBuffer(0, IID_ID3D11Texture2D, (void**)&color));
 
 				D3D11_RENDER_TARGET_VIEW_DESC desc;
-				desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+				desc.ViewDimension = (m_flags & BGFX_RESET_MSAA_MASK)
+					? D3D11_RTV_DIMENSION_TEXTURE2DMS
+					: D3D11_RTV_DIMENSION_TEXTURE2D
+					;
 				desc.Texture2D.MipSlice = 0;
 				desc.Format = (m_flags & BGFX_RESET_SRGB_BACKBUFFER)
 					? DXGI_FORMAT_R8G8B8A8_UNORM_SRGB


### PR DESCRIPTION
When adding sRGB support for the backbuffer render target in D3D11,
the now explicitly specified RTV desc specifies a TEXTURE2D dimension.
For multisampled targets, this needs to be TEXTURE2DMS dimension.

This solves it by branching on the presence of MSAA in the reset flags but
could envisionably be obtained by looking at the desc of the backbuffer.