### PR TITLE
Fix for Context not bound on OSX 10.10.3 #439

### DIFF
--- a/src/glcontext_nsgl.mm
+++ b/src/glcontext_nsgl.mm
@@ -176,6 +176,8 @@ namespace bgfx { namespace gl
 	{
 		if (NULL == _swapChain)
 		{
+			NSOpenGLContext* glContext = (NSOpenGLContext*)m_context;
+			[glContext makeCurrentContext];
 		}
 		else
 		{


### PR DESCRIPTION
fix for https://github.com/bkaradzic/bgfx/issues/439