### PR TITLE
Attempt to use DXGI 1.1 when possible

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -800,7 +800,11 @@ namespace bgfx { namespace d3d11
 
 			errorState = ErrorState::LoadedDXGI;
 
-			CreateDXGIFactory = (PFN_CREATE_DXGI_FACTORY)bx::dlsym(m_dxgidll, "CreateDXGIFactory");
+			CreateDXGIFactory = (PFN_CREATE_DXGI_FACTORY)bx::dlsym(m_dxgidll, "CreateDXGIFactory1");
+			if (NULL == CreateDXGIFactory)
+			{
+				CreateDXGIFactory = (PFN_CREATE_DXGI_FACTORY)bx::dlsym(m_dxgidll, "CreateDXGIFactory");
+			}
 			if (NULL == CreateDXGIFactory)
 			{
 				BX_TRACE("Function CreateDXGIFactory not found.");


### PR DESCRIPTION
OpenVR requires DXGI 1.1 to share textures using a keyed
mutex to guantee ordering between the compositor and application.
OpenVR will startup with an adpater created by a 1.0 factory, but
will fail when submitting frames to the compositor.

See: https://steamcommunity.com/app/358720/discussions/0/405692224241830277/