### PR TITLE
Make it possible to reset the native window

### DIFF
--- a/examples/common/entry/entry_android.cpp
+++ b/examples/common/entry/entry_android.cpp
@@ -140,7 +140,7 @@ namespace entry
 					// Command from main thread: a new ANativeWindow is ready for use.  Upon
 					// receiving this command, android_app->window will contain the new window
 					// surface.
-					if (m_window == NULL)
+					if (m_window != m_app->window)
 					{
 						m_window = m_app->window;
 						bgfx::androidSetWindow(m_window);
@@ -152,7 +152,14 @@ namespace entry
 						WindowHandle defaultWindow = { 0 };
 						m_eventQueue.postSizeEvent(defaultWindow, width, height);
 
-						m_thread.init(MainThreadEntry::threadFunc, &m_mte);
+						if (!m_thread.isRunning())
+						{
+							m_thread.init(MainThreadEntry::threadFunc, &m_mte);
+						}
+						else
+						{
+							bgfx::reset(width, height, BGFX_RESET_NATIVE_WINDOW);
+						}
 					}
 					break;
 

--- a/include/bgfx/bgfxdefines.h
+++ b/include/bgfx/bgfxdefines.h
@@ -360,6 +360,7 @@
 #define BGFX_RESET_HIDPI                 UINT32_C(0x00010000) //!< Enable HiDPI rendering.
 #define BGFX_RESET_DEPTH_CLAMP           UINT32_C(0x00020000) //!< Enable depth clamp.
 #define BGFX_RESET_SUSPEND               UINT32_C(0x00040000) //!< Suspend rendering.
+#define BGFX_RESET_NATIVE_WINDOW         UINT32_C(0x00080000) //!< Reset the platform native window handle.
 
 #define BGFX_RESET_RESERVED_SHIFT        31                   //!< Internal bits shift.
 #define BGFX_RESET_RESERVED_MASK         UINT32_C(0x80000000) //!< Internal bits mask.

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -305,10 +305,9 @@ namespace bgfx
 		{
 			BGFX_FATAL(true
 				&& g_platformData.ndt     == _data.ndt
-				&& g_platformData.nwh     == _data.nwh
 				&& g_platformData.context == _data.context
 				, Fatal::UnableToInitialize
-				, "Only backbuffer pointer can be changed after initialization!"
+				, "Only backbuffer pointer and native window handle can be changed after initialization!"
 				);
 		}
 		memcpy(&g_platformData, &_data, sizeof(PlatformData) );

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2154,6 +2154,9 @@ namespace bgfx
 					m_resolution.m_flags |= BGFX_RESET_INTERNAL_FORCE;
 				}
 			}
+
+			if (_flags & BGFX_RESET_NATIVE_WINDOW)
+				m_resolution.m_flags |= BGFX_RESET_INTERNAL_FORCE;
 		}
 
 		BGFX_API_FUNC(void setDebug(uint32_t _debug) )

--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -343,6 +343,16 @@ EGL_IMPORT
 #	if BX_PLATFORM_ANDROID
 		if (NULL != m_display)
 		{
+			if (_flags & BGFX_RESET_NATIVE_WINDOW)
+			{
+				EGLNativeWindowType nwh = (EGLNativeWindowType )g_platformData.nwh;
+				eglMakeCurrent(EGL_NO_DISPLAY, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+				eglDestroySurface(m_display, m_surface);
+				m_surface = eglCreateWindowSurface(m_display, m_config, nwh, NULL);
+				BGFX_FATAL(m_surface != EGL_NO_SURFACE, Fatal::UnableToInitialize, "Failed to create surface.");
+				EGLBoolean success = eglMakeCurrent(m_display, m_surface, m_surface, m_context);
+				BGFX_FATAL(success, Fatal::UnableToInitialize, "Failed to set context.");
+			}
 			EGLint format;
 			eglGetConfigAttrib(m_display, m_config, EGL_NATIVE_VISUAL_ID, &format);
 			ANativeWindow_setBuffersGeometry( (ANativeWindow*)g_platformData.nwh, _width, _height, format);


### PR DESCRIPTION
On Android when the application goes into the background, the EGL
window surface becomes invalid. It is possible to resume rendering when
coming to the foreground by resetting and reinitializing bgfx from
scratch, but this is costly in terms of performance.

This patch provides an alternative by letting the application recreate
the EGL window surface while keeping the EGL context intact. This allows
the application to resume rendering without needing to reload textures,
shaders, etc.

To test, build and run the Hello World example on Android, switch to
another app and then back again. The screen should not remain blank
after switching back.