### PR TITLE
Modified imguiBool to return 'changed' state

### DIFF
--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -3415,12 +3415,14 @@ bool imguiCheck(const char* _text, bool _checked, bool _enabled)
 	return s_imgui.check(_text, _checked, _enabled);
 }
 
-void imguiBool(const char* _text, bool& _flag, bool _enabled)
+bool imguiBool(const char* _text, bool& _flag, bool _enabled)
 {
-	if (imguiCheck(_text, _flag, _enabled) )
+    bool result = imguiCheck(_text, _flag, _enabled);
+	if (result)
 	{
 		_flag = !_flag;
 	}
+    return result;
 }
 
 bool imguiCollapse(const char* _text, const char* _subtext, bool _checked, bool _enabled)

--- a/examples/common/imgui/imgui.h
+++ b/examples/common/imgui/imgui.h
@@ -173,7 +173,7 @@ void imguiSetCurrentScissor(); // Call before drawing custom widgets over imgui 
 bool imguiButton(const char* _text, bool _enabled = true, ImguiAlign::Enum _align = ImguiAlign::LeftIndented, uint32_t _rgb0 = IMGUI_BUTTON_RGB0, int32_t _r = IMGUI_BUTTON_R);
 bool imguiItem(const char* _text, bool _enabled = true);
 bool imguiCheck(const char* _text, bool _checked, bool _enabled = true);
-void imguiBool(const char* _text, bool& _flag, bool _enabled = true);
+bool imguiBool(const char* _text, bool& _flag, bool _enabled = true);
 bool imguiCollapse(const char* _text, const char* _subtext, bool _checked, bool _enabled = true);
 void imguiLabel(const char* _format, ...);
 void imguiLabel(uint32_t _rgba, const char* _format, ...);


### PR DESCRIPTION
This is useful for logically or-ing the state of several UI elements together to know if any have changed (e.g. because some common action needs to be taken):
uiChanged |= imguiBool(...)
uiChanged |= imguiSlider(...)
...