### PR TITLE
Remove commitEye() and fix extra frame of latency in OpenGL as well

### DIFF
--- a/src/hmd_ovr.cpp
+++ b/src/hmd_ovr.cpp
@@ -13,7 +13,6 @@ namespace bgfx
 		: m_hmd(NULL)
 		, m_isenabled(false)
 		, m_mirror(NULL)
-		, m_hmdFrameReady(-1)
 		, m_frameIndex(0)
 		, m_sensorSampleTime(0)
 	{
@@ -125,14 +124,6 @@ namespace bgfx
 		}
 	}
 
-	void OVR::commitEye(uint8_t _eye)
-	{
-		if (m_isenabled)
-		{
-			m_hmdFrameReady = ovr_CommitTextureSwapChain(m_hmd, m_eyeBuffers[_eye]->m_swapTextureChain);
-		}
-	}
-
 	bool OVR::swap(HMD& _hmd, bool originBottomLeft)
 	{
 		_hmd.flags = BGFX_HMD_NONE;
@@ -144,16 +135,15 @@ namespace bgfx
 			_hmd.deviceHeight = m_hmdDesc.Resolution.h;
 		}
 
+		if (!m_isenabled)
+		{
+			return false;
+		}
+
 		// commit eyes to HMD
 		for (int eye = 0; eye < 2; eye++)
 		{
-			commitEye(eye);
-		}
-
-		// check that eyes committed successfully
-		if (!m_isenabled || !OVR_SUCCESS(m_hmdFrameReady))
-		{
-			return false;
+			ovr_CommitTextureSwapChain(m_hmd, m_eyeBuffers[eye]->m_swapTextureChain);
 		}
 
 		_hmd.flags |= BGFX_HMD_RENDERING;

--- a/src/hmd_ovr.h
+++ b/src/hmd_ovr.h
@@ -72,7 +72,6 @@ namespace bgfx
 		void renderEyeStart(uint8_t _eye);
 		bool postReset();
 		void preReset();
-		void commitEye(uint8_t _eye);
 		bool swap(HMD& _hmd, bool originBottomLeft);
 		void recenter();
 		void getEyePose(HMD& _hmd);
@@ -84,7 +83,6 @@ namespace bgfx
 		ovrPosef    m_pose[2];
 		ovrVector3f m_hmdToEyeOffset[2];
 		ovrSizei    m_hmdSize;
-		ovrResult   m_hmdFrameReady;
 		OVRBufferI *m_eyeBuffers[2];
 		OVRMirrorI *m_mirror;
 		long long   m_frameIndex;
@@ -137,10 +135,6 @@ namespace bgfx
 			_viewport->m_y      = 0;
 			_viewport->m_width  = 0;
 			_viewport->m_height = 0;
-		}
-
-		void commitEye(uint8_t /*_eye*/)
-		{
 		}
 
 		void renderEyeStart(uint8_t /*_eye*/)

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5658,8 +5658,6 @@ namespace bgfx { namespace gl
 						if (m_ovr.isEnabled() )
 						{
 							m_ovr.getViewport(eye, &viewState.m_rect);
-							// commit previous eye to HMD and start rendering new frame
-							m_ovr.commitEye(eye);
 							m_ovr.renderEyeStart(eye);
 						}
 						else


### PR DESCRIPTION
OVR::commitEye() is no longer needed since now it's only an internal one-liner. Fix from PR #746 has also been applied to GL renderer, so it's the same everywhere.