### PR TITLE
Api improvement. Calling setUniform() without _num will now use the _…

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -2165,11 +2165,12 @@ namespace bgfx
 	///
 	/// @param[in] _handle Uniform.
 	/// @param[in] _value Pointer to uniform data.
-	/// @param[in] _num Number of elements.
+	/// @param[in] _num Number of elements. Passing `UINT16_MAX` will
+	///   use the _num passed on uniform creation.
 	///
 	/// @attention C99 equivalent is `bgfx_set_uniform`.
 	///
-	void setUniform(UniformHandle _handle, const void* _value, uint16_t _num = 1);
+	void setUniform(UniformHandle _handle, const void* _value, uint16_t _num = UINT16_MAX);
 
 	/// Set index buffer for draw primitive.
 	///

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -3617,7 +3617,7 @@ namespace bgfx
 		{
 			BGFX_CHECK_HANDLE("setUniform", m_uniformHandle, _handle);
 			UniformRef& uniform = m_uniformRef[_handle.idx];
-			BX_CHECK(uniform.m_num >= _num, "Truncated uniform update. %d (max: %d)", _num, uniform.m_num);
+			BX_CHECK(_num == UINT16_MAX || uniform.m_num >= _num, "Truncated uniform update. %d (max: %d)", _num, uniform.m_num);
 			if (BX_ENABLED(BGFX_CONFIG_DEBUG_UNIFORM) )
 			{
 				BX_CHECK(m_uniformSet.end() == m_uniformSet.find(_handle.idx)


### PR DESCRIPTION
…num passed on creation.