### PR TITLE
Scintilla/imgui: removed getFontInfo(), using data exposed by imgui

### DIFF
--- a/3rdparty/ocornut-imgui/imgui.cpp
+++ b/3rdparty/ocornut-imgui/imgui.cpp
@@ -2703,7 +2703,7 @@ static void RenderCheckMark(ImVec2 pos, ImU32 col)
     a.x = pos.x + start_x;
     b.x = a.x + rem_third;
     c.x = a.x + rem_third * 3.0f;
-    b.y = pos.y + (float)(int)(g.Font->BaseLine * (g.FontSize / g.Font->FontSize) + 0.5f) + (float)(int)(g.Font->DisplayOffset.y);
+    b.y = pos.y + (float)(int)(g.Font->Ascent * (g.FontSize / g.Font->FontSize) + 0.5f) + (float)(int)(g.Font->DisplayOffset.y);
     a.y = b.y - rem_third;
     c.y = b.y - rem_third * 2.0f;
 
@@ -8910,12 +8910,6 @@ struct ImFontAtlas::ImFontAtlasData
     int                 RangesCount;
 };
 
-const stbtt_fontinfo& getFontInfo(int index)
-{
-    const ImGuiIO& io = ImGui::GetIO();
-    return io.Fonts[index].InputData[0]->FontInfo;
-}
-
 ImFontAtlas::ImFontAtlas()
 {
     TexID = NULL;
@@ -9215,7 +9209,8 @@ bool    ImFontAtlas::Build()
         const float font_scale = stbtt_ScaleForPixelHeight(&data.FontInfo, data.SizePixels);
         int font_ascent, font_descent, font_line_gap;
         stbtt_GetFontVMetrics(&data.FontInfo, &font_ascent, &font_descent, &font_line_gap);
-        data.OutFont->BaseLine = (font_ascent * font_scale);
+        data.OutFont->Ascent = (font_ascent * font_scale);
+        data.OutFont->Descent = (font_descent * font_scale);
         data.OutFont->Glyphs.resize(0);
 
         const float uv_scale_x = 1.0f / TexWidth;
@@ -9374,7 +9369,7 @@ void    ImFont::Clear()
 {
     FontSize = 0.0f;
     DisplayOffset = ImVec2(-0.5f, 0.5f);
-    BaseLine = 0.0f;
+    Ascent = Descent = 0.0f;
     ContainerAtlas = NULL;
     Glyphs.clear();
     FallbackGlyph = NULL;

--- a/3rdparty/ocornut-imgui/imgui.h
+++ b/3rdparty/ocornut-imgui/imgui.h
@@ -1106,7 +1106,8 @@ struct ImFont
         signed short    XOffset, YOffset;
         float           U0, V0, U1, V1;     // Texture coordinates
     };
-    float               BaseLine;           // Distance from top to bottom of e.g. 'A' [0..FontSize]
+    float               Ascent;             // Distance from top to bottom of e.g. 'A' [0..FontSize]
+    float               Descent;            // 
     ImFontAtlas*        ContainerAtlas;     // What we has been loaded into
     ImVector<Glyph>     Glyphs;
     const Glyph*        FallbackGlyph;      // == FindGlyph(FontFallbackChar)
@@ -1119,9 +1120,10 @@ struct ImFont
     IMGUI_API ~ImFont();
     IMGUI_API void              Clear();
     IMGUI_API void              BuildLookupTable();
+    IMGUI_API float             GetCharAdvance(unsigned short c) const  { return ((size_t)c < IndexXAdvance.size()) ? IndexXAdvance[(size_t)c] : FallbackXAdvance; }
     IMGUI_API const Glyph*      FindGlyph(unsigned short c) const;
     IMGUI_API void              SetFallbackChar(ImWchar c);
-    IMGUI_API bool              IsLoaded() const        { return ContainerAtlas != NULL; }
+    IMGUI_API bool              IsLoaded() const                        { return ContainerAtlas != NULL; }
 
     // 'max_width' stops rendering after a certain width (could be turned into a 2d size). FLT_MAX to disable.
     // 'wrap_width' enable automatic word-wrapping across multiple lines to fit into given width. 0.0f to disable.


### PR DESCRIPTION
Removed the need for getFontInfo(). Note: linegap is always 0 as that's what imgui does for paragraph (will add support for linegap later on. I found it was often zero)