### PR TITLE
Use GLX calls to get window handle on Linux/BSD instead of X11 calls.

### DIFF
--- a/include/bgfx/bgfxplatform.h
+++ b/include/bgfx/bgfxplatform.h
@@ -316,7 +316,7 @@ namespace bgfx
 		PlatformData pd;
 #	if BX_PLATFORM_LINUX || BX_PLATFORM_BSD
 		pd.ndt          = glfwGetX11Display();
-		pd.nwh          = (void*)(uintptr_t)glfwGetX11Window(_window);
+		pd.nwh          = (void*)(uintptr_t)glfwGetGLXWindow(_window);
 		pd.context      = glfwGetGLXContext(_window);
 #	elif BX_PLATFORM_OSX
 		pd.ndt          = NULL;


### PR DESCRIPTION
I was trying to get bgfx and GLFW running but was running into an issue when initializing bgfx.

In ```include/bgfx/bgfxplatform.h``` the window handle is initialized from a glfw window using:
```
#      if BX_PLATFORM_LINUX || BX_PLATFORM_BSD
                pd.ndt          = glfwGetX11Display();
                pd.nwh          = (void*)(uintptr_t)glfwGetX11Window(_window);
                pd.context      = glfwGetGLXContext(_window);
```
however by doing so I get an error that it is not able to create drawables after importing the OpenGL functions:

```
../../../src/glimports.h (462): BGFX 0x7ffff4e0cf20 glStringMarkerGREMEDY (glStringMarkerGREMEDY)
../../../src/glimports.h (463): BGFX 0x7ffff7fcc040 glFrameTerminatorGREMEDY (glFrameTerminatorGREMEDY)
../../../src/glimports.h (464): BGFX 0x7ffff7fcc050 glGetTranslatedShaderSourceANGLE (glGetTranslatedShaderSourceANGLE)
libGL error: failed to create drawable
libGL error: failed to create drawable
X Error of failed request:  0
  Major opcode of failed request:  154 (GLX)
  Minor opcode of failed request:  26 (X_GLXMakeContextCurrent)
  Serial number of failed request:  185
  Current serial number in output stream:  185
```
When changing the initialization to use
`                pd.nwh          = (void*)(uintptr_t)glfwGetGLXWindow(_window);`
instead of
`                pd.nwh          = (void*)(uintptr_t)glfwGetX11Window(_window);`
fixes it.