### PR TITLE
Fix blit for depth textures.

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4901,7 +4901,7 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 								, 0
 								, src.m_ptr
 								, srcZ*src.m_numMips+blit.m_srcMip
-								, &box
+								, isDepth((TextureFormat::Enum)src.m_textureFormat) ? NULL : &box
 								);
 						}
 					}

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -3649,9 +3649,9 @@ namespace bgfx { namespace d3d9
 						// GetRenderTargetData (dst must be SYSTEMMEM)
 
 						HRESULT hr = m_device->StretchRect(srcSurface
-							, &srcRect
+							, isDepth((TextureFormat::Enum)src.m_textureFormat) ? NULL : &srcRect
 							, dstSurface
-							, &dstRect
+							, isDepth((TextureFormat::Enum)src.m_textureFormat) ? NULL : &dstRect
 							, D3DTEXF_NONE
 							);
 						if (FAILED(hr) )


### PR DESCRIPTION
SrcRect and DstRect need to be NULL in DX9/DX11 when performing a copy from depth texture to depth texture.