### PR TITLE
Textures created with BackbufferRatio::enum are not sized correctly

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2674,8 +2674,8 @@ again:
 
 		if (BackbufferRatio::Count != _ratio)
 		{
-			_width  = uint16_t(s_ctx->m_frame->m_resolution.m_width);
-			_height = uint16_t(s_ctx->m_frame->m_resolution.m_height);
+			_width  = uint16_t(s_ctx->m_resolution.m_width);
+			_height = uint16_t(s_ctx->m_resolution.m_height);
 			getTextureSizeFromRatio(_ratio, _width, _height);
 		}
 


### PR DESCRIPTION
Inconsistency:
> "bgfx::reset" uses "context->m_resolution" to resize textures.
> "bgfx::createTexture2d" uses "context->frame[0]->m_resolution".

The problem appears when the first "bgfx::reset" is done with a resolution different than 1280x720px, and a texture2d is created consecutively using "bgfx::createTexture2d(bgfx::BackbufferRatio::Enum,...)".

Bug not detected by HDR sample because main window size is setted to 1280x720.