### PR TITLE
VR: Properly support MSAA in OVR builds

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1725,18 +1725,29 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 
 						DX_RELEASE(m_swapChain, 0);
 
+						SWAP_CHAIN_DESC_TYPE* scd = &m_scd;
+#if BGFX_CONFIG_USE_OVR
+						SWAP_CHAIN_DESC_TYPE swapChainScd;
+						if ((m_flags & BGFX_RESET_HMD) && m_ovr.isInitialized())
+						{
+							swapChainScd = m_scd;
+							swapChainScd.SampleDesc = s_msaa[0];
+							scd = &swapChainScd;
+						}
+#endif // BGFX_CONFIG_USE_OVR
+
 #if BX_PLATFORM_WINRT
 						HRESULT hr;
 						hr = m_factory->CreateSwapChainForCoreWindow(m_device
 							, (::IUnknown*)g_platformData.nwh
-							, &m_scd
+							, scd
 							, NULL
 							, &m_swapChain
 							);
 #else
 						HRESULT hr;
 						hr = m_factory->CreateSwapChain(m_device
-							, &m_scd
+							, scd
 							, &m_swapChain
 							);
 #endif // BX_PLATFORM_WINRT
@@ -2294,7 +2305,7 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 					bx::write(&writer, magic);
 
 					TextureCreate tc;
-					tc.m_flags   = BGFX_TEXTURE_RT;
+					tc.m_flags   = BGFX_TEXTURE_RT|(((m_flags & BGFX_RESET_MSAA_MASK) >> BGFX_RESET_MSAA_SHIFT) << BGFX_TEXTURE_RT_MSAA_SHIFT);
 					tc.m_width   = m_ovr.m_rtSize.w;
 					tc.m_height  = m_ovr.m_rtSize.h;
 					tc.m_sides   = 0;
@@ -2702,10 +2713,11 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 		bool m_wireframe;
 
 #if BX_PLATFORM_WINRT
-        DXGI_SWAP_CHAIN_DESC1 m_scd;
+		typedef DXGI_SWAP_CHAIN_DESC1 SWAP_CHAIN_DESC_TYPE;
 #else
-		DXGI_SWAP_CHAIN_DESC m_scd;
+		typedef DXGI_SWAP_CHAIN_DESC SWAP_CHAIN_DESC_TYPE;
 #endif
+		SWAP_CHAIN_DESC_TYPE m_scd;
 		uint32_t m_flags;
 		uint32_t m_maxAnisotropy;
 

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2150,9 +2150,17 @@ namespace bgfx { namespace gl
 				m_resolution = _resolution;
 				m_resolution.m_flags = flags;
 
+				uint32_t flags = m_resolution.m_flags;
+#if BGFX_CONFIG_USE_OVR
+				if ((flags & BGFX_RESET_HMD) && m_ovr.isInitialized())
+				{
+					flags &= ~BGFX_RESET_MSAA_MASK;
+				}
+#endif // BGFX_CONFIG_OVR
+
 				setRenderContextSize(m_resolution.m_width
 						, m_resolution.m_height
-						, m_resolution.m_flags
+						, flags
 						);
 				updateCapture();
 
@@ -2461,7 +2469,7 @@ namespace bgfx { namespace gl
 					bx::write(&writer, magic);
 
 					TextureCreate tc;
-					tc.m_flags   = BGFX_TEXTURE_RT;
+					tc.m_flags   = BGFX_TEXTURE_RT|(((m_resolution.m_flags & BGFX_RESET_MSAA_MASK) >> BGFX_RESET_MSAA_SHIFT) << BGFX_TEXTURE_RT_MSAA_SHIFT);;
 					tc.m_width   = m_ovr.m_rtSize.w;
 					tc.m_height  = m_ovr.m_rtSize.h;
 					tc.m_sides   = 0;


### PR DESCRIPTION
Fixes #338

Create the swap chain without MSAA, and the eye textures
with MSAA. The core issue was using the surface description
for the backbuffer for the DSV on the eye textures which did
not match.

This meethod follows both the oculus and openvr guidance on MSAA -
MSAA is configured on the eye render targets, but not on the swap
chain.