### PR TITLE
Added invalidation of renderpipeline state cache. In case the program…

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -1453,6 +1453,8 @@ namespace bgfx { namespace mtl
 
 		m_processedUniforms = false;
 		m_numPredefined = 0;
+
+		m_renderPipelineStateCache.invalidate();
 	}
 
 	UniformType::Enum convertMtlType(MTLDataType _type)


### PR DESCRIPTION
… object gets re-used the cache can return invalid instances of the descriptor.

This will crash when live reloading shaders that haven't changed and the renderpipeline descriptor cache will still match and return the old version.
Clearing the cache when deleting the program seemed to make sense and fixes it.