### PR TITLE
Fix crash on some OpenGLES devices

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1451,7 +1451,21 @@ namespace bgfx { namespace gl
 					setTextureFormat(TextureFormat::BGRA8, GL_RGBA, GL_BGRA, GL_UNSIGNED_BYTE);
 				}
 			}
+			
+#ifdef BGFX_CONFIG_RENDERER_OPENGLES
+			// on some older devices attempting glTexImage2D or glCompressedTexImage2D with unsupported compressed formats can crash
+			// so disable the format by setting to GL_ZERO
+			for (uint32_t ii = 0; ii < TextureFormat::Unknown; ++ii)
+			{
+				if ( !s_textureFormat[ ii ].m_supported )
+				{
+					s_textureFormat[ ii ].m_internalFmt = GL_ZERO;
+					s_textureFormat[ ii ].m_internalFmtSrgb = GL_ZERO;
+				}
+			}
+#endif
 
+			
 			if (BX_ENABLED(BX_PLATFORM_EMSCRIPTEN)
 			||  !isTextureFormatValid(TextureFormat::R8) )
 			{


### PR DESCRIPTION
On some older OpenGLES devices, attempting to bind textures to
unsupported compressed formats can crash. So explicitly disable the
unsupported formats so this never happens.