### PR TITLE
VR: Fix skewed viewports with buffered eye textures

### DIFF
--- a/src/ovr.cpp
+++ b/src/ovr.cpp
@@ -69,6 +69,14 @@ namespace bgfx
 		ovr_Shutdown();
 	}
 
+	void OVR::getViewport(uint8_t _eye, Rect* _viewport)
+	{
+		_viewport->m_width = (m_rtSize.w - s_eyeBuffer)/2;
+		_viewport->m_height = m_rtSize.h;
+		_viewport->m_x = _eye * (m_rtSize.w + s_eyeBuffer + 1)/2;
+		_viewport->m_y = 0;
+	}
+
 	bool OVR::postReset(void* _nwh, ovrRenderAPIConfig* _config, bool _debug)
 	{
 		if (_debug)

--- a/src/ovr.h
+++ b/src/ovr.h
@@ -67,6 +67,7 @@ namespace bgfx
 		void init();
 		void shutdown();
 
+		void getViewport(uint8_t _eye, Rect* _viewport);
 		bool postReset(void* _nwh, ovrRenderAPIConfig* _config, bool _debug = false);
 		void postReset(const ovrTexture& _texture);
 		void preReset();

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -3844,8 +3844,17 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 							PIX_BEGINEVENT(D3DCOLOR_RGBA(0xff, 0x00, 0x00, 0xff), viewNameW);
 						}
 
-						viewState.m_rect.m_x = eye * (viewState.m_rect.m_width+1)/2;
-						viewState.m_rect.m_width /= 2;
+#if BGFX_CONFIG_USE_OVR
+						if (m_ovr.isEnabled())
+						{
+							m_ovr.getViewport(eye, &viewState.m_rect);
+						}
+						else
+#endif // BGFX_CONFIG_USE_OVR
+						{
+							viewState.m_rect.m_x = eye * (viewState.m_rect.m_width+1)/2;
+							viewState.m_rect.m_width /= 2;
+						}
 					}
 					else
 					{

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -4955,8 +4955,17 @@ namespace bgfx { namespace gl
 							GL_CHECK(glInsertEventMarker(0, viewName) );
 						}
 
-						viewState.m_rect.m_x = eye * (viewState.m_rect.m_width+1)/2;
-						viewState.m_rect.m_width /= 2;
+#if BGFX_CONFIG_USE_OVR
+						if (m_ovr.isEnabled())
+						{
+							m_ovr.getViewport(eye, &viewState.m_rect);
+						}
+						else
+#endif // BGFX_CONFIG_USE_OVR
+						{
+							viewState.m_rect.m_x = eye * (viewState.m_rect.m_width+1)/2;
+							viewState.m_rect.m_width /= 2;
+						}
 					}
 					else
 					{


### PR DESCRIPTION
Bug fix for #419

Viewport calculations need to take VR eye buffer size into
account. Noticable at the older 100px boundary. Skewing still
exists at newer 8px buffer, but is harder to notice.
Eventually causes pretty bad eye strain, though.

Easily reproduced by setting the buffer to something obscenely
large, such as 2048.