### PR TITLE
Fixing android-mips build

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -2211,9 +2211,9 @@ namespace bgfx
 		}
 	}
 
-	const Memory* imageAlloc(ImageContainer& _imageContainer, TextureFormat::Enum _format, uint16_t _width, uint16_t _height, uint16_t _depth, bool _cubeMap, bool _numMips)
+	const Memory* imageAlloc(ImageContainer& _imageContainer, TextureFormat::Enum _format, uint16_t _width, uint16_t _height, uint16_t _depth, bool _cubeMap, bool _generateMips)
 	{
-		const uint8_t numMips = _numMips ? imageGetNumMips(_format, _width, _height) : 1;
+		const uint8_t numMips = _generateMips ? imageGetNumMips(_format, _width, _height) : 1;
 		uint32_t size = imageGetSize(_format, _width, _height, 0, false, numMips);
 		const Memory* image = alloc(size);
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -2211,9 +2211,9 @@ namespace bgfx
 		}
 	}
 
-	const Memory* imageAlloc(ImageContainer& _imageContainer, TextureFormat::Enum _format, uint16_t _width, uint16_t _height, uint16_t _depth, bool _cubeMap, bool _mips)
+	const Memory* imageAlloc(ImageContainer& _imageContainer, TextureFormat::Enum _format, uint16_t _width, uint16_t _height, uint16_t _depth, bool _cubeMap, bool _numMips)
 	{
-		const uint8_t numMips = _mips ? imageGetNumMips(_format, _width, _height) : 1;
+		const uint8_t numMips = _numMips ? imageGetNumMips(_format, _width, _height) : 1;
 		uint32_t size = imageGetSize(_format, _width, _height, 0, false, numMips);
 		const Memory* image = alloc(size);
 

--- a/src/image.h
+++ b/src/image.h
@@ -121,7 +121,7 @@ namespace bgfx
 	bool imageConvert(void* _dst, TextureFormat::Enum _dstFormat, const void* _src, TextureFormat::Enum _srcFormat, uint32_t _width, uint32_t _height);
 
 	///
-	const Memory* imageAlloc(ImageContainer& _imageContainer, TextureFormat::Enum _format, uint16_t _width, uint16_t _height, uint16_t _depth = 0, bool _cubeMap = false, bool _numMips = false);
+	const Memory* imageAlloc(ImageContainer& _imageContainer, TextureFormat::Enum _format, uint16_t _width, uint16_t _height, uint16_t _depth = 0, bool _cubeMap = false, bool _generateMips = false);
 
 	///
 	void imageFree(const Memory* _memory);

--- a/src/image.h
+++ b/src/image.h
@@ -121,7 +121,7 @@ namespace bgfx
 	bool imageConvert(void* _dst, TextureFormat::Enum _dstFormat, const void* _src, TextureFormat::Enum _srcFormat, uint32_t _width, uint32_t _height);
 
 	///
-	const Memory* imageAlloc(ImageContainer& _imageContainer, TextureFormat::Enum _format, uint16_t _width, uint16_t _height, uint16_t _depth = 0, bool _cubeMap = false, bool _mips = false);
+	const Memory* imageAlloc(ImageContainer& _imageContainer, TextureFormat::Enum _format, uint16_t _width, uint16_t _height, uint16_t _depth = 0, bool _cubeMap = false, bool _numMips = false);
 
 	///
 	void imageFree(const Memory* _memory);


### PR DESCRIPTION
'_mips' is a pre-defined macro on android-mips platform, changing function parameter name to '_numMips'