### PR TITLE
metal fixes

### DIFF
--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -229,6 +229,8 @@ namespace bgfx { namespace mtl
 				);
 			return state;
 		}
+	
+		bool depth24Stencil8PixelFormatSupported() { return m_obj.depth24Stencil8PixelFormatSupported; }
 	MTL_CLASS_END
 
 	MTL_CLASS(Function)


### PR DESCRIPTION
fixed typo in vertex half vertex format
added missing texture formats
fixed packed depth/stencil format usage

Note that I have to add missing texture formats to s_textureFormat. This problem should be caught by  static assert but it seems on XCode with default settings static_assert does not work.