### PR TITLE
Use predefined.m_count instead of hardcoded 1

### DIFF
--- a/src/renderer.h
+++ b/src/renderer.h
@@ -92,7 +92,7 @@ namespace bgfx
 						_renderer->setShaderUniform4f(flags
 							, predefined.m_loc
 							, &frect[0]
-							, 1
+							, predefined.m_count
 							);
 					}
 					break;
@@ -106,7 +106,7 @@ namespace bgfx
 						_renderer->setShaderUniform4f(flags
 							, predefined.m_loc
 							, &frect[0]
-							, 1
+							, predefined.m_count
 							);
 					}
 					break;
@@ -246,7 +246,7 @@ namespace bgfx
 						_renderer->setShaderUniform4f(flags
 							, predefined.m_loc
 							, &m_alphaRef
-							, 1
+							, predefined.m_count
 							);
 					}
 					break;


### PR DESCRIPTION
For platforms that pack shader constants on 4 byte boundaries instead
of 16.