### PR TITLE
Fixed texturec build with --with-profiler enabled

### DIFF
--- a/scripts/texturec.lua
+++ b/scripts/texturec.lua
@@ -7,6 +7,10 @@ project "texturec"
 	uuid "838801ee-7bc3-11e1-9f19-eae7d36e7d26"
 	kind "ConsoleApp"
 
+	defines {
+		"ENTRY_CONFIG_PROFILER=0",
+	}
+
 	includedirs {
 		path.join(BX_DIR, "include"),
 		path.join(BGFX_DIR, "include"),


### PR DESCRIPTION
Fixes a build issue with Remotery include paths by forcibly disabling profiling for texturec.