### PR TITLE
Allow programs using examples/entry to have exit codes

### DIFF
--- a/examples/common/entry/entry_windows.cpp
+++ b/examples/common/entry/entry_windows.cpp
@@ -499,7 +499,7 @@ namespace entry
 
 			s_xinput.shutdown();
 
-			return 0;
+			return (0 == thread.getExitCode() ? EXIT_SUCCESS : EXIT_FAILURE);
 		}
 
 		LRESULT process(HWND _hwnd, UINT _id, WPARAM _wparam, LPARAM _lparam)

--- a/examples/common/entry/entry_x11.cpp
+++ b/examples/common/entry/entry_x11.cpp
@@ -477,7 +477,7 @@ namespace entry
 			XUnmapWindow(m_display, m_window[0]);
 			XDestroyWindow(m_display, m_window[0]);
 
-			return EXIT_SUCCESS;
+			return (0 == thread.getExitCode() ? EXIT_SUCCESS : EXIT_FAILURE);
 		}
 
 		void setModifier(Modifier::Enum _modifier, bool _set)


### PR DESCRIPTION
Any objection to allowing programs that use the examples/common/entry* stuff to have exit codes based on the return value of their \_main\_ function?
Currently, the run function in entry_*.cpp always returns 0.

Here's a pull request for linux and windows, the two platforms I can easily test on at the moment.