### PR TITLE
Fixed glcpp .gitignore

### DIFF
--- a/3rdparty/glsl-optimizer/src/glsl/glcpp/.gitignore
+++ b/3rdparty/glsl-optimizer/src/glsl/glcpp/.gitignore
@@ -1,7 +1,5 @@
 glcpp
 glcpp-parse.output
-glcpp-parse.c
-glcpp-parse.h
 
 *.o
 *.lo


### PR DESCRIPTION
Especially annoying when you clone bgfx and `git add` it to your repo. :)