### PR TITLE
Added VK_DECIMAL to keyboard code translation

### DIFF
--- a/examples/common/entry/entry_windows.cpp
+++ b/examples/common/entry/entry_windows.cpp
@@ -368,6 +368,7 @@ namespace entry
 			s_translateKey[VK_OEM_7]      = Key::Quote;
 			s_translateKey[VK_OEM_COMMA]  = Key::Comma;
 			s_translateKey[VK_OEM_PERIOD] = Key::Period;
+			s_translateKey[VK_DECIMAL] 	  = Key::Period;
 			s_translateKey[VK_OEM_2]      = Key::Slash;
 			s_translateKey[VK_OEM_5]      = Key::Backslash;
 			s_translateKey[VK_OEM_3]      = Key::Tilde;


### PR DESCRIPTION
It wasn't possible to use the period on numpad before. Added VK_DECIMAL to translateKey array. This works fine on Windows 8.1