### PR TITLE
Fix crash in D3D9 shadowmap examples.

### DIFF
--- a/examples/15-shadowmaps-simple/shadowmaps_simple.cpp
+++ b/examples/15-shadowmaps-simple/shadowmaps_simple.cpp
@@ -133,7 +133,7 @@ int _main_(int _argc, char** _argv)
 		progShadow = loadProgram("vs_sms_shadow", "fs_sms_shadow");
 		progMesh   = loadProgram("vs_sms_mesh",   "fs_sms_mesh");
 
-		shadowMapTexture = bgfx::createTexture2D(shadowMapSize, shadowMapSize, 1, bgfx::TextureFormat::D16, BGFX_TEXTURE_COMPARE_LEQUAL);
+		shadowMapTexture = bgfx::createTexture2D(shadowMapSize, shadowMapSize, 1, bgfx::TextureFormat::D16, BGFX_TEXTURE_RT | BGFX_TEXTURE_COMPARE_LEQUAL);
 		bgfx::TextureHandle fbtextures[] = { shadowMapTexture };
 		shadowMapFB = bgfx::createFrameBuffer(BX_COUNTOF(fbtextures), fbtextures, true);
 	}

--- a/examples/16-shadowmaps/shadowmaps.cpp
+++ b/examples/16-shadowmaps/shadowmaps.cpp
@@ -1942,7 +1942,7 @@ int _main_(int _argc, char** _argv)
 		bgfx::TextureHandle fbtextures[] =
 		{
 			bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::BGRA8, BGFX_TEXTURE_RT),
-			bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::D24S8),
+			bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::D24S8, BGFX_TEXTURE_RT),
 		};
 		s_rtShadowMap[ii] = bgfx::createFrameBuffer(BX_COUNTOF(fbtextures), fbtextures, true);
 	}
@@ -3096,7 +3096,7 @@ int _main_(int _argc, char** _argv)
 				bgfx::TextureHandle fbtextures[] =
 				{
 					bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::BGRA8, BGFX_TEXTURE_RT),
-					bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::D24S8),
+					bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::D24S8, BGFX_TEXTURE_RT),
 				};
 				s_rtShadowMap[0] = bgfx::createFrameBuffer(BX_COUNTOF(fbtextures), fbtextures, true);
 			}
@@ -3111,7 +3111,7 @@ int _main_(int _argc, char** _argv)
 						bgfx::TextureHandle fbtextures[] =
 						{
 							bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::BGRA8, BGFX_TEXTURE_RT),
-							bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::D24S8),
+							bgfx::createTexture2D(currentShadowMapSize, currentShadowMapSize, 1, bgfx::TextureFormat::D24S8, BGFX_TEXTURE_RT),
 						};
 						s_rtShadowMap[ii] = bgfx::createFrameBuffer(BX_COUNTOF(fbtextures), fbtextures, true);
 					}


### PR DESCRIPTION
Crash log:

    ..\..\..\src\renderer_d3d9.cpp (2838): BGFX Texture   8: BGRA8 (requested: BGRA8), 1024x1024 (render target).
    ..\..\..\src\renderer_d3d9.cpp (2496): BGFX CHECK device->CreateTexture(_width , _height , _numMips , 0 , s_textureFormat[fmt].m_fmt , D3DPOOL_SYSTEMMEM , &m_staging2d , 0 ) FAILED 0x8876086c