### PR TITLE
Set m_view to 0 in GlContext ctor

### DIFF
--- a/src/glcontext_nsgl.h
+++ b/src/glcontext_nsgl.h
@@ -16,6 +16,7 @@ namespace bgfx { namespace gl
 	{
 		GlContext()
 			: m_context(0)
+			, m_view(0)
 		{
 		}
 


### PR DESCRIPTION
Needed because when the context has already been created (e.g. using GLFW), m_view doesn't get initialized inside create and the code here https://github.com/bkaradzic/bgfx/blob/master/src/glcontext_nsgl.mm#L142 crashes.