### PR TITLE
VertexDecl::m_hash should count m_stride too

### DIFF
--- a/src/vertexdecl.cpp
+++ b/src/vertexdecl.cpp
@@ -107,6 +107,7 @@ namespace bgfx
 		murmur.begin();
 		murmur.add(m_attributes, sizeof(m_attributes) );
 		murmur.add(m_offset, sizeof(m_offset) );
+		murmur.add(m_stride);
 		m_hash = murmur.end();
 	}
 


### PR DESCRIPTION
when m_stride is not part of m_hash then

    decl1.begin()
        .add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float)
    .end();

and:

    decl2.begin()
        .add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float)
        .skip(3 * sizeof(float))
    .end();

are considered as same decls.
