### PR TITLE
d3d9 framebuffer correctly handles bgfx::reset

### DIFF
--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -2921,6 +2921,7 @@ namespace bgfx { namespace d3d9
 		{
 			DX_RELEASE(m_color[0],  0);
 			DX_RELEASE(m_swapChain, 0);
+			DX_RELEASE(m_depthStencil, 0);
 		}
 		else
 		{
@@ -2950,6 +2951,16 @@ namespace bgfx { namespace d3d9
 		{
 			DX_CHECK(s_renderD3D9->m_device->CreateAdditionalSwapChain(&s_renderD3D9->m_params, &m_swapChain) );
 			DX_CHECK(m_swapChain->GetBackBuffer(0, D3DBACKBUFFER_TYPE_MONO, &m_color[0]) );
+			DX_CHECK(s_renderD3D9->m_device->CreateDepthStencilSurface(
+				s_renderD3D9->m_params.BackBufferWidth
+				, s_renderD3D9->m_params.BackBufferHeight
+				, s_renderD3D9->m_params.AutoDepthStencilFormat
+				, s_renderD3D9->m_params.MultiSampleType
+				, s_renderD3D9->m_params.MultiSampleQuality
+				, FALSE
+				, &m_depthStencil
+				, NULL
+				));
 		}
 		else
 		{


### PR DESCRIPTION
If a framebuffer is created before bgfx::reset is handled, d3d9 device is not reset correctly and application crashes. 

Code to reproduce the crash:
```cpp
int _main_(int /*_argc*/, char** /*_argv*/)
{
	HINSTANCE instance = (HINSTANCE)GetModuleHandle(NULL);

	WNDCLASSEX wnd;
	memset(&wnd, 0, sizeof(wnd));
	wnd.cbSize = sizeof(wnd);
	wnd.style = CS_HREDRAW | CS_VREDRAW;
	wnd.lpfnWndProc = DefWindowProc;
	wnd.hInstance = instance;
	wnd.hIcon = nullptr;
	wnd.hCursor = nullptr;
	wnd.lpszClassName = "bgfxa";
	wnd.hIconSm = nullptr;
	RegisterClassExA(&wnd);

	bgfx::init();
	bgfx::reset(500, 500);

	auto whandle = CreateWindowA("bgfxa"
		, "BGFXa"
		, WS_OVERLAPPEDWINDOW | WS_VISIBLE
		, 0
		, 0
		, 400
		, 400
		, NULL
		, NULL
		, instance
		, 0
		);

	bgfx::createFrameBuffer(whandle, 400, 400);

	bgfx::frame();
	bgfx::frame();

	return 0;
}
```