### PR TITLE
VR: Add buffer between left/right eye textures

### DIFF
--- a/src/ovr.cpp
+++ b/src/ovr.cpp
@@ -9,6 +9,12 @@
 
 namespace bgfx
 {
+#if OVR_VERSION <= OVR_VERSION_050
+	static const int s_eyeBuffer = 100;
+#else
+	static const int s_eyeBuffer = 8;
+#endif // OVR_VERSION...
+
 	OVR::OVR()
 		: m_hmd(NULL)
 		, m_isenabled(false)
@@ -50,7 +56,7 @@ namespace bgfx
 
 		ovrSizei sizeL = ovrHmd_GetFovTextureSize(m_hmd, ovrEye_Left,  m_hmd->DefaultEyeFov[0], 1.0f);
 		ovrSizei sizeR = ovrHmd_GetFovTextureSize(m_hmd, ovrEye_Right, m_hmd->DefaultEyeFov[1], 1.0f);
-		m_rtSize.w = sizeL.w + sizeR.w;
+		m_rtSize.w = sizeL.w + sizeR.w + s_eyeBuffer;
 		m_rtSize.h = bx::uint32_max(sizeL.h, sizeR.h);
 		m_warning = true;
 	}
@@ -169,12 +175,12 @@ ovrError:
 			ovrRecti rect;
 			rect.Pos.x  = 0;
 			rect.Pos.y  = 0;
-			rect.Size.w = m_rtSize.w/2;
+			rect.Size.w = (m_rtSize.w - s_eyeBuffer)/2;
 			rect.Size.h = m_rtSize.h;
 
 			m_texture[0].Header.RenderViewport = rect;
 
-			rect.Pos.x += rect.Size.w;
+			rect.Pos.x += rect.Size.w + s_eyeBuffer;
 			m_texture[1].Header.RenderViewport = rect;
 
 			m_timing = ovrHmd_BeginFrame(m_hmd, 0);


### PR DESCRIPTION
This prevents bleeding across the individual viewports
when the oculus SDK applies distortion mapping. The current
reccommended values are 100px for SDK <= 0.5 and 8px for > 0.5

See: http://static.oculus.com/sdk-downloads/documents/0.6.0/Oculus_Developer_Guide.pdf
  in the "Bugs Fixed Since the Last Release" section.

For an example of this artifact, see the correct scene render:
![Imgur](http://i.imgur.com/fZZExg8.jpg)

followed by a scene that bleeds the left eye into the right eye:
![Imgur](http://i.imgur.com/dZalmPS.jpg)