### PR TITLE
Customizable genie and bx paths

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ endif
 
 # $(info $(OS))
 
-GENIE=../bx/tools/bin/$(OS)/genie $(GENIE_FLAGS)
+GENIE ?= ../bx/tools/bin/$(OS)/genie $(GENIE_FLAGS)
 
 all:
 	$(GENIE) --with-tools --with-shared-lib vs2008

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -68,7 +68,10 @@ solution "bgfx"
 BGFX_DIR = path.getabsolute("..")
 local BGFX_BUILD_DIR = path.join(BGFX_DIR, ".build")
 local BGFX_THIRD_PARTY_DIR = path.join(BGFX_DIR, "3rdparty")
-BX_DIR = path.getabsolute(path.join(BGFX_DIR, "../bx"))
+BX_DIR = os.getenv("BX_DIR")
+if BX_DIR == "" then
+  BX_DIR = path.getabsolute(path.join(BGFX_DIR, "../bx"))
+end
 
 if not os.isdir(BX_DIR) then
 	print("bx not found at " .. BX_DIR)


### PR DESCRIPTION
This makes it easier for package managers to locate the required dependencies. With these changes I was able to package bgfx for nixos without needing to monkeypatch.