### PR TITLE
Allow passing flags to genie via make.

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ endif
 
 # $(info $(OS))
 
-GENIE=../bx/tools/bin/$(OS)/genie
+GENIE=../bx/tools/bin/$(OS)/genie $(GENIE_FLAGS)
 
 all:
 	$(GENIE) --with-tools --with-shared-lib vs2008


### PR DESCRIPTION
This allows passing flags to genie via the makefile:

    make osx GENIE_FLAGS=--with-glfw