### PR TITLE
Update for ImGui 1.43 with AA (NB: issues with DX9)

### DIFF
--- a/examples/common/imgui/scintilla.cpp
+++ b/examples/common/imgui/scintilla.cpp
@@ -741,7 +741,7 @@ public:
 			ImGuiIO& io = ImGui::GetIO();
 			Scintilla::Point pt = Scintilla::Point::FromInts( (int)io.MouseClickedPos[0].x, (int)io.MouseClickedPos[0].y);
 
-			ButtonDown(pt, (unsigned int)io.MouseDownTime[0], false, false, false);
+			ButtonDown(pt, (unsigned int)io.MouseDownDuration[0], false, false, false);
 		}
 
 		Tick();


### PR DESCRIPTION
Following https://github.com/bkaradzic/imgui/commit/d21ba194961a40357fafc091fb8ad2d98992537f#commitcomment-12161853

This is the patch to apply if you update to the current Master of ImGui, the AA-branch has just been merged in.

- It is still off and blurry on DX9. Your patch (adding PixelCenterOffset) fixes it for fonts but not for border. On the test window if you open a menu you'll notice the menu borders are blurry in DX9. You can also click Window Options-->Show Border, and in Style->Colors set the border color to full white with no transparency.

For comparaison, default border on menu
![border](https://cloud.githubusercontent.com/assets/8225057/8700450/10f86b06-2ac9-11e5-8a77-8a2f756bf16e.PNG)

Borders everywhere, max white
![border1](https://cloud.githubusercontent.com/assets/8225057/8700455/18bb38fa-2ac9-11e5-827f-ea0c1c290979.PNG)

I believe it should be fixed by offsetting the entire projection matrix by 0.5 and then you can remove PixelCenterOffset and get back to vanilla ImGui. Couldn't figure out how to alter the matrix, runtime didn't seem to use what I set up in bx::mtxOrtho() / bgfx::setViewTransform() but I am not familiar with bgfx architecture. It could be that the example have a small bug that wasn't visible here.

- If you comment the call to AddFontFromMemoryTTF() it will load the default font which is an easy way to tell if rendering is correct.  You can also set io.MouseDrawCursor = true; rendered by ImGui as another test.