### PR TITLE
fix: when resizing a dynamic vertex buffer, update numVertices

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2509,6 +2509,7 @@ namespace bgfx
 				dvb.m_handle.idx  = uint16_t(ptr>>32);
 				dvb.m_offset      = uint32_t(ptr);
 				dvb.m_size        = _mem->size;
+                dvb.m_numVertices = dvb.m_size / dvb.m_stride;
 				dvb.m_startVertex = bx::strideAlign(dvb.m_offset, dvb.m_stride)/dvb.m_stride;
 			}
 


### PR DESCRIPTION
Had a problem when expanding a dynamic vertex buffer. This change seems to fix it.