### PR TITLE
Improved the handling of iOS UIView resize / rotate

### DIFF
--- a/examples/common/entry/entry_ios.mm
+++ b/examples/common/entry/entry_ios.mm
@@ -169,6 +169,13 @@ using namespace entry;
 	return self;
 }
 
+- (void)layoutSubviews
+{
+    uint32_t frameW = (uint32_t)(self.contentScaleFactor * self.frame.size.width);
+    uint32_t frameH = (uint32_t)(self.contentScaleFactor * self.frame.size.height);
+    s_ctx->m_eventQueue.postSizeEvent(s_defaultWindow, frameW, frameH);
+}
+
 - (void)start
 {
 	if (nil == m_displayLink)

--- a/src/glcontext_eagl.mm
+++ b/src/glcontext_eagl.mm
@@ -98,6 +98,50 @@ namespace bgfx { namespace gl
 	{
 		BX_UNUSED(_width, _height, _flags);
 		BX_TRACE("resize context");
+
+        if (0 != m_fbo)
+		{
+			GL_CHECK(glDeleteFramebuffers(1, &m_fbo) );
+			m_fbo = 0;
+		}
+
+		if (0 != m_colorRbo)
+		{
+			GL_CHECK(glDeleteRenderbuffers(1, &m_colorRbo) );
+			m_colorRbo = 0;
+		}
+
+		if (0 != m_depthStencilRbo)
+		{
+			GL_CHECK(glDeleteRenderbuffers(1, &m_depthStencilRbo) );
+			m_depthStencilRbo = 0;
+		}
+
+        GL_CHECK(glGenFramebuffers(1, &m_fbo) );
+		GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_fbo) );
+
+		GL_CHECK(glGenRenderbuffers(1, &m_colorRbo) );
+		GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, m_colorRbo) );
+
+		[((EAGLContext*)m_context) renderbufferStorage:GL_RENDERBUFFER fromDrawable:(CAEAGLLayer*)g_platformData.nwh];
+		GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorRbo) );
+
+		GLint width;
+		GLint height;
+		GL_CHECK(glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &width) );
+		GL_CHECK(glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &height) );
+		BX_TRACE("Screen size: %d x %d", width, height);
+
+		GL_CHECK(glGenRenderbuffers(1, &m_depthStencilRbo) );
+		GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, m_depthStencilRbo) );
+		GL_CHECK(glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, width, height) ); // from OES_packed_depth_stencil
+		GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilRbo) );
+		GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilRbo) );
+
+		BX_CHECK(GL_FRAMEBUFFER_COMPLETE ==  glCheckFramebufferStatus(GL_FRAMEBUFFER)
+			, "glCheckFramebufferStatus failed 0x%08x"
+			, glCheckFramebufferStatus(GL_FRAMEBUFFER)
+			);
 	}
 
 	bool GlContext::isSwapChainSupported()


### PR DESCRIPTION
When an iOS UIView is resized or rotated, the associated FBO and RBO needed to be recreated, otherwise the rendered output will be stretched uglily.