### PR TITLE
Extended Remotery profiling.

### DIFF
--- a/examples/common/entry/entry.cpp
+++ b/examples/common/entry/entry.cpp
@@ -4,12 +4,6 @@
  */
 
 #include <bx/bx.h>
-#if BX_PLATFORM_WINDOWS
-// BK - Remotery needs WinSock, but on VS2015/Win10 build
-//      fails if WinSock2 is included after Windows.h?!
-#	include <WinSock2.h>
-#endif // BX_PLATFORM_WINDOWS
-
 #include <bgfx/bgfx.h>
 #include <bx/string.h>
 #include <bx/readerwriter.h>
@@ -25,7 +19,7 @@
 #include "input.h"
 
 #define RMT_ENABLED ENTRY_CONFIG_PROFILER
-#include <remotery/lib/Remotery.c>
+#include <remotery/lib/Remotery.h>
 
 extern "C" int _main_(int _argc, char** _argv);
 

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -94,6 +94,7 @@ if _OPTIONS["with-profiler"] then
 	defines {
 		"ENTRY_CONFIG_PROFILER=1",
 		"BGFX_CONFIG_PROFILER_REMOTERY=1",
+        "_WINSOCKAPI_"
 	}
 end
 

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -5,6 +5,12 @@
 
 #include "bgfx_p.h"
 
+#if BGFX_CONFIG_PROFILER_REMOTERY
+#	define RMT_USE_D3D11 BGFX_CONFIG_RENDERER_DIRECT3D11
+#	define RMT_USE_OPENGL 0
+#	include <remotery/lib/Remotery.c>
+#endif
+
 namespace bgfx
 {
 #define BGFX_MAIN_THREAD_MAGIC UINT32_C(0x78666762)

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -53,14 +53,24 @@
 #	if BGFX_CONFIG_PROFILER_MICROPROFILE
 #		include <microprofile.h>
 #		define BGFX_PROFILER_SCOPE(_group, _name, _color) MICROPROFILE_SCOPEI(#_group, #_name, _color)
+#		define BGFX_PROFILER_BEGIN(_group, _name, _color) BX_NOOP()
+#		define BGFX_PROFILER_BEGIN_DYNAMIC(_namestr) BX_NOOP()
+#		define BGFX_PROFILER_END() BX_NOOP()
 #		define BGFX_PROFILER_SET_CURRENT_THREAD_NAME(_name) BX_NOOP()
 #	elif BGFX_CONFIG_PROFILER_REMOTERY
 #		define RMT_ENABLED BGFX_CONFIG_PROFILER_REMOTERY
+#		define RMT_USE_D3D11 BGFX_CONFIG_RENDERER_DIRECT3D11
 #		include <remotery/lib/Remotery.h>
 #		define BGFX_PROFILER_SCOPE(_group, _name, _color) rmt_ScopedCPUSample(_group##_##_name)
+#		define BGFX_PROFILER_BEGIN(_group, _name, _color) rmt_BeginCPUSample(_group##_##_name)
+#		define BGFX_PROFILER_BEGIN_DYNAMIC(_namestr) rmt_BeginCPUSampleDynamic(_namestr)
+#		define BGFX_PROFILER_END() rmt_EndCPUSample()
 #		define BGFX_PROFILER_SET_CURRENT_THREAD_NAME(_name) rmt_SetCurrentThreadName(_name)
 #	else
 #		define BGFX_PROFILER_SCOPE(_group, _name, _color) BX_NOOP()
+#		define BGFX_PROFILER_BEGIN(_group, _name, _color) BX_NOOP()
+#		define BGFX_PROFILER_BEGIN_DYNAMIC(_namestr) BX_NOOP()
+#		define BGFX_PROFILER_END() BX_NOOP()
 #		define BGFX_PROFILER_SET_CURRENT_THREAD_NAME(_name) BX_NOOP()
 #	endif // BGFX_CONFIG_PROFILER_*
 #endif // BGFX_PROFILER_SCOPE

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -11,6 +11,7 @@
 namespace bgfx { namespace d3d9
 {
 	static wchar_t s_viewNameW[BGFX_CONFIG_MAX_VIEWS][BGFX_CONFIG_MAX_VIEW_NAME];
+	static char s_viewName[BGFX_CONFIG_MAX_VIEWS][BGFX_CONFIG_MAX_VIEW_NAME];
 
 	struct PrimInfo
 	{
@@ -732,9 +733,8 @@ namespace bgfx { namespace d3d9
 			// Init reserved part of view name.
 			for (uint32_t ii = 0; ii < BGFX_CONFIG_MAX_VIEWS; ++ii)
 			{
-				char name[BGFX_CONFIG_MAX_VIEW_NAME_RESERVED+1];
-				bx::snprintf(name, sizeof(name), "%3d   ", ii);
-				mbstowcs(s_viewNameW[ii], name, BGFX_CONFIG_MAX_VIEW_NAME_RESERVED);
+				bx::snprintf(s_viewName[ii], BGFX_CONFIG_MAX_VIEW_NAME_RESERVED + 1, "%3d   ", ii);
+				mbstowcs(s_viewNameW[ii], s_viewName[ii], BGFX_CONFIG_MAX_VIEW_NAME_RESERVED);
 			}
 
 			if (NULL != m_deviceEx)
@@ -1106,6 +1106,11 @@ namespace bgfx { namespace d3d9
 					, BX_COUNTOF(s_viewNameW[0])-BGFX_CONFIG_MAX_VIEW_NAME_RESERVED
 					);
 			}
+
+			bx::strlcpy(&s_viewName[_id][BGFX_CONFIG_MAX_VIEW_NAME_RESERVED]
+				, _name
+				, BX_COUNTOF(s_viewName[0]) - BGFX_CONFIG_MAX_VIEW_NAME_RESERVED
+				);
 		}
 
 		void updateUniform(uint16_t _loc, const void* _data, uint32_t _size) BX_OVERRIDE
@@ -3564,6 +3569,11 @@ namespace bgfx { namespace d3d9
 
 					PIX_ENDEVENT();
 					PIX_BEGINEVENT(D3DCOLOR_RGBA(0xff, 0x00, 0x00, 0xff), s_viewNameW[key.m_view]);
+					if (item > 0)
+					{
+						BGFX_PROFILER_END();
+					}
+					BGFX_PROFILER_BEGIN_DYNAMIC(s_viewName[key.m_view]);
 
 					view = key.m_view;
 					programIdx = invalidHandle;
@@ -4077,6 +4087,8 @@ namespace bgfx { namespace d3d9
 				captureElapsed = -bx::getHPCounter();
 				capture();
 				captureElapsed += bx::getHPCounter();
+
+				BGFX_PROFILER_END();
 			}
 		}
 


### PR DESCRIPTION
Can't seem to get the OpenGL GPU profiling to compile due to unresolved external symbols. Not sure how you'd want that solved in the grand scheme of things (suggested: using namespace bgfx; didn't work).

You'll need to update Remotery before these changes will work.