### PR TITLE
[c99] Remove extra semicolon after typedef.

### DIFF
--- a/include/bgfx.c99.h
+++ b/include/bgfx.c99.h
@@ -184,7 +184,7 @@ typedef enum bgfx_backbuffer_ratio
 } bgfx_backbuffer_ratio_t;
 
 #define BGFX_HANDLE_T(_name) \
-    typedef struct _name { uint16_t idx; } _name##_t;
+    typedef struct _name { uint16_t idx; } _name##_t
 
 BGFX_HANDLE_T(bgfx_indirect_buffer_handle);
 BGFX_HANDLE_T(bgfx_dynamic_index_buffer_handle);


### PR DESCRIPTION
The BGFX_HANDLE_T macro ended with a semicolon and all of the uses
also ended with a semicolon, so there was an extra semicolon in
the resulting code.