### PR TITLE
Fixing geometryc for meshes exported without uv coordinates

### DIFF
--- a/tools/geometryc/geometryc.cpp
+++ b/tools/geometryc/geometryc.cpp
@@ -510,8 +510,8 @@ int main(int _argc, const char* _argv[])
 				for (uint32_t edge = 0, numEdges = argc-1; edge < numEdges; ++edge)
 				{
 					Index3 index;
-					index.m_texcoord = 0;
-					index.m_normal = 0;
+					index.m_texcoord = -1;
+					index.m_normal = -1;
 					index.m_vertexIndex = -1;
 
 					char* vertex = argv[edge+1];
@@ -528,8 +528,12 @@ int main(int _argc, const char* _argv[])
 							index.m_normal = (nn < 0) ? nn+numNormals : nn-1;
 						}
 
-						const int tex = atoi(texcoord);
-						index.m_texcoord = (tex < 0) ? tex+numTexcoords : tex-1;
+						// https://en.wikipedia.org/wiki/Wavefront_.obj_file#Vertex_Normal_Indices_Without_Texture_Coordinate_Indices
+						if(*texcoord != '\0')
+						{
+							const int tex = atoi(texcoord);
+							index.m_texcoord = (tex < 0) ? tex+numTexcoords : tex-1;
+						}
 					}
 
 					const int pos = atoi(vertex);
@@ -716,8 +720,8 @@ int main(int _argc, const char* _argv[])
 	bool hasTexcoord;
 	{
 		Index3Map::const_iterator it = indexMap.begin();
-		hasNormal   = 0 != it->second.m_normal;
-		hasTexcoord = 0 != it->second.m_texcoord;
+		hasNormal   = -1 != it->second.m_normal;
+		hasTexcoord = -1 != it->second.m_texcoord;
 
 		if (!hasTexcoord
 		&&  texcoords.size() == positions.size() )


### PR DESCRIPTION
Meshes exported from blender which do not contains texture coordinates were not converted properly.
I think there was a bug on "hasNormal" detection too.

OBJ file for reference (note the "//"):
```
# Blender v2.74 (sub 0) OBJ File: 'NoTexCoord.blend'
# www.blender.org
o NoTexCoord
v -0.200000 0.000000 -1.000000
v -0.000000 0.000000 -1.000000
v 0.000000 0.000000 1.000000
v -0.200000 0.000000 1.000000
v -0.200000 0.500000 -1.000000
v -0.000000 0.500000 -1.000000
v 0.000000 0.500000 1.000000
v -0.200000 0.500000 1.000000
vn 0.000000 0.000000 -1.000000
vn 1.000000 0.000000 -0.000000
vn 0.000000 0.000000 1.000000
vn -1.000000 0.000000 0.000000
vn 0.000000 -1.000000 0.000000
vn 0.000000 1.000000 0.000000
s off
f 5//1 6//1 2//1 1//1
f 6//2 7//2 3//2 2//2
f 7//3 8//3 4//3 3//3
f 8//4 5//4 1//4 4//4
f 1//5 2//5 3//5 4//5
f 8//6 7//6 6//6 5//6
```