### PR TITLE
Rgale runtime path

### DIFF
--- a/examples/04-mesh/mesh.cpp
+++ b/examples/04-mesh/mesh.cpp
@@ -32,7 +32,7 @@ int _main_(int /*_argc*/, char** /*_argv*/)
 	// Create program from shaders.
 	bgfx::ProgramHandle program = loadProgram("vs_mesh", "fs_mesh");
 
-	Mesh* mesh = meshLoad("meshes/bunny.bin");
+	Mesh* mesh = meshLoad(COMMON_RUNTIME "meshes/bunny.bin");
 
 	int64_t timeOffset = bx::getHPCounter();
 

--- a/examples/09-hdr/hdr.cpp
+++ b/examples/09-hdr/hdr.cpp
@@ -197,7 +197,7 @@ int _main_(int /*_argc*/, char** /*_argv*/)
 	bgfx::UniformHandle u_tonemap   = bgfx::createUniform("u_tonemap",  bgfx::UniformType::Vec4);
 	bgfx::UniformHandle u_offset    = bgfx::createUniform("u_offset",   bgfx::UniformType::Vec4, 16);
 
-	Mesh* mesh = meshLoad("meshes/bunny.bin");
+	Mesh* mesh = meshLoad(COMMON_RUNTIME "meshes/bunny.bin");
 
 	bgfx::FrameBufferHandle fbh;
 	bgfx::TextureHandle fbtextures[] =

--- a/examples/10-font/font.cpp
+++ b/examples/10-font/font.cpp
@@ -75,13 +75,13 @@ int _main_(int /*_argc*/, char** /*_argv*/)
 	// Load some TTF files.
 	const char* fontFilePath[7] =
 	{
-		"font/droidsans.ttf",
-		"font/chp-fire.ttf",
-		"font/bleeding_cowboys.ttf",
-		"font/mias_scribblings.ttf",
-		"font/ruritania.ttf",
-		"font/signika-regular.ttf",
-		"font/five_minutes.otf",
+		COMMON_RUNTIME "font/droidsans.ttf",
+		COMMON_RUNTIME "font/chp-fire.ttf",
+		COMMON_RUNTIME "font/bleeding_cowboys.ttf",
+		COMMON_RUNTIME "font/mias_scribblings.ttf",
+		COMMON_RUNTIME "font/ruritania.ttf",
+		COMMON_RUNTIME "font/signika-regular.ttf",
+		COMMON_RUNTIME "font/five_minutes.otf",
 	};
 
 	const uint32_t numFonts = BX_COUNTOF(fontFilePath);
@@ -103,13 +103,13 @@ int _main_(int /*_argc*/, char** /*_argv*/)
 		fontManager->destroyTtf(fontFiles[ii]);
 	}
 
-	TrueTypeHandle fontAwesomeTtf = loadTtf(fontManager, "font/fontawesome-webfont.ttf");
+	TrueTypeHandle fontAwesomeTtf = loadTtf(fontManager, COMMON_RUNTIME "font/fontawesome-webfont.ttf");
 
 	// This font doesn't have any preloaded glyph's but the truetype file
 	// is loaded so glyph will be generated as needed.
 	FontHandle fontAwesome72 = fontManager->createFontByPixelSize(fontAwesomeTtf, 0, 72);
 
-	TrueTypeHandle visitorTtf = loadTtf(fontManager, "font/visitor1.ttf");
+	TrueTypeHandle visitorTtf = loadTtf(fontManager, COMMON_RUNTIME "font/visitor1.ttf");
 
 	// This font doesn't have any preloaded glyph's but the truetype file
 	// is loaded so glyph will be generated as needed.

--- a/examples/12-lod/lod.cpp
+++ b/examples/12-lod/lod.cpp
@@ -71,16 +71,16 @@ int _main_(int /*_argc*/, char** /*_argv*/)
 
 	Mesh* meshTop[3] =
 	{
-		meshLoad("meshes/tree1b_lod0_1.bin"),
-		meshLoad("meshes/tree1b_lod1_1.bin"),
-		meshLoad("meshes/tree1b_lod2_1.bin"),
+		meshLoad(COMMON_RUNTIME "meshes/tree1b_lod0_1.bin"),
+		meshLoad(COMMON_RUNTIME "meshes/tree1b_lod1_1.bin"),
+		meshLoad(COMMON_RUNTIME "meshes/tree1b_lod2_1.bin"),
 	};
 
 	Mesh* meshTrunk[3] =
 	{
-		meshLoad("meshes/tree1b_lod0_2.bin"),
-		meshLoad("meshes/tree1b_lod1_2.bin"),
-		meshLoad("meshes/tree1b_lod2_2.bin"),
+		meshLoad(COMMON_RUNTIME "meshes/tree1b_lod0_2.bin"),
+		meshLoad(COMMON_RUNTIME "meshes/tree1b_lod1_2.bin"),
+		meshLoad(COMMON_RUNTIME "meshes/tree1b_lod2_2.bin"),
 	};
 
 	// Imgui.

--- a/examples/15-shadowmaps-simple/shadowmaps_simple.cpp
+++ b/examples/15-shadowmaps-simple/shadowmaps_simple.cpp
@@ -98,9 +98,9 @@ int _main_(int /*_argc*/, char** /*_argv*/)
 		.end();
 
 	// Meshes.
-	Mesh* bunny      = meshLoad("meshes/bunny.bin");
-	Mesh* cube       = meshLoad("meshes/cube.bin");
-	Mesh* hollowcube = meshLoad("meshes/hollowcube.bin");
+	Mesh* bunny      = meshLoad(COMMON_RUNTIME  "meshes/bunny.bin");
+	Mesh* cube       = meshLoad(COMMON_RUNTIME  "meshes/cube.bin");
+	Mesh* hollowcube = meshLoad(COMMON_RUNTIME  "meshes/hollowcube.bin");
 
 	bgfx::VertexBufferHandle vbh = bgfx::createVertexBuffer(
 			  bgfx::makeRef(s_hplaneVertices, sizeof(s_hplaneVertices) )

--- a/examples/18-ibl/ibl.cpp
+++ b/examples/18-ibl/ibl.cpp
@@ -262,7 +262,7 @@ int _main_(int /*_argc*/, char** /*_argv*/)
 	bgfx::ProgramHandle programSky   = loadProgram("vs_ibl_skybox", "fs_ibl_skybox");
 
 	Mesh* meshBunny;
-	meshBunny = meshLoad("meshes/bunny.bin");
+	meshBunny = meshLoad(COMMON_RUNTIME "meshes/bunny.bin");
 
 	struct Settings
 	{

--- a/examples/common/bgfx_utils.cpp
+++ b/examples/common/bgfx_utils.cpp
@@ -91,25 +91,25 @@ static bgfx::ShaderHandle loadShader(bx::FileReaderI* _reader, const char* _name
 {
 	char filePath[512];
 
-	const char* shaderPath = "shaders/dx9/";
+	const char* shaderPath = COMMON_RUNTIME "shaders/dx9/";
 
 	switch (bgfx::getRendererType() )
 	{
 	case bgfx::RendererType::Direct3D11:
 	case bgfx::RendererType::Direct3D12:
-		shaderPath = "shaders/dx11/";
+		shaderPath = COMMON_RUNTIME "shaders/dx11/";
 		break;
 
 	case bgfx::RendererType::OpenGL:
-		shaderPath = "shaders/glsl/";
+		shaderPath = COMMON_RUNTIME "shaders/glsl/";
 		break;
 
 	case bgfx::RendererType::Metal:
-		shaderPath = "shaders/metal/";
+		shaderPath = COMMON_RUNTIME "shaders/metal/";
 		break;
 			
 	case bgfx::RendererType::OpenGLES:
-		shaderPath = "shaders/gles/";
+		shaderPath = COMMON_RUNTIME "shaders/gles/";
 		break;
 
 	default:
@@ -153,7 +153,7 @@ bgfx::TextureHandle loadTexture(bx::FileReaderI* _reader, const char* _name, uin
 	char filePath[512] = { '\0' };
 	if (NULL == strchr(_name, '/') )
 	{
-		strcpy(filePath, "textures/");
+		strcpy(filePath, COMMON_RUNTIME "textures/");
 	}
 
 	strcat(filePath, _name);

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -11,4 +11,12 @@
 
 #include "entry/entry.h"
 
+#ifndef COMMON_RUNTIME
+#	if BX_PLATFORM_EMSCRIPTEN
+#		define COMMON_RUNTIME "/examples/runtime/"
+#	else
+#		define COMMON_RUNTIME ""
+#	endif
+#endif
+
 #endif // COMMON_H_HEADER_GUARD


### PR DESCRIPTION
For example only, when paired with https://github.com/bkaradzic/bx/pull/67 this adds a prefix to the asset path and allows most examples to run.

Examples with problems are:

3)

../../../src/bgfx.cpp (57): BGFX 0x00000002: Failed to compile shader.

7)

../../../src/bgfx.cpp(25): ALLOC 0x5a96550 of 36 byte(s) example-07-callbackDebug.bc.html:1233:13
../../../src/bgfx.cpp(25): ALLOC 0x5a96578 of 36 byte(s) example-07-callbackDebug.bc.html:1233:13
../../../src/bgfx.cpp(25): ALLOC 0x5a965a0 of 36 byte(s)
Warning unresponsive script

10)

../../../src/bgfx.cpp (57): BGFX 0x06965320: ؐ

11)

../../../src/bgfx.cpp (57): BGFX 0x00000002: Failed to compile shader.

12)

Warning unresponsive script, click continue and works

13)

../../../src/bgfx_p.h (3083): BGFX Creating uniform (handle  20) u_texColor example-13-stencilDebug.bc.html:1233:13
13 example-13-stencilDebug.bc.html:1233:13
13

14)

Cannot enlarge memory arrays. Either (1) compile with -s TOTAL_MEMORY=X with X higher than the current value 268435456

16)

../../../src/bgfx_p.h (3083): BGFX Creating uniform (handle  42) u_shadowMap3 example-16-shadowmapsDebug.bc.html:1233:13
13

