### PR TITLE
Document bgfx::touch.

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -2361,7 +2361,14 @@ namespace bgfx
 		, uint32_t _flags = UINT32_MAX
 		);
 
-	/// Touch view.
+	/// Submit an empty primitive for rendering. Uniforms and draw state
+	/// will be applied but no geometry will be submitted.
+	///
+	/// These empty draw calls will sort before ordinary draw calls.
+	///
+	/// @param[in] _id View id.
+	/// @returns Number of draw calls.
+	///
 	uint32_t touch(uint8_t _id);
 
 	/// Submit primitive for rendering.


### PR DESCRIPTION
While researching this I noticed that the “program” part of the sort key is set to 0 for invalid programs (i.e. those used with `touch`), presumably so they sort first. But, 0 is also a valid program ID. So, `touch` calls won't necessarily sort before all other calls if program ID 0 is also used.

It looks like bgfx uses the first 8 program IDs internally so it didn't cause any issues for me. Just thought it might be worth pointing out here in case it's a mistake.