### PR TITLE
Fix for assert in VS2015 debug builds (and likely others too). ( Expr…

### DIFF
--- a/3rdparty/forsyth-too/forsythtriangleorderoptimizer.cpp
+++ b/3rdparty/forsyth-too/forsythtriangleorderoptimizer.cpp
@@ -293,7 +293,7 @@ namespace Forsyth
 
                 assert(vertexData.activeFaceListSize > 0);
                 uint* begin = &activeFaceList[vertexData.activeFaceListStart];
-                uint* end = &activeFaceList[vertexData.activeFaceListStart + vertexData.activeFaceListSize];
+				uint* end = &(activeFaceList[vertexData.activeFaceListStart + vertexData.activeFaceListSize - 1]) + 1;
                 uint* it = std::find(begin, end, bestFace);
                 assert(it != end);
                 std::swap(*it, *(end-1));


### PR DESCRIPTION
…ession: vector subscript out of range )

I should say that I have only tested this fix by running the geometry compiler on a very simple model: a cube I exported from Blender. I have not tried to load and display the model because I haven't gotten that far with the rendering yet. Still, this seems to be a safe, simple, and worthwhile fix imho. It's nice to be able to run the compiler in debug mode from start to finish.