### PR TITLE
Configurable genie, bx location

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ endif
 
 # $(info $(OS))
 
-GENIE=../bx/tools/bin/$(OS)/genie $(GENIE_FLAGS)
+GENIE ?= ../bx/tools/bin/$(OS)/genie $(GENIE_FLAGS)
 
 all:
 	$(GENIE) --with-tools --with-shared-lib vs2008

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -66,9 +66,13 @@ solution "bgfx"
 	startproject "example-00-helloworld"
 
 BGFX_DIR = path.getabsolute("..")
+BX_DIR = os.getenv("BX_DIR")
+
 local BGFX_BUILD_DIR = path.join(BGFX_DIR, ".build")
 local BGFX_THIRD_PARTY_DIR = path.join(BGFX_DIR, "3rdparty")
-BX_DIR = path.getabsolute(path.join(BGFX_DIR, "../bx"))
+if not BX_DIR then
+  BX_DIR = path.getabsolute(path.join(BGFX_DIR, "../bx"))
+end
 
 if not os.isdir(BX_DIR) then
 	print("bx not found at " .. BX_DIR)


### PR DESCRIPTION
This makes it easier for package managers to locate the required dependencies. With these changes I was able to package bgfx for nixos without needing to monkeypatch.