### PR TITLE
Adds suspend event mapped to application lifecycle

### DIFF
--- a/examples/common/entry/entry.cpp
+++ b/examples/common/entry/entry.cpp
@@ -464,7 +464,10 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 				case Event::Window:
 					break;
 
-				default:
+                case Event::Suspend:
+                    break;
+
+                    default:
 					break;
 				}
 			}

--- a/examples/common/entry/entry.h
+++ b/examples/common/entry/entry.h
@@ -62,7 +62,8 @@ namespace entry
 	};
 
 	struct Modifier
-	{		enum Enum
+	{
+		enum Enum
 		{
 			None       = 0,
 			LeftAlt    = 0x01,
@@ -182,6 +183,19 @@ namespace entry
 			GamepadBack,
 			GamepadStart,
 			GamepadGuide,
+
+			Count
+		};
+	};
+
+	struct Suspend
+	{
+		enum Enum
+		{
+			WillSuspend,
+			DidSuspend,
+			WillResume,
+			DidResume,
 
 			Count
 		};

--- a/examples/common/entry/entry_android.cpp
+++ b/examples/common/entry/entry_android.cpp
@@ -181,14 +181,22 @@ namespace entry
 					break;
 
 				case APP_CMD_GAINED_FOCUS:
+				{
 					// Command from main thread: the app's activity window has gained
 					// input focus.
+					WindowHandle defaultWindow = { 0 };
+					m_eventQueue.postSuspendEvent(defaultWindow, Suspend::WillResume);
 					break;
+				}
 
 				case APP_CMD_LOST_FOCUS:
+				{
 					// Command from main thread: the app's activity window has lost
 					// input focus.
+					WindowHandle defaultWindow = { 0 };
+					m_eventQueue.postSuspendEvent(defaultWindow, Suspend::WillSuspend);
 					break;
+				}
 
 				case APP_CMD_CONFIG_CHANGED:
 					// Command from main thread: the current device configuration has changed.
@@ -204,8 +212,12 @@ namespace entry
 					break;
 
 				case APP_CMD_RESUME:
+				{
 					// Command from main thread: the app's activity has been resumed.
+					WindowHandle defaultWindow = { 0 };
+					m_eventQueue.postSuspendEvent(defaultWindow, Suspend::DidResume);
 					break;
+				}
 
 				case APP_CMD_SAVE_STATE:
 					// Command from main thread: the app should generate a new saved state
@@ -216,8 +228,12 @@ namespace entry
 					break;
 
 				case APP_CMD_PAUSE:
+				{
 					// Command from main thread: the app's activity has been paused.
+					WindowHandle defaultWindow = { 0 };
+					m_eventQueue.postSuspendEvent(defaultWindow, Suspend::DidSuspend);
 					break;
+				}
 
 				case APP_CMD_STOP:
 					// Command from main thread: the app's activity has been stopped.

--- a/examples/common/entry/entry_ios.mm
+++ b/examples/common/entry/entry_ios.mm
@@ -323,22 +323,26 @@ static	void* m_device = NULL;
 - (void)applicationWillResignActive:(UIApplication *)application
 {
 	BX_UNUSED(application);
+	s_ctx->m_eventQueue.postSuspendEvent(s_defaultWindow, Suspend::WillSuspend);
 	[m_view stop];
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application
 {
 	BX_UNUSED(application);
+	s_ctx->m_eventQueue.postSuspendEvent(s_defaultWindow, Suspend::DidSuspend);
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application
 {
 	BX_UNUSED(application);
+	s_ctx->m_eventQueue.postSuspendEvent(s_defaultWindow, Suspend::WillResume);
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
 	BX_UNUSED(application);
+	s_ctx->m_eventQueue.postSuspendEvent(s_defaultWindow, Suspend::DidResume);
 	[m_view start];
 }
 

--- a/examples/common/entry/entry_osx.mm
+++ b/examples/common/entry/entry_osx.mm
@@ -39,6 +39,8 @@
 - (void)windowWillClose:(NSNotification*)notification;
 - (BOOL)windowShouldClose:(NSWindow*)window;
 - (void)windowDidResize:(NSNotification*)notification;
+- (void)windowDidBecomeKey:(NSNotification *)notification;
+- (void)windowDidResignKey:(NSNotification *)notification;
 
 @end
 
@@ -384,6 +386,18 @@ namespace entry
 			m_eventQueue.postMouseEvent(s_defaultWindow, m_mx, m_my, m_scroll, MouseButton::Right, false);
 		}
 
+		void windowDidBecomeKey()
+		{
+            m_eventQueue.postSuspendEvent(s_defaultWindow, Suspend::WillResume);
+			m_eventQueue.postSuspendEvent(s_defaultWindow, Suspend::DidResume);
+		}
+
+		void windowDidResignKey()
+		{
+            m_eventQueue.postSuspendEvent(s_defaultWindow, Suspend::WillSuspend);
+			m_eventQueue.postSuspendEvent(s_defaultWindow, Suspend::DidSuspend);
+		}
+
 		int32_t run(int _argc, char** _argv)
 		{
 			[NSApplication sharedApplication];
@@ -721,6 +735,20 @@ namespace entry
 	BX_UNUSED(notification);
 	using namespace entry;
 	s_ctx.windowDidResize();
+}
+
+- (void)windowDidBecomeKey:(NSNotification*)notification
+{
+    BX_UNUSED(notification);
+    using namespace entry;
+    s_ctx.windowDidBecomeKey();
+}
+
+- (void)windowDidResignKey:(NSNotification*)notification
+{
+    BX_UNUSED(notification);
+    using namespace entry;
+    s_ctx.windowDidResignKey();
 }
 
 @end

--- a/examples/common/entry/entry_p.h
+++ b/examples/common/entry/entry_p.h
@@ -75,6 +75,7 @@ namespace entry
 			Mouse,
 			Size,
 			Window,
+			Suspend,
 		};
 
 		Event(Enum _type)
@@ -152,6 +153,13 @@ namespace entry
 		ENTRY_IMPLEMENT_EVENT(WindowEvent, Event::Window);
 
 		void* m_nwh;
+	};
+
+	struct SuspendEvent : public Event
+	{
+		ENTRY_IMPLEMENT_EVENT(SuspendEvent, Event::Suspend);
+
+		Suspend::Enum m_state;
 	};
 
 	const Event* poll();
@@ -245,6 +253,13 @@ namespace entry
 		{
 			WindowEvent* ev = new WindowEvent(_handle);
 			ev->m_nwh = _nwh;
+			m_queue.push(ev);
+		}
+
+		void postSuspendEvent(WindowHandle _handle, Suspend::Enum _state)
+		{
+			SuspendEvent* ev = new SuspendEvent(_handle);
+			ev->m_state = _state;
 			m_queue.push(ev);
 		}
 


### PR DESCRIPTION
Step 1. On Android WillSuspend and WillResume maps to focus and DidSuspend and DidResume maps to onPause and onResume. On OSX WillSuspend and DidSuspend maps to resign key, WillResume and DidResumg maps to make key.