### PR TITLE
[BGFX] Fix for integer vertex attribs (to make GL30+ behavior consistent with DX11 behavior). Also with hack to workaround varying.def.sc limitation

### DIFF
--- a/src/glimports.h
+++ b/src/glimports.h
@@ -200,6 +200,7 @@ typedef void           (GL_APIENTRYP PFNGLVERTEXATTRIB3FPROC) (GLuint index, GLf
 typedef void           (GL_APIENTRYP PFNGLVERTEXATTRIB4FPROC) (GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
 typedef void           (GL_APIENTRYP PFNGLVERTEXATTRIBDIVISORPROC) (GLuint index, GLuint divisor);
 typedef void           (GL_APIENTRYP PFNGLVERTEXATTRIBPOINTERPROC) (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer);
+typedef void           (GL_APIENTRYP PFNGLVERTEXATTRIBIPOINTERPROC) (GLuint index, GLint size, GLenum type, GLsizei stride, const void *pointer);
 typedef void           (GL_APIENTRYP PFNGLVIEWPORTPROC) (GLint x, GLint y, GLsizei width, GLsizei height);
 
 typedef void           (GL_APIENTRYP PFNGLGETTRANSLATEDSHADERSOURCEANGLEPROC)(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *source);
@@ -374,6 +375,7 @@ GL_IMPORT______(false, PFNGLUNIFORMMATRIX4FVPROC,                  glUniformMatr
 GL_IMPORT______(false, PFNGLUSEPROGRAMPROC,                        glUseProgram);
 GL_IMPORT______(true,  PFNGLVERTEXATTRIBDIVISORPROC,               glVertexAttribDivisor);
 GL_IMPORT______(false, PFNGLVERTEXATTRIBPOINTERPROC,               glVertexAttribPointer);
+GL_IMPORT______(false, PFNGLVERTEXATTRIBIPOINTERPROC,              glVertexAttribIPointer);
 GL_IMPORT______(false, PFNGLVERTEXATTRIB1FPROC,                    glVertexAttrib1f);
 GL_IMPORT______(false, PFNGLVERTEXATTRIB2FPROC,                    glVertexAttrib2f);
 GL_IMPORT______(false, PFNGLVERTEXATTRIB3FPROC,                    glVertexAttrib3f);


### PR DESCRIPTION
So, part A) It took me a while to figure this out, but in DX11, unnormalized uint8 vertex streams are never converted to floats, so you have to set up your shader's input semantic to be an integer type to read the data correctly. However, in GL3.0 and above, it *will* convert to floats (which breaks things if you have integer input types in your shader). To get the behavior consistent between the two, I found that you can use glVertexAttribIPointer() instead of glVertexAttribPointer() on unnormalized uint8 attribs, which seems to work out great (tested on windows and OSX using GL4.1).

Note: this also turns out to be nicely backwards combatible with DX9/GL2.1, since shaderc auto-converts ivec3 inputs into vec3 inputs, and uint8's are always converted to floats before the shader. Heh.

Which leads me to part B) As a result of switching my shader inputs to ivec3's, I also ran into an issue with the attrib names being hardcoded for renderer_gl, which means I had to throw in a hack in renderer_gl.cpp to be able to do this in my varying.def.sc:

vec4 a_position : POSITION;
ivec4 i_position : POSITION;

...in order to have some shaders that use uint8 positions and some shaders that use float positions. Not the greatest, but works for me for the time being. You may not want to pull that part of the code. A real solution would be to modify shaderc to bake the used input attrib names into the .bin files and use those strings in ProgramGL::init() instead of the hardcoded s_attribName[] array, but I wanted to run this by you before I spent the time to do that. Plus, would that need to be ported to the metal renderer?

Thoughts?