### PR TITLE
Fix a bug where the depth buffer is not written to in the OpenGL renderer

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6198,7 +6198,15 @@ namespace bgfx { namespace gl
 						}
 						else
 						{
-							GL_CHECK(glDisable(GL_DEPTH_TEST) );
+							if (BGFX_STATE_DEPTH_WRITE & newFlags)
+							{
+								GL_CHECK(glEnable(GL_DEPTH_TEST) );
+								GL_CHECK(glDepthFunc(GL_ALWAYS) );
+							}
+							else
+							{
+								GL_CHECK(glDisable(GL_DEPTH_TEST) );
+							}
 						}
 					}
 


### PR DESCRIPTION
`glDisable(GL_DEPTH_TEST)` disables not just depth testing but depth writing too. In the OpenGL renderer, it is called even when depth writing is enabled. This commit makes it fall back to `glEnable(GL_DEPTH_TEST)` and `glDepthFunc(GL_ALWAYS)` when it is enabled.