### PR TITLE
Fixed backwards error check in geometryc.

### DIFF
--- a/tools/geometryc/geometryc.cpp
+++ b/tools/geometryc/geometryc.cpp
@@ -811,7 +811,7 @@ int main(int _argc, const char* _argv[])
 	PrimitiveArray primitives;
 
 	bx::CrtFileWriter writer;
-	if (bx::open(&writer, outFilePath) )
+	if (!bx::open(&writer, outFilePath) )
 	{
 		printf("Unable to open output file '%s'.", outFilePath);
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
It seems like bx::open() returns true on success, so there should be a negation in this error check.