### PR TITLE
add makefile target to publish docs to gh-pages.

### DIFF
--- a/makefile
+++ b/makefile
@@ -225,6 +225,16 @@ docs:
 	doxygen scripts/bgfx.doxygen
 	markdown README.md > .build/docs/readme.html
 
+publish_docs:
+	-@rm -rf .build/docs/html
+	make docs
+	git init .build/docs/html/
+	git --git-dir .build/docs/html/.git --work-tree .build/docs/html/ remote add origin git@github.com:bkaradzic/bgfx.git
+	git --git-dir .build/docs/html/.git --work-tree .build/docs/html/ add .
+	git --git-dir .build/docs/html/.git --work-tree .build/docs/html/ checkout -b gh-pages
+	-git --git-dir .build/docs/html/.git --work-tree .build/docs/html/ commit -m "Update documentation."
+	git --git-dir .build/docs/html/.git --work-tree .build/docs/html/ push -u origin gh-pages -f
+
 clean:
 	@echo Cleaning...
 	-@rm -rf .build


### PR DESCRIPTION
Hey there,

I've added a `publish_docs` target on `makefile` to publish the html documentation on GitHub Pages. It may allow easy access to the documentation for new users of `bgfx`. 

I've published the docs in my account, and the result is the following URL: http://endel.github.io/bgfx

**Usage:**

```bash
make publish_docs
```

Maybe it's a good idea to publish every update to `gh-pages` in a build server, or something. If you run the script, it will publish in your account: https://bkaradzic.github.io/bgfx

It also would be great to have the same on `bx`, which seems that doesn't have any documentation, is that correct?

Thanks you