### PR TITLE
Fixed swapped R and B in D3D11 and OpenGL video capture

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -3081,6 +3081,13 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 				D3D11_MAPPED_SUBRESOURCE mapped;
 				DX_CHECK(m_deviceCtx->Map(m_captureTexture, 0, D3D11_MAP_READ, 0, &mapped) );
 
+				imageSwizzleBgra8(getBufferWidth()
+					, getBufferHeight()
+					, mapped.RowPitch
+					, mapped.pData
+					, mapped.pData
+					);
+
 				g_callback->captureFrame(mapped.pData, getBufferHeight()*mapped.RowPitch);
 
 				m_deviceCtx->Unmap(m_captureTexture, 0);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2899,6 +2899,11 @@ namespace bgfx { namespace gl
 					, m_capture
 					) );
 
+				if (GL_RGBA == m_readPixelsFmt)
+				{
+					imageSwizzleBgra8(m_resolution.m_width, m_resolution.m_height, m_resolution.m_width*4, m_capture, m_capture);
+				}
+
 				g_callback->captureFrame(m_capture, m_captureSize);
 			}
 		}


### PR DESCRIPTION
Added missing swizzle for RGBA to BGRA (copied from saveScreenShot).

I'm not able to test D3D12, but D3D9 seems fine.