### PR TITLE
- Export functions for the C ++ API for dynamic linking

### DIFF
--- a/include/bgfx.h
+++ b/include/bgfx.h
@@ -1,4 +1,4 @@
-/*
+
  * Copyright 2011-2015 Branimir Karadzic. All rights reserved.
  * License: https://github.com/bkaradzic/bgfx/blob/master/LICENSE
  */
@@ -10,6 +10,12 @@
 #include <stdlib.h> // size_t
 
 #include "bgfxdefines.h"
+
+#if defined(BX_PLATFORM_WINDOWS)
+#   define BGFX_SHARED_LIB_API __declspec(dllexport)
+#else
+#   define BGFX_SHARED_LIB_API
+#endif // defined(BX_PLATFORM_WINDOWS)
 
 ///
 #define BGFX_HANDLE(_name) \
@@ -425,13 +431,13 @@ namespace bgfx
 	/// Vertex declaration.
 	struct VertexDecl
 	{
-		VertexDecl();
+		BGFX_SHARED_LIB_API VertexDecl();
 
 		/// Start VertexDecl.
-		VertexDecl& begin(RendererType::Enum _renderer = RendererType::Null);
+		BGFX_SHARED_LIB_API VertexDecl& begin(RendererType::Enum _renderer = RendererType::Null);
 
 		/// End VertexDecl.
-		void end();
+		BGFX_SHARED_LIB_API void end();
 
 		/// Add attribute to VertexDecl.
 		///
@@ -449,25 +455,25 @@ namespace bgfx
 		/// @remarks
 		///   Must be called between begin/end.
 		///
-		VertexDecl& add(Attrib::Enum _attrib, uint8_t _num, AttribType::Enum _type, bool _normalized = false, bool _asInt = false);
+		BGFX_SHARED_LIB_API VertexDecl& add(Attrib::Enum _attrib, uint8_t _num, AttribType::Enum _type, bool _normalized = false, bool _asInt = false);
 
 		/// Skip _num bytes in vertex stream.
-		VertexDecl& skip(uint8_t _num);
+		BGFX_SHARED_LIB_API VertexDecl& skip(uint8_t _num);
 
 		/// Decode attribute.
-		void decode(Attrib::Enum _attrib, uint8_t& _num, AttribType::Enum& _type, bool& _normalized, bool& _asInt) const;
+		BGFX_SHARED_LIB_API void decode(Attrib::Enum _attrib, uint8_t& _num, AttribType::Enum& _type, bool& _normalized, bool& _asInt) const;
 
 		/// Returns true if VertexDecl contains attribute.
-		bool has(Attrib::Enum _attrib) const { return 0xff != m_attributes[_attrib]; }
+		BGFX_SHARED_LIB_API bool has(Attrib::Enum _attrib) const { return 0xff != m_attributes[_attrib]; }
 
 		/// Returns relative attribute offset from the vertex.
-		uint16_t getOffset(Attrib::Enum _attrib) const { return m_offset[_attrib]; }
+		BGFX_SHARED_LIB_API uint16_t getOffset(Attrib::Enum _attrib) const { return m_offset[_attrib]; }
 
 		/// Returns vertex stride.
-		uint16_t getStride() const { return m_stride; }
+		BGFX_SHARED_LIB_API uint16_t getStride() const { return m_stride; }
 
 		/// Returns size of vertex buffer for number of vertices.
-		uint32_t getSize(uint32_t _num) const { return _num*m_stride; }
+		BGFX_SHARED_LIB_API uint32_t getSize(uint32_t _num) const { return _num*m_stride; }
 
 		uint32_t m_hash;
 		uint16_t m_stride;
@@ -476,10 +482,10 @@ namespace bgfx
 	};
 
 	/// Pack vec4 into vertex stream format.
-	void vertexPack(const float _input[4], bool _inputNormalized, Attrib::Enum _attr, const VertexDecl& _decl, void* _data, uint32_t _index = 0);
+	BGFX_SHARED_LIB_API void vertexPack(const float _input[4], bool _inputNormalized, Attrib::Enum _attr, const VertexDecl& _decl, void* _data, uint32_t _index = 0);
 
 	/// Unpack vec4 from vertex stream format.
-	void vertexUnpack(float _output[4], Attrib::Enum _attr, const VertexDecl& _decl, const void* _data, uint32_t _index = 0);
+	BGFX_SHARED_LIB_API void vertexUnpack(float _output[4], Attrib::Enum _attr, const VertexDecl& _decl, const void* _data, uint32_t _index = 0);
 
 	/// Converts vertex stream data from one vertex stream format to another.
 	///
@@ -489,7 +495,7 @@ namespace bgfx
 	/// @param _srcData Source vertex stream data.
 	/// @param _num Number of vertices to convert from source to destination.
 	///
-	void vertexConvert(const VertexDecl& _destDecl, void* _destData, const VertexDecl& _srcDecl, const void* _srcData, uint32_t _num = 1);
+	BGFX_SHARED_LIB_API void vertexConvert(const VertexDecl& _destDecl, void* _destData, const VertexDecl& _srcDecl, const void* _srcData, uint32_t _num = 1);
 
 	/// Weld vertices.
 	///
@@ -501,7 +507,7 @@ namespace bgfx
 	/// @param _epsilon Error tolerance for vertex position comparison.
 	/// @returns Number of unique vertices after vertex welding.
 	///
-	uint16_t weldVertices(uint16_t* _output, const VertexDecl& _decl, const void* _data, uint16_t _num, float _epsilon = 0.001f);
+	BGFX_SHARED_LIB_API uint16_t weldVertices(uint16_t* _output, const VertexDecl& _decl, const void* _data, uint16_t _num, float _epsilon = 0.001f);
 
 	/// Swizzle RGBA8 image to BGRA8.
 	///
@@ -512,7 +518,7 @@ namespace bgfx
 	/// @param _dst Destination image. Must be the same size as input image.
 	///   _dst might be pointer to the same memory as _src.
 	///
-	void imageSwizzleBgra8(uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _src, void* _dst);
+	BGFX_SHARED_LIB_API void imageSwizzleBgra8(uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _src, void* _dst);
 
 	/// Downsample RGBA8 image with 2x2 pixel average filter.
 	///
@@ -523,13 +529,13 @@ namespace bgfx
 	/// @param _dst Destination image. Must be at least quarter size of
 	///   input image. _dst might be pointer to the same memory as _src.
 	///
-	void imageRgba8Downsample2x2(uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _src, void* _dst);
+	BGFX_SHARED_LIB_API void imageRgba8Downsample2x2(uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _src, void* _dst);
 
 	/// Returns supported backend API renderers.
-	uint8_t getSupportedRenderers(RendererType::Enum _enum[RendererType::Count]);
+	BGFX_SHARED_LIB_API uint8_t getSupportedRenderers(RendererType::Enum _enum[RendererType::Count]);
 
 	/// Returns name of renderer.
-	const char* getRendererName(RendererType::Enum _type);
+	BGFX_SHARED_LIB_API const char* getRendererName(RendererType::Enum _type);
 
 	/// Initialize bgfx library.
 	///
@@ -555,13 +561,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_init`.
 	///
-	void init(RendererType::Enum _type = RendererType::Count, uint16_t _vendorId = BGFX_PCI_ID_NONE, uint16_t _deviceId = 0, CallbackI* _callback = NULL, bx::ReallocatorI* _reallocator = NULL);
+	BGFX_SHARED_LIB_API void init(RendererType::Enum _type = RendererType::Count, uint16_t _vendorId = BGFX_PCI_ID_NONE, uint16_t _deviceId = 0, CallbackI* _callback = NULL, bx::ReallocatorI* _reallocator = NULL);
 
 	/// Shutdown bgfx library.
 	///
 	/// @attention C99 equivalent is `bgfx_shutdown`.
 	///
-	void shutdown();
+	BGFX_SHARED_LIB_API void shutdown();
 
 	/// Reset graphic settings and back-buffer size.
 	///
@@ -586,7 +592,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_reset`.
 	///
-	void reset(uint32_t _width, uint32_t _height, uint32_t _flags = BGFX_RESET_NONE);
+	BGFX_SHARED_LIB_API void reset(uint32_t _width, uint32_t _height, uint32_t _flags = BGFX_RESET_NONE);
 
 	/// Advance to next frame. When using multithreaded renderer, this call
 	/// just swaps internal buffers, kicks render thread, and returns. In
@@ -598,7 +604,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_frame`.
 	///
-	uint32_t frame();
+	BGFX_SHARED_LIB_API uint32_t frame();
 
 	/// Returns current renderer backend API type.
 	///
@@ -607,7 +613,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_get_renderer_type`.
 	///
-	RendererType::Enum getRendererType();
+	BGFX_SHARED_LIB_API RendererType::Enum getRendererType();
 
 	/// Returns renderer capabilities.
 	///
@@ -618,25 +624,25 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_get_caps`.
 	///
-	const Caps* getCaps();
+	BGFX_SHARED_LIB_API const Caps* getCaps();
 
 	/// Returns HMD info.
 	///
 	/// @attention C99 equivalent is `bgfx_get_hmd`.
 	///
-	const HMD* getHMD();
+	BGFX_SHARED_LIB_API const HMD* getHMD();
 
 	/// Allocate buffer to pass to bgfx calls. Data will be freed inside bgfx.
 	///
 	/// @attention C99 equivalent is `bgfx_alloc`.
 	///
-	const Memory* alloc(uint32_t _size);
+	BGFX_SHARED_LIB_API const Memory* alloc(uint32_t _size);
 
 	/// Allocate buffer and copy data into it. Data will be freed inside bgfx.
 	///
 	/// @attention C99 equivalent is `bgfx_copy`.
 	///
-	const Memory* copy(const void* _data, uint32_t _size);
+	BGFX_SHARED_LIB_API const Memory* copy(const void* _data, uint32_t _size);
 
 	/// Make reference to data to pass to bgfx. Unlike `bgfx::alloc` this call
 	/// doesn't allocate memory for data. It just copies pointer to data. You
@@ -647,7 +653,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent are `bgfx_make_ref`, `bgfx_make_ref_release`.
 	///
-	const Memory* makeRef(const void* _data, uint32_t _size, ReleaseFn _releaseFn = NULL, void* _userData = NULL);
+	BGFX_SHARED_LIB_API const Memory* makeRef(const void* _data, uint32_t _size, ReleaseFn _releaseFn = NULL, void* _userData = NULL);
 
 	/// Set debug flags.
 	///
@@ -662,19 +668,19 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_debug`.
 	///
-	void setDebug(uint32_t _debug);
+	BGFX_SHARED_LIB_API void setDebug(uint32_t _debug);
 
 	/// Clear internal debug text buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_dbg_text_clear`.
 	///
-	void dbgTextClear(uint8_t _attr = 0, bool _small = false);
+	BGFX_SHARED_LIB_API void dbgTextClear(uint8_t _attr = 0, bool _small = false);
 
 	/// Print into internal debug text buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_dbg_text_printf`.
 	///
-	void dbgTextPrintf(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, ...);
+	BGFX_SHARED_LIB_API void dbgTextPrintf(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, ...);
 
 	/// Draw image into internal debug text buffer.
 	///
@@ -687,7 +693,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_dbg_text_image`.
 	///
-	void dbgTextImage(uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height, const void* _data, uint16_t _pitch);
+	BGFX_SHARED_LIB_API void dbgTextImage(uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height, const void* _data, uint16_t _pitch);
 
 	/// Create static index buffer.
 	///
@@ -707,13 +713,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_index_buffer`.
 	///
-	IndexBufferHandle createIndexBuffer(const Memory* _mem, uint16_t _flags = BGFX_BUFFER_NONE);
+	BGFX_SHARED_LIB_API IndexBufferHandle createIndexBuffer(const Memory* _mem, uint16_t _flags = BGFX_BUFFER_NONE);
 
 	/// Destroy static index buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_index_buffer`.
 	///
-	void destroyIndexBuffer(IndexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyIndexBuffer(IndexBufferHandle _handle);
 
 	/// Create static vertex buffer.
 	///
@@ -723,7 +729,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_vertex_buffer`.
 	///
-	VertexBufferHandle createVertexBuffer(const Memory* _mem, const VertexDecl& _decl, uint16_t _flags = BGFX_BUFFER_NONE);
+	BGFX_SHARED_LIB_API VertexBufferHandle createVertexBuffer(const Memory* _mem, const VertexDecl& _decl, uint16_t _flags = BGFX_BUFFER_NONE);
 
 	/// Destroy static vertex buffer.
 	///
@@ -731,7 +737,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_vertex_buffer`.
 	///
-	void destroyVertexBuffer(VertexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyVertexBuffer(VertexBufferHandle _handle);
 
 	/// Create empty dynamic index buffer.
 	///
@@ -751,7 +757,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_dynamic_index_buffer`.
 	///
-	DynamicIndexBufferHandle createDynamicIndexBuffer(uint32_t _num, uint16_t _flags = BGFX_BUFFER_NONE);
+	BGFX_SHARED_LIB_API DynamicIndexBufferHandle createDynamicIndexBuffer(uint32_t _num, uint16_t _flags = BGFX_BUFFER_NONE);
 
 	/// Create dynamic index buffer and initialized it.
 	///
@@ -771,17 +777,16 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_dynamic_index_buffer_mem`.
 	///
-	DynamicIndexBufferHandle createDynamicIndexBuffer(const Memory* _mem, uint16_t _flags = BGFX_BUFFER_NONE);
+	BGFX_SHARED_LIB_API DynamicIndexBufferHandle createDynamicIndexBuffer(const Memory* _mem, uint16_t _flags = BGFX_BUFFER_NONE);
 
 	/// Update dynamic index buffer.
 	///
 	/// @param _handle Dynamic index buffer handle.
-	/// @param _startIndex Start index.
 	/// @param _mem Index buffer data.
 	///
 	/// @attention C99 equivalent is `bgfx_update_dynamic_index_buffer`.
 	///
-	void updateDynamicIndexBuffer(DynamicIndexBufferHandle _handle, uint32_t _startIndex, const Memory* _mem);
+	BGFX_SHARED_LIB_API void updateDynamicIndexBuffer(DynamicIndexBufferHandle _handle, const Memory* _mem);
 
 	/// Destroy dynamic index buffer.
 	///
@@ -789,7 +794,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_dynamic_index_buffer`.
 	///
-	void destroyDynamicIndexBuffer(DynamicIndexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyDynamicIndexBuffer(DynamicIndexBufferHandle _handle);
 
 	/// Create empty dynamic vertex buffer.
 	///
@@ -810,7 +815,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_dynamic_vertex_buffer`.
 	///
-	DynamicVertexBufferHandle createDynamicVertexBuffer(uint32_t _num, const VertexDecl& _decl, uint16_t _flags = BGFX_BUFFER_NONE);
+	BGFX_SHARED_LIB_API DynamicVertexBufferHandle createDynamicVertexBuffer(uint32_t _num, const VertexDecl& _decl, uint16_t _flags = BGFX_BUFFER_NONE);
 
 	/// Create dynamic vertex buffer and initialize it.
 	///
@@ -831,11 +836,11 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_dynamic_vertex_buffer_mem`.
 	///
-	DynamicVertexBufferHandle createDynamicVertexBuffer(const Memory* _mem, const VertexDecl& _decl, uint16_t _flags = BGFX_BUFFER_NONE);
+	BGFX_SHARED_LIB_API DynamicVertexBufferHandle createDynamicVertexBuffer(const Memory* _mem, const VertexDecl& _decl, uint16_t _flags = BGFX_BUFFER_NONE);
 
 	/// Update dynamic vertex buffer.
 	///
-	/// @param _handle Dynamic vertex buffer handle.
+/// @param _handle Dynamic vertex buffer handle.
 	/// @param _startVertex Start vertex.
 	/// @param _mem Vertex buffer data.
 	///
@@ -847,7 +852,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_dynamic_vertex_buffer`.
 	///
-	void destroyDynamicVertexBuffer(DynamicVertexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyDynamicVertexBuffer(DynamicVertexBufferHandle _handle);
 
 	/// Returns true if internal transient index buffer has enough space.
 	///
@@ -855,7 +860,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_check_avail_transient_index_buffer`.
 	///
-	bool checkAvailTransientIndexBuffer(uint32_t _num);
+	BGFX_SHARED_LIB_API bool checkAvailTransientIndexBuffer(uint32_t _num);
 
 	/// Returns true if internal transient vertex buffer has enough space.
 	///
@@ -864,7 +869,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_check_avail_transient_vertex_buffer`.
 	///
-	bool checkAvailTransientVertexBuffer(uint32_t _num, const VertexDecl& _decl);
+	BGFX_SHARED_LIB_API bool checkAvailTransientVertexBuffer(uint32_t _num, const VertexDecl& _decl);
 
 	/// Returns true if internal instance data buffer has enough space.
 	///
@@ -873,7 +878,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_check_avail_instance_data_buffer`.
 	///
-	bool checkAvailInstanceDataBuffer(uint32_t _num, uint16_t _stride);
+	BGFX_SHARED_LIB_API bool checkAvailInstanceDataBuffer(uint32_t _num, uint16_t _stride);
 
 	/// Returns true if both internal transient index and vertex buffer have
 	/// enough space.
@@ -884,7 +889,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_check_avail_transient_buffers`.
 	///
-	bool checkAvailTransientBuffers(uint32_t _numVertices, const VertexDecl& _decl, uint32_t _numIndices);
+	BGFX_SHARED_LIB_API bool checkAvailTransientBuffers(uint32_t _numVertices, const VertexDecl& _decl, uint32_t _numIndices);
 
 	/// Allocate transient index buffer.
 	///
@@ -900,7 +905,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transient_index_buffer`.
 	///
-	void allocTransientIndexBuffer(TransientIndexBuffer* _tib, uint32_t _num);
+	BGFX_SHARED_LIB_API void allocTransientIndexBuffer(TransientIndexBuffer* _tib, uint32_t _num);
 
 	/// Allocate transient vertex buffer.
 	///
@@ -916,7 +921,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transient_vertex_buffer`.
 	///
-	void allocTransientVertexBuffer(TransientVertexBuffer* _tvb, uint32_t _num, const VertexDecl& _decl);
+	BGFX_SHARED_LIB_API void allocTransientVertexBuffer(TransientVertexBuffer* _tvb, uint32_t _num, const VertexDecl& _decl);
 
 	/// Check for required space and allocate transient vertex and index
 	/// buffers. If both space requirements are satisfied function returns
@@ -927,7 +932,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transient_buffers`.
 	///
-	bool allocTransientBuffers(TransientVertexBuffer* _tvb, const VertexDecl& _decl, uint32_t _numVertices, TransientIndexBuffer* _tib, uint32_t _numIndices);
+	BGFX_SHARED_LIB_API bool allocTransientBuffers(TransientVertexBuffer* _tvb, const VertexDecl& _decl, uint32_t _numVertices, TransientIndexBuffer* _tib, uint32_t _numIndices);
 
 	/// Allocate instance data buffer.
 	///
@@ -937,25 +942,25 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_instance_data_buffer`.
 	///
-	const InstanceDataBuffer* allocInstanceDataBuffer(uint32_t _num, uint16_t _stride);
+	BGFX_SHARED_LIB_API const InstanceDataBuffer* allocInstanceDataBuffer(uint32_t _num, uint16_t _stride);
 
 	/// Create draw indirect buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_create_indirect_buffer`.
 	///
-	IndirectBufferHandle createIndirectBuffer(uint32_t _num);
+	BGFX_SHARED_LIB_API IndirectBufferHandle createIndirectBuffer(uint32_t _num);
 
 	/// Destroy draw indirect buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_indirect_buffer`.
 	///
-	void destroyIndirectBuffer(IndirectBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyIndirectBuffer(IndirectBufferHandle _handle);
 
 	/// Create shader from memory buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_create_shader`.
 	///
-	ShaderHandle createShader(const Memory* _mem);
+	BGFX_SHARED_LIB_API ShaderHandle createShader(const Memory* _mem);
 
 	/// Returns num of uniforms, and uniform handles used inside shader.
 	///
@@ -969,14 +974,14 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_get_shader_uniforms`.
 	///
-	uint16_t getShaderUniforms(ShaderHandle _handle, UniformHandle* _uniforms = NULL, uint16_t _max = 0);
+	BGFX_SHARED_LIB_API uint16_t getShaderUniforms(ShaderHandle _handle, UniformHandle* _uniforms = NULL, uint16_t _max = 0);
 
 	/// Destroy shader. Once program is created with shader it is safe to
 	/// destroy shader.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_shader`.
 	///
-	void destroyShader(ShaderHandle _handle);
+	BGFX_SHARED_LIB_API void destroyShader(ShaderHandle _handle);
 
 	/// Create program with vertex and fragment shaders.
 	///
@@ -989,7 +994,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_program`.
 	///
-	ProgramHandle createProgram(ShaderHandle _vsh, ShaderHandle _fsh, bool _destroyShaders = false);
+	BGFX_SHARED_LIB_API ProgramHandle createProgram(ShaderHandle _vsh, ShaderHandle _fsh, bool _destroyShaders = false);
 
 	/// Create program with compute shader.
 	///
@@ -1000,19 +1005,19 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_compute_program`.
 	///
-	ProgramHandle createProgram(ShaderHandle _csh, bool _destroyShader = false);
+	BGFX_SHARED_LIB_API ProgramHandle createProgram(ShaderHandle _csh, bool _destroyShader = false);
 
 	/// Destroy program.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_program`.
 	///
-	void destroyProgram(ProgramHandle _handle);
+	BGFX_SHARED_LIB_API void destroyProgram(ProgramHandle _handle);
 
 	/// Calculate amount of memory required for texture.
 	///
 	/// @attention C99 equivalent is `bgfx_calc_texture_size`.
 	///
-	void calcTextureSize(TextureInfo& _info, uint16_t _width, uint16_t _height, uint16_t _depth, bool _cubeMap, uint8_t _numMips, TextureFormat::Enum _format);
+	BGFX_SHARED_LIB_API void calcTextureSize(TextureInfo& _info, uint16_t _width, uint16_t _height, uint16_t _depth, bool _cubeMap, uint8_t _numMips, TextureFormat::Enum _format);
 
 	/// Create texture from memory buffer.
 	///
@@ -1030,7 +1035,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture`.
 	///
-	TextureHandle createTexture(const Memory* _mem, uint32_t _flags = BGFX_TEXTURE_NONE, uint8_t _skip = 0, TextureInfo* _info = NULL);
+	BGFX_SHARED_LIB_API TextureHandle createTexture(const Memory* _mem, uint32_t _flags = BGFX_TEXTURE_NONE, uint8_t _skip = 0, TextureInfo* _info = NULL);
 
 	/// Create 2D texture.
 	///
@@ -1043,12 +1048,12 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture_2d`.
 	///
-	TextureHandle createTexture2D(uint16_t _width, uint16_t _height, uint8_t _numMips, TextureFormat::Enum _format, uint32_t _flags = BGFX_TEXTURE_NONE, const Memory* _mem = NULL);
+	BGFX_SHARED_LIB_API TextureHandle createTexture2D(uint16_t _width, uint16_t _height, uint8_t _numMips, TextureFormat::Enum _format, uint32_t _flags = BGFX_TEXTURE_NONE, const Memory* _mem = NULL);
 
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture_2d_scaled`.
 	///
-	TextureHandle createTexture2D(BackbufferRatio::Enum _ratio, uint8_t _numMips, TextureFormat::Enum _format, uint32_t _flags = BGFX_TEXTURE_NONE);
+	BGFX_SHARED_LIB_API TextureHandle createTexture2D(BackbufferRatio::Enum _ratio, uint8_t _numMips, TextureFormat::Enum _format, uint32_t _flags = BGFX_TEXTURE_NONE);
 
 	/// Create 3D texture.
 	///
@@ -1062,7 +1067,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture_3d`.
 	///
-	TextureHandle createTexture3D(uint16_t _width, uint16_t _height, uint16_t _depth, uint8_t _numMips, TextureFormat::Enum _format, uint32_t _flags = BGFX_TEXTURE_NONE, const Memory* _mem = NULL);
+	BGFX_SHARED_LIB_API TextureHandle createTexture3D(uint16_t _width, uint16_t _height, uint16_t _depth, uint8_t _numMips, TextureFormat::Enum _format, uint32_t _flags = BGFX_TEXTURE_NONE, const Memory* _mem = NULL);
 
 	/// Create Cube texture.
 	///
@@ -1074,7 +1079,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture_cube`.
 	///
-	TextureHandle createTextureCube(uint16_t _size, uint8_t _numMips, TextureFormat::Enum _format, uint32_t _flags = BGFX_TEXTURE_NONE, const Memory* _mem = NULL);
+	BGFX_SHARED_LIB_API TextureHandle createTextureCube(uint16_t _size, uint8_t _numMips, TextureFormat::Enum _format, uint32_t _flags = BGFX_TEXTURE_NONE, const Memory* _mem = NULL);
 
 	/// Update 2D texture.
 	///
@@ -1090,7 +1095,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_update_texture_2d`.
 	///
-	void updateTexture2D(TextureHandle _handle, uint8_t _mip, uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height, const Memory* _mem, uint16_t _pitch = UINT16_MAX);
+	BGFX_SHARED_LIB_API void updateTexture2D(TextureHandle _handle, uint8_t _mip, uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height, const Memory* _mem, uint16_t _pitch = UINT16_MAX);
 
 	/// Update 3D texture.
 	///
@@ -1106,7 +1111,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_update_texture_3d`.
 	///
-	void updateTexture3D(TextureHandle _handle, uint8_t _mip, uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _width, uint16_t _height, uint16_t _depth, const Memory* _mem);
+	BGFX_SHARED_LIB_API void updateTexture3D(TextureHandle _handle, uint8_t _mip, uint16_t _x, uint16_t _y, uint16_t _z, uint16_t _width, uint16_t _height, uint16_t _depth, const Memory* _mem);
 
 	/// Update Cube texture.
 	///
@@ -1142,13 +1147,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_update_texture_cube`.
 	///
-	void updateTextureCube(TextureHandle _handle, uint8_t _side, uint8_t _mip, uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height, const Memory* _mem, uint16_t _pitch = UINT16_MAX);
+	BGFX_SHARED_LIB_API void updateTextureCube(TextureHandle _handle, uint8_t _side, uint8_t _mip, uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height, const Memory* _mem, uint16_t _pitch = UINT16_MAX);
 
 	/// Destroy texture.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_texture`.
 	///
-	void destroyTexture(TextureHandle _handle);
+	BGFX_SHARED_LIB_API void destroyTexture(TextureHandle _handle);
 
 	/// Create frame buffer (simple).
 	///
@@ -1159,12 +1164,12 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer`.
 	///
-	FrameBufferHandle createFrameBuffer(uint16_t _width, uint16_t _height, TextureFormat::Enum _format, uint32_t _textureFlags = BGFX_TEXTURE_U_CLAMP|BGFX_TEXTURE_V_CLAMP);
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(uint16_t _width, uint16_t _height, TextureFormat::Enum _format, uint32_t _textureFlags = BGFX_TEXTURE_U_CLAMP | BGFX_TEXTURE_V_CLAMP);
 
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer_scaled`.
 	///
-	FrameBufferHandle createFrameBuffer(BackbufferRatio::Enum _ratio, TextureFormat::Enum _format, uint32_t _textureFlags = BGFX_TEXTURE_U_CLAMP|BGFX_TEXTURE_V_CLAMP);
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(BackbufferRatio::Enum _ratio, TextureFormat::Enum _format, uint32_t _textureFlags = BGFX_TEXTURE_U_CLAMP | BGFX_TEXTURE_V_CLAMP);
 
 	/// Create frame buffer.
 	///
@@ -1175,7 +1180,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer_from_handles`.
 	///
-	FrameBufferHandle createFrameBuffer(uint8_t _num, TextureHandle* _handles, bool _destroyTextures = false);
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(uint8_t _num, TextureHandle* _handles, bool _destroyTextures = false);
 
 	/// Create frame buffer for multiple window rendering.
 	///
@@ -1191,13 +1196,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer_from_nwh`.
 	///
-	FrameBufferHandle createFrameBuffer(void* _nwh, uint16_t _width, uint16_t _height, TextureFormat::Enum _depthFormat = TextureFormat::UnknownDepth);
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(void* _nwh, uint16_t _width, uint16_t _height, TextureFormat::Enum _depthFormat = TextureFormat::UnknownDepth);
 
 	/// Destroy frame buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_frame_buffer`.
 	///
-	void destroyFrameBuffer(FrameBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyFrameBuffer(FrameBufferHandle _handle);
 
 	/// Create shader uniform parameter.
 	///
@@ -1227,7 +1232,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_uniform`.
 	///
-	UniformHandle createUniform(const char* _name, UniformType::Enum _type, uint16_t _num = 1);
+	BGFX_SHARED_LIB_API UniformHandle createUniform(const char* _name, UniformType::Enum _type, uint16_t _num = 1);
 
 	/// Destroy shader uniform parameter.
 	///
@@ -1235,7 +1240,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_uniform`.
 	///
-	void destroyUniform(UniformHandle _handle);
+	BGFX_SHARED_LIB_API void destroyUniform(UniformHandle _handle);
 
 	/// Set clear color palette value.
 	///
@@ -1244,7 +1249,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is ``.
 	///
-	void setClearColor(uint8_t _index, uint32_t _rgba);
+	BGFX_SHARED_LIB_API void setClearColor(uint8_t _index, uint32_t _rgba);
 
 	/// Set clear color palette value.
 	///
@@ -1253,7 +1258,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is ``.
 	///
-	void setClearColor(uint8_t _index, float _r, float _g, float _b, float _a);
+	BGFX_SHARED_LIB_API void setClearColor(uint8_t _index, float _r, float _g, float _b, float _a);
 
 	/// Set clear color palette value.
 	///
@@ -1262,7 +1267,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_clear_color`.
 	///
-	void setClearColor(uint8_t _index, const float _rgba[4]);
+	BGFX_SHARED_LIB_API void setClearColor(uint8_t _index, const float _rgba[4]);
 
 	/// Set view name.
 	///
@@ -1282,7 +1287,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_name`.
 	///
-	void setViewName(uint8_t _id, const char* _name);
+	BGFX_SHARED_LIB_API void setViewName(uint8_t _id, const char* _name);
 
 	/// Set view rectangle. Draw primitive outside view will be clipped.
 	///
@@ -1294,7 +1299,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_rect`.
 	///
-	void setViewRect(uint8_t _id, uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height);
+	BGFX_SHARED_LIB_API void setViewRect(uint8_t _id, uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height);
 
 	/// Set view scissor. Draw primitive outside view will be clipped. When
 	/// _x, _y, _width and _height are set to 0, scissor will be disabled.
@@ -1306,7 +1311,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_scissor`.
 	///
-	void setViewScissor(uint8_t _id, uint16_t _x = 0, uint16_t _y = 0, uint16_t _width = 0, uint16_t _height = 0);
+	BGFX_SHARED_LIB_API void setViewScissor(uint8_t _id, uint16_t _x = 0, uint16_t _y = 0, uint16_t _width = 0, uint16_t _height = 0);
 
 	/// Set view clear flags.
 	///
@@ -1319,7 +1324,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_clear`.
 	///
-	void setViewClear(uint8_t _id, uint16_t _flags, uint32_t _rgba = 0x000000ff, float _depth = 1.0f, uint8_t _stencil = 0);
+	BGFX_SHARED_LIB_API void setViewClear(uint8_t _id, uint16_t _flags, uint32_t _rgba = 0x000000ff, float _depth = 1.0f, uint8_t _stencil = 0);
 
 	/// Set view clear flags with different clear color for each
 	/// frame buffer texture. Must use setClearColor to setup clear color
@@ -1333,14 +1338,14 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_clear_mrt`.
 	///
-	void setViewClear(uint8_t _id, uint16_t _flags, float _depth, uint8_t _stencil, uint8_t _0 = UINT8_MAX, uint8_t _1 = UINT8_MAX, uint8_t _2 = UINT8_MAX, uint8_t _3 = UINT8_MAX, uint8_t _4 = UINT8_MAX, uint8_t _5 = UINT8_MAX, uint8_t _6 = UINT8_MAX, uint8_t _7 = UINT8_MAX);
+	BGFX_SHARED_LIB_API void setViewClear(uint8_t _id, uint16_t _flags, float _depth, uint8_t _stencil, uint8_t _0 = UINT8_MAX, uint8_t _1 = UINT8_MAX, uint8_t _2 = UINT8_MAX, uint8_t _3 = UINT8_MAX, uint8_t _4 = UINT8_MAX, uint8_t _5 = UINT8_MAX, uint8_t _6 = UINT8_MAX, uint8_t _7 = UINT8_MAX);
 
 	/// Set view into sequential mode. Draw calls will be sorted in the same
 	/// order in which submit calls were called.
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_seq`.
 	///
-	void setViewSeq(uint8_t _id, bool _enabled);
+	BGFX_SHARED_LIB_API void setViewSeq(uint8_t _id, bool _enabled);
 
 	/// Set view frame buffer.
 	///
@@ -1354,7 +1359,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_frame_buffer`.
 	///
-	void setViewFrameBuffer(uint8_t _id, FrameBufferHandle _handle);
+	BGFX_SHARED_LIB_API void setViewFrameBuffer(uint8_t _id, FrameBufferHandle _handle);
 
 	/// Set view view and projection matrices, all draw primitives in this
 	/// view will use these matrices.
@@ -1371,7 +1376,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent are `bgfx_set_view_transform`, `bgfx_set_view_transform_stereo`.
 	///
-	void setViewTransform(uint8_t _id, const void* _view, const void* _projL, uint8_t _flags = BGFX_VIEW_STEREO, const void* _projR = NULL);
+	BGFX_SHARED_LIB_API void setViewTransform(uint8_t _id, const void* _view, const void* _projL, uint8_t _flags = BGFX_VIEW_STEREO, const void* _projR = NULL);
 
 	/// Post submit view reordering.
 	///
@@ -1382,13 +1387,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is ``.
 	///
-	void setViewRemap(uint8_t _id = 0, uint8_t _num = UINT8_MAX, const void* _remap = NULL);
+	BGFX_SHARED_LIB_API void setViewRemap(uint8_t _id = 0, uint8_t _num = UINT8_MAX, const void* _remap = NULL);
 
 	/// Sets debug marker.
 	///
 	/// @attention C99 equivalent is `bgfx_set_marker`.
 	///
-	void setMarker(const char* _marker);
+	BGFX_SHARED_LIB_API void setMarker(const char* _marker);
 
 	/// Set render states for draw primitive.
 	///
@@ -1415,7 +1420,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_state`.
 	///
-	void setState(uint64_t _state, uint32_t _rgba = 0);
+	BGFX_SHARED_LIB_API void setState(uint64_t _state, uint32_t _rgba = 0);
 
 	/// Set stencil test state.
 	///
@@ -1425,7 +1430,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_stencil`.
 	///
-	void setStencil(uint32_t _fstencil, uint32_t _bstencil = BGFX_STENCIL_NONE);
+	BGFX_SHARED_LIB_API void setStencil(uint32_t _fstencil, uint32_t _bstencil = BGFX_STENCIL_NONE);
 
 	/// Set scissor for draw primitive. For scissor for all primitives in
 	/// view see setViewScissor.
@@ -1438,7 +1443,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_scissor`.
 	///
-	uint16_t setScissor(uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height);
+	BGFX_SHARED_LIB_API uint16_t setScissor(uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height);
 
 	/// Set scissor from cache for draw primitive.
 	///
@@ -1447,7 +1452,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_scissor_cached`.
 	///
-	void setScissor(uint16_t _cache = UINT16_MAX);
+	BGFX_SHARED_LIB_API void setScissor(uint16_t _cache = UINT16_MAX);
 
 	/// Set model matrix for draw primitive. If it is not called model will
 	/// be rendered with identity model matrix.
@@ -1459,7 +1464,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_transform`.
 	///
-	uint32_t setTransform(const void* _mtx, uint16_t _num = 1);
+	BGFX_SHARED_LIB_API uint32_t setTransform(const void* _mtx, uint16_t _num = 1);
 
 	/// Reserve `_num` matrices in internal matrix cache. Pointer returned
 	/// can be modifed until `bgfx::frame` is called.
@@ -1470,7 +1475,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transform`.
 	///
-	uint32_t allocTransform(Transform* _transform, uint16_t _num);
+	BGFX_SHARED_LIB_API uint32_t allocTransform(Transform* _transform, uint16_t _num);
 
 	/// Set model matrix from matrix cache for draw primitive.
 	///
@@ -1479,91 +1484,91 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_transform_cached`.
 	///
-	void setTransform(uint32_t _cache, uint16_t _num = 1);
+	BGFX_SHARED_LIB_API void setTransform(uint32_t _cache, uint16_t _num = 1);
 
 	/// Set shader uniform parameter for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_uniform`.
 	///
-	void setUniform(UniformHandle _handle, const void* _value, uint16_t _num = 1);
+	BGFX_SHARED_LIB_API void setUniform(UniformHandle _handle, const void* _value, uint16_t _num = 1);
 
 	/// Set index buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_index_buffer`.
 	///
-	void setIndexBuffer(IndexBufferHandle _handle, uint32_t _firstIndex = 0, uint32_t _numIndices = UINT32_MAX);
+	BGFX_SHARED_LIB_API void setIndexBuffer(IndexBufferHandle _handle, uint32_t _firstIndex = 0, uint32_t _numIndices = UINT32_MAX);
 
 	/// Set index buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_dynamic_index_buffer`.
 	///
-	void setIndexBuffer(DynamicIndexBufferHandle _handle, uint32_t _firstIndex = 0, uint32_t _numIndices = UINT32_MAX);
+	BGFX_SHARED_LIB_API void setIndexBuffer(DynamicIndexBufferHandle _handle, uint32_t _firstIndex = 0, uint32_t _numIndices = UINT32_MAX);
 
 	/// Set index buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is ``.
 	///
-	void setIndexBuffer(const TransientIndexBuffer* _tib);
+	BGFX_SHARED_LIB_API void setIndexBuffer(const TransientIndexBuffer* _tib);
 
 	/// Set index buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_transient_index_buffer`.
 	///
-	void setIndexBuffer(const TransientIndexBuffer* _tib, uint32_t _firstIndex, uint32_t _numIndices);
+	BGFX_SHARED_LIB_API void setIndexBuffer(const TransientIndexBuffer* _tib, uint32_t _firstIndex, uint32_t _numIndices);
 
 	/// Set vertex buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is ``.
 	///
-	void setVertexBuffer(VertexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void setVertexBuffer(VertexBufferHandle _handle);
 
 	/// Set vertex buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_vertex_buffer`.
 	///
-	void setVertexBuffer(VertexBufferHandle _handle, uint32_t _startVertex, uint32_t _numVertices);
+	BGFX_SHARED_LIB_API void setVertexBuffer(VertexBufferHandle _handle, uint32_t _startVertex, uint32_t _numVertices);
 
 	/// Set vertex buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_dynamic_vertex_buffer`.
 	///
-	void setVertexBuffer(DynamicVertexBufferHandle _handle, uint32_t _numVertices = UINT32_MAX);
+	BGFX_SHARED_LIB_API void setVertexBuffer(DynamicVertexBufferHandle _handle, uint32_t _numVertices = UINT32_MAX);
 
 	/// Set vertex buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is ``.
 	///
-	void setVertexBuffer(const TransientVertexBuffer* _tvb);
+	BGFX_SHARED_LIB_API void setVertexBuffer(const TransientVertexBuffer* _tvb);
 
 	/// Set vertex buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_transient_vertex_buffer`.
 	///
-	void setVertexBuffer(const TransientVertexBuffer* _tvb, uint32_t _startVertex, uint32_t _numVertices);
+	BGFX_SHARED_LIB_API void setVertexBuffer(const TransientVertexBuffer* _tvb, uint32_t _startVertex, uint32_t _numVertices);
 
 	/// Set instance data buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_instance_data_buffer`.
 	///
-	void setInstanceDataBuffer(const InstanceDataBuffer* _idb, uint32_t _num = UINT32_MAX);
+	BGFX_SHARED_LIB_API void setInstanceDataBuffer(const InstanceDataBuffer* _idb, uint32_t _num = UINT32_MAX);
 
 	/// Set instance data buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_instance_data_from_vertex_buffer`.
 	///
-	void setInstanceDataBuffer(VertexBufferHandle _handle, uint32_t _startVertex, uint32_t _num);
+	BGFX_SHARED_LIB_API void setInstanceDataBuffer(VertexBufferHandle _handle, uint32_t _startVertex, uint32_t _num);
 
 	/// Set instance data buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_instance_data_from_dynamic_vertex_buffer`.
 	///
-	void setInstanceDataBuffer(DynamicVertexBufferHandle _handle, uint32_t _startVertex, uint32_t _num);
+	BGFX_SHARED_LIB_API void setInstanceDataBuffer(DynamicVertexBufferHandle _handle, uint32_t _startVertex, uint32_t _num);
 
 	/// Set program for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_program`.
 	///
-	void setProgram(ProgramHandle _handle);
+	BGFX_SHARED_LIB_API void setProgram(ProgramHandle _handle);
 
 	/// Set texture stage for draw primitive.
 	///
@@ -1582,7 +1587,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_texture`.
 	///
-	void setTexture(uint8_t _stage, UniformHandle _sampler, TextureHandle _handle, uint32_t _flags = UINT32_MAX);
+	BGFX_SHARED_LIB_API void setTexture(uint8_t _stage, UniformHandle _sampler, TextureHandle _handle, uint32_t _flags = UINT32_MAX);
 
 	/// Set texture stage for draw primitive.
 	///
@@ -1599,7 +1604,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_texture_from_frame_buffer`.
 	///
-	void setTexture(uint8_t _stage, UniformHandle _sampler, FrameBufferHandle _handle, uint8_t _attachment = 0, uint32_t _flags = UINT32_MAX);
+	BGFX_SHARED_LIB_API void setTexture(uint8_t _stage, UniformHandle _sampler, FrameBufferHandle _handle, uint8_t _attachment = 0, uint32_t _flags = UINT32_MAX);
 
 	/// Submit primitive for rendering.
 	///
@@ -1609,74 +1614,74 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_submit`.
 	///
-	uint32_t submit(uint8_t _id, int32_t _depth = 0);
+	BGFX_SHARED_LIB_API uint32_t submit(uint8_t _id, int32_t _depth = 0);
 
 	/// Submit primitive for rendering with index and instance data info from
 	/// indirect buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_submit_indirect`.
 	///
-	uint32_t submit(uint8_t _id, IndirectBufferHandle _indirectHandle, uint16_t _start = 0, uint16_t _num = 1, int32_t _depth = 0);
+	BGFX_SHARED_LIB_API uint32_t submit(uint8_t _id, IndirectBufferHandle _indirectHandle, uint16_t _start = 0, uint16_t _num = 1, int32_t _depth = 0);
 
 	///
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_index_buffer`.
 	///
-	void setBuffer(uint8_t _stage, IndexBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, IndexBufferHandle _handle, Access::Enum _access);
 
 	///
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_vertex_buffer`.
 	///
-	void setBuffer(uint8_t _stage, VertexBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, VertexBufferHandle _handle, Access::Enum _access);
 
 	///
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_dynamic_index_buffer`.
 	///
-	void setBuffer(uint8_t _stage, DynamicIndexBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, DynamicIndexBufferHandle _handle, Access::Enum _access);
 
 	///
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_dynamic_vertex_buffer`.
 	///
-	void setBuffer(uint8_t _stage, DynamicVertexBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, DynamicVertexBufferHandle _handle, Access::Enum _access);
 
 	///
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_indirect_buffer`.
 	///
-	void setBuffer(uint8_t _stage, IndirectBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, IndirectBufferHandle _handle, Access::Enum _access);
 
 	/// Set compute image from texture.
 	///
 	/// @attention C99 equivalent is `bgfx_set_image`.
 	///
-	void setImage(uint8_t _stage, UniformHandle _sampler, TextureHandle _handle, uint8_t _mip, Access::Enum _access, TextureFormat::Enum _format = TextureFormat::Count);
+	BGFX_SHARED_LIB_API void setImage(uint8_t _stage, UniformHandle _sampler, TextureHandle _handle, uint8_t _mip, Access::Enum _access, TextureFormat::Enum _format = TextureFormat::Count);
 
 	/// Set compute image from frame buffer texture.
 	///
 	/// @attention C99 equivalent is `bgfx_set_image_from_frame_buffer`.
 	///
-	void setImage(uint8_t _stage, UniformHandle _sampler, FrameBufferHandle _handle, uint8_t _attachment, Access::Enum _access, TextureFormat::Enum _format = TextureFormat::Count);
+	BGFX_SHARED_LIB_API void setImage(uint8_t _stage, UniformHandle _sampler, FrameBufferHandle _handle, uint8_t _attachment, Access::Enum _access, TextureFormat::Enum _format = TextureFormat::Count);
 
 	/// Dispatch compute.
 	///
 	/// @attention C99 equivalent is `bgfx_dispatch`.
 	///
-	uint32_t dispatch(uint8_t _id, ProgramHandle _handle, uint16_t _numX = 1, uint16_t _numY = 1, uint16_t _numZ = 1, uint8_t _flags = BGFX_SUBMIT_EYE_FIRST);
+	BGFX_SHARED_LIB_API uint32_t dispatch(uint8_t _id, ProgramHandle _handle, uint16_t _numX = 1, uint16_t _numY = 1, uint16_t _numZ = 1, uint8_t _flags = BGFX_SUBMIT_EYE_FIRST);
 
 	/// Dispatch compute indirect.
 	///
 	/// @attention C99 equivalent is `bgfx_dispatch_indirect`.
 	///
-	uint32_t dispatch(uint8_t _id, ProgramHandle _handle, IndirectBufferHandle _indirectHandle, uint16_t _start = 0, uint16_t _num = 1, uint8_t _flags = BGFX_SUBMIT_EYE_FIRST);
+	BGFX_SHARED_LIB_API uint32_t dispatch(uint8_t _id, ProgramHandle _handle, IndirectBufferHandle _indirectHandle, uint16_t _start = 0, uint16_t _num = 1, uint8_t _flags = BGFX_SUBMIT_EYE_FIRST);
 
 	/// Discard all previously set state for draw or compute call.
 	///
 	/// @attention C99 equivalent is `bgfx_discard`.
 	///
-	void discard();
+	BGFX_SHARED_LIB_API void discard();
 
 	/// Request screen shot.
 	///
@@ -1687,7 +1692,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_save_screen_shot`.
 	///
-	void saveScreenShot(const char* _filePath);
+	BGFX_SHARED_LIB_API void saveScreenShot(const char* _filePath);
 
 } // namespace bgfx
 

--- a/include/bgfxplatform.h
+++ b/include/bgfxplatform.h
@@ -12,6 +12,12 @@
 
 #include <bx/platform.h>
 
+#if defined(BX_PLATFORM_WINDOWS)
+#   define BGFX_SHARED_LIB_API __declspec(dllexport)
+#else
+#   define BGFX_SHARED_LIB_API
+#endif // defined(BX_PLATFORM_WINDOWS)
+
 namespace bgfx
 {
 	struct RenderFrame
@@ -40,7 +46,7 @@ namespace bgfx
 		void* backBufferDS; //< Backbuffer depth/stencil.
 	};
 
-	void setPlatformData(const PlatformData& _hooks);
+	BGFX_SHARED_LIB_API 
 
 } // namespace bgfx
 


### PR DESCRIPTION
Export functions for the C ++ API for dynamic linking. Otherwise, it can not be used as a bgfx Shared library.