### PR TITLE
DLL exports for C++ API

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -12,6 +12,26 @@
 
 #include <bgfx/bgfxdefines.h>
 
+#ifndef BGFX_SHARED_LIB_BUILD
+#	define BGFX_SHARED_LIB_BUILD 0
+#endif // BGFX_SHARED_LIB_BUILD
+
+#ifndef BGFX_SHARED_LIB_USE
+#	define BGFX_SHARED_LIB_USE 0
+#endif // BGFX_SHARED_LIB_USE
+
+#if defined(_MSC_VER)
+#	if BGFX_SHARED_LIB_BUILD
+#		define BGFX_SHARED_LIB_API __declspec(dllexport)
+#	elif BGFX_SHARED_LIB_USE
+#		define BGFX_SHARED_LIB_API __declspec(dllimport)
+#   else
+#		define BGFX_SHARED_LIB_API
+#	endif // BGFX_SHARED_LIB_*
+#else
+#	define BGFX_SHARED_LIB_API
+#endif // defined(_MSC_VER)
+
 ///
 #define BGFX_HANDLE(_name) \
 			struct _name { uint16_t idx; }; \
@@ -664,7 +684,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_vertex_decl_t`.
 	///
-	struct VertexDecl
+	struct BGFX_SHARED_LIB_API VertexDecl
 	{
 		VertexDecl();
 
@@ -746,7 +766,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_vertex_pack`.
 	///
-	void vertexPack(
+	BGFX_SHARED_LIB_API void vertexPack(
 		  const float _input[4]
 		, bool _inputNormalized
 		, Attrib::Enum _attr
@@ -759,7 +779,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_vertex_unpack`.
 	///
-	void vertexUnpack(
+	BGFX_SHARED_LIB_API void vertexUnpack(
 		  float _output[4]
 		, Attrib::Enum _attr
 		, const VertexDecl& _decl
@@ -777,7 +797,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_vertex_convert`.
 	///
-	void vertexConvert(
+	BGFX_SHARED_LIB_API void vertexConvert(
 		  const VertexDecl& _destDecl
 		, void* _destData
 		, const VertexDecl& _srcDecl
@@ -797,7 +817,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_weld_vertices`.
 	///
-	uint16_t weldVertices(
+	BGFX_SHARED_LIB_API uint16_t weldVertices(
 		  uint16_t* _output
 		, const VertexDecl& _decl
 		, const void* _data
@@ -821,7 +841,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_topology_convert`.
 	///
-	uint32_t topologyConvert(
+	BGFX_SHARED_LIB_API uint32_t topologyConvert(
 		  TopologyConvert::Enum _conversion
 		, void* _dst
 		, uint32_t _dstSize
@@ -841,7 +861,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_image_swizzle_bgra8`.
 	///
-	void imageSwizzleBgra8(
+	BGFX_SHARED_LIB_API void imageSwizzleBgra8(
 		  uint32_t _width
 		, uint32_t _height
 		, uint32_t _pitch
@@ -860,7 +880,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_image_rgba8_downsample_2x2`.
 	///
-	void imageRgba8Downsample2x2(
+	BGFX_SHARED_LIB_API void imageRgba8Downsample2x2(
 		  uint32_t _width
 		, uint32_t _height
 		, uint32_t _pitch
@@ -872,13 +892,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_get_supported_renderers`.
 	///
-	uint8_t getSupportedRenderers(RendererType::Enum _enum[RendererType::Count]);
+	BGFX_SHARED_LIB_API uint8_t getSupportedRenderers(RendererType::Enum _enum[RendererType::Count]);
 
 	/// Returns name of renderer.
 	///
 	/// @attention C99 equivalent is `bgfx_get_renderer_name`.
 	///
-	const char* getRendererName(RendererType::Enum _type);
+	BGFX_SHARED_LIB_API const char* getRendererName(RendererType::Enum _type);
 
 	/// Initialize bgfx library.
 	///
@@ -908,7 +928,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_init`.
 	///
-	bool init(
+	BGFX_SHARED_LIB_API bool init(
 		  RendererType::Enum _type = RendererType::Count
 		, uint16_t _vendorId = BGFX_PCI_ID_NONE
 		, uint16_t _deviceId = 0
@@ -920,7 +940,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_shutdown`.
 	///
-	void shutdown();
+	BGFX_SHARED_LIB_API void shutdown();
 
 	/// Reset graphic settings and back-buffer size.
 	///
@@ -947,7 +967,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_reset`.
 	///
-	void reset(uint32_t _width, uint32_t _height, uint32_t _flags = BGFX_RESET_NONE);
+	BGFX_SHARED_LIB_API void reset(uint32_t _width, uint32_t _height, uint32_t _flags = BGFX_RESET_NONE);
 
 	/// Advance to next frame. When using multithreaded renderer, this call
 	/// just swaps internal buffers, kicks render thread, and returns. In
@@ -961,7 +981,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_frame`.
 	///
-	uint32_t frame(bool _capture = false);
+	BGFX_SHARED_LIB_API uint32_t frame(bool _capture = false);
 
 	/// Returns current renderer backend API type.
 	///
@@ -970,7 +990,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_get_renderer_type`.
 	///
-	RendererType::Enum getRendererType();
+	BGFX_SHARED_LIB_API RendererType::Enum getRendererType();
 
 	/// Returns renderer capabilities.
 	///
@@ -981,29 +1001,29 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_get_caps`.
 	///
-	const Caps* getCaps();
+	BGFX_SHARED_LIB_API const Caps* getCaps();
 
 	/// Returns HMD info.
 	///
 	/// @attention C99 equivalent is `bgfx_get_hmd`.
 	///
-	const HMD* getHMD();
+	BGFX_SHARED_LIB_API const HMD* getHMD();
 
 	/// Returns performance counters.
 	///
-	const Stats* getStats();
+	BGFX_SHARED_LIB_API const Stats* getStats();
 
 	/// Allocate buffer to pass to bgfx calls. Data will be freed inside bgfx.
 	///
 	/// @attention C99 equivalent is `bgfx_alloc`.
 	///
-	const Memory* alloc(uint32_t _size);
+	BGFX_SHARED_LIB_API const Memory* alloc(uint32_t _size);
 
 	/// Allocate buffer and copy data into it. Data will be freed inside bgfx.
 	///
 	/// @attention C99 equivalent is `bgfx_copy`.
 	///
-	const Memory* copy(const void* _data, uint32_t _size);
+	BGFX_SHARED_LIB_API const Memory* copy(const void* _data, uint32_t _size);
 
 	/// Make reference to data to pass to bgfx. Unlike `bgfx::alloc` this call
 	/// doesn't allocate memory for data. It just copies pointer to data. You
@@ -1014,7 +1034,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent are `bgfx_make_ref`, `bgfx_make_ref_release`.
 	///
-	const Memory* makeRef(
+	BGFX_SHARED_LIB_API const Memory* makeRef(
 		  const void* _data
 		, uint32_t _size
 		, ReleaseFn _releaseFn = NULL
@@ -1034,19 +1054,19 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_debug`.
 	///
-	void setDebug(uint32_t _debug);
+	BGFX_SHARED_LIB_API void setDebug(uint32_t _debug);
 
 	/// Clear internal debug text buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_dbg_text_clear`.
 	///
-	void dbgTextClear(uint8_t _attr = 0, bool _small = false);
+	BGFX_SHARED_LIB_API void dbgTextClear(uint8_t _attr = 0, bool _small = false);
 
 	/// Print into internal debug text buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_dbg_text_printf`.
 	///
-	void dbgTextPrintf(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, ...);
+	BGFX_SHARED_LIB_API void dbgTextPrintf(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, ...);
 
 	/// Draw image into internal debug text buffer.
 	///
@@ -1059,7 +1079,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_dbg_text_image`.
 	///
-	void dbgTextImage(
+	BGFX_SHARED_LIB_API void dbgTextImage(
 		  uint16_t _x
 		, uint16_t _y
 		, uint16_t _width
@@ -1086,13 +1106,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_index_buffer`.
 	///
-	IndexBufferHandle createIndexBuffer(const Memory* _mem, uint16_t _flags = BGFX_BUFFER_NONE);
+	BGFX_SHARED_LIB_API IndexBufferHandle createIndexBuffer(const Memory* _mem, uint16_t _flags = BGFX_BUFFER_NONE);
 
 	/// Destroy static index buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_index_buffer`.
 	///
-	void destroyIndexBuffer(IndexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyIndexBuffer(IndexBufferHandle _handle);
 
 	/// Create static vertex buffer.
 	///
@@ -1114,7 +1134,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_vertex_buffer`.
 	///
-	VertexBufferHandle createVertexBuffer(
+	BGFX_SHARED_LIB_API VertexBufferHandle createVertexBuffer(
 		  const Memory* _mem
 		, const VertexDecl& _decl
 		, uint16_t _flags = BGFX_BUFFER_NONE
@@ -1126,7 +1146,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_vertex_buffer`.
 	///
-	void destroyVertexBuffer(VertexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyVertexBuffer(VertexBufferHandle _handle);
 
 	/// Create empty dynamic index buffer.
 	///
@@ -1146,7 +1166,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_dynamic_index_buffer`.
 	///
-	DynamicIndexBufferHandle createDynamicIndexBuffer(
+	BGFX_SHARED_LIB_API DynamicIndexBufferHandle createDynamicIndexBuffer(
 		  uint32_t _num
 		, uint16_t _flags = BGFX_BUFFER_NONE
 		);
@@ -1169,7 +1189,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_dynamic_index_buffer_mem`.
 	///
-	DynamicIndexBufferHandle createDynamicIndexBuffer(
+	BGFX_SHARED_LIB_API DynamicIndexBufferHandle createDynamicIndexBuffer(
 		  const Memory* _mem
 		, uint16_t _flags = BGFX_BUFFER_NONE
 		);
@@ -1182,7 +1202,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_update_dynamic_index_buffer`.
 	///
-	void updateDynamicIndexBuffer(
+	BGFX_SHARED_LIB_API void updateDynamicIndexBuffer(
 		  DynamicIndexBufferHandle _handle
 		, uint32_t _startIndex
 		, const Memory* _mem
@@ -1194,7 +1214,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_dynamic_index_buffer`.
 	///
-	void destroyDynamicIndexBuffer(DynamicIndexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyDynamicIndexBuffer(DynamicIndexBufferHandle _handle);
 
 	/// Create empty dynamic vertex buffer.
 	///
@@ -1215,7 +1235,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_dynamic_vertex_buffer`.
 	///
-	DynamicVertexBufferHandle createDynamicVertexBuffer(
+	BGFX_SHARED_LIB_API DynamicVertexBufferHandle createDynamicVertexBuffer(
 		  uint32_t _num
 		, const VertexDecl& _decl
 		, uint16_t _flags = BGFX_BUFFER_NONE
@@ -1240,7 +1260,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_dynamic_vertex_buffer_mem`.
 	///
-	DynamicVertexBufferHandle createDynamicVertexBuffer(
+	BGFX_SHARED_LIB_API DynamicVertexBufferHandle createDynamicVertexBuffer(
 		  const Memory* _mem
 		, const VertexDecl& _decl
 		, uint16_t _flags = BGFX_BUFFER_NONE
@@ -1254,7 +1274,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_update_dynamic_vertex_buffer`.
 	///
-	void updateDynamicVertexBuffer(
+	BGFX_SHARED_LIB_API void updateDynamicVertexBuffer(
 		  DynamicVertexBufferHandle _handle
 		, uint32_t _startVertex
 		, const Memory* _mem
@@ -1264,7 +1284,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_dynamic_vertex_buffer`.
 	///
-	void destroyDynamicVertexBuffer(DynamicVertexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyDynamicVertexBuffer(DynamicVertexBufferHandle _handle);
 
 	/// Returns true if internal transient index buffer has enough space.
 	///
@@ -1272,7 +1292,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_check_avail_transient_index_buffer`.
 	///
-	bool checkAvailTransientIndexBuffer(uint32_t _num);
+	BGFX_SHARED_LIB_API bool checkAvailTransientIndexBuffer(uint32_t _num);
 
 	/// Returns true if internal transient vertex buffer has enough space.
 	///
@@ -1281,7 +1301,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_check_avail_transient_vertex_buffer`.
 	///
-	bool checkAvailTransientVertexBuffer(uint32_t _num, const VertexDecl& _decl);
+	BGFX_SHARED_LIB_API bool checkAvailTransientVertexBuffer(uint32_t _num, const VertexDecl& _decl);
 
 	/// Returns true if internal instance data buffer has enough space.
 	///
@@ -1290,7 +1310,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_check_avail_instance_data_buffer`.
 	///
-	bool checkAvailInstanceDataBuffer(uint32_t _num, uint16_t _stride);
+	BGFX_SHARED_LIB_API bool checkAvailInstanceDataBuffer(uint32_t _num, uint16_t _stride);
 
 	/// Returns true if both internal transient index and vertex buffer have
 	/// enough space.
@@ -1301,7 +1321,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_check_avail_transient_buffers`.
 	///
-	bool checkAvailTransientBuffers(
+	BGFX_SHARED_LIB_API bool checkAvailTransientBuffers(
 		  uint32_t _numVertices
 		, const VertexDecl& _decl
 		, uint32_t _numIndices
@@ -1321,7 +1341,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transient_index_buffer`.
 	///
-	void allocTransientIndexBuffer(TransientIndexBuffer* _tib, uint32_t _num);
+	BGFX_SHARED_LIB_API void allocTransientIndexBuffer(TransientIndexBuffer* _tib, uint32_t _num);
 
 	/// Allocate transient vertex buffer.
 	///
@@ -1337,7 +1357,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transient_vertex_buffer`.
 	///
-	void allocTransientVertexBuffer(TransientVertexBuffer* _tvb
+	BGFX_SHARED_LIB_API void allocTransientVertexBuffer(TransientVertexBuffer* _tvb
 		, uint32_t _num
 		, const VertexDecl& _decl
 		);
@@ -1351,7 +1371,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transient_buffers`.
 	///
-	bool allocTransientBuffers(TransientVertexBuffer* _tvb
+	BGFX_SHARED_LIB_API bool allocTransientBuffers(TransientVertexBuffer* _tvb
 		, const VertexDecl& _decl
 		, uint32_t _numVertices
 		, TransientIndexBuffer* _tib
@@ -1366,25 +1386,25 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_instance_data_buffer`.
 	///
-	const InstanceDataBuffer* allocInstanceDataBuffer(uint32_t _num, uint16_t _stride);
+	BGFX_SHARED_LIB_API const InstanceDataBuffer* allocInstanceDataBuffer(uint32_t _num, uint16_t _stride);
 
 	/// Create draw indirect buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_create_indirect_buffer`.
 	///
-	IndirectBufferHandle createIndirectBuffer(uint32_t _num);
+	BGFX_SHARED_LIB_API IndirectBufferHandle createIndirectBuffer(uint32_t _num);
 
 	/// Destroy draw indirect buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_indirect_buffer`.
 	///
-	void destroyIndirectBuffer(IndirectBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyIndirectBuffer(IndirectBufferHandle _handle);
 
 	/// Create shader from memory buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_create_shader`.
 	///
-	ShaderHandle createShader(const Memory* _mem);
+	BGFX_SHARED_LIB_API ShaderHandle createShader(const Memory* _mem);
 
 	/// Returns num of uniforms, and uniform handles used inside shader.
 	///
@@ -1398,7 +1418,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_get_shader_uniforms`.
 	///
-	uint16_t getShaderUniforms(
+	BGFX_SHARED_LIB_API uint16_t getShaderUniforms(
 		  ShaderHandle _handle
 		, UniformHandle* _uniforms = NULL
 		, uint16_t _max = 0
@@ -1409,7 +1429,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_shader`.
 	///
-	void destroyShader(ShaderHandle _handle);
+	BGFX_SHARED_LIB_API void destroyShader(ShaderHandle _handle);
 
 	/// Create program with vertex and fragment shaders.
 	///
@@ -1422,7 +1442,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_program`.
 	///
-	ProgramHandle createProgram(
+	BGFX_SHARED_LIB_API ProgramHandle createProgram(
 		  ShaderHandle _vsh
 		, ShaderHandle _fsh
 		, bool _destroyShaders = false
@@ -1437,7 +1457,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_compute_program`.
 	///
-	ProgramHandle createProgram(
+	BGFX_SHARED_LIB_API ProgramHandle createProgram(
 		  ShaderHandle _csh
 		, bool _destroyShader = false
 		);
@@ -1446,13 +1466,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_program`.
 	///
-	void destroyProgram(ProgramHandle _handle);
+	BGFX_SHARED_LIB_API void destroyProgram(ProgramHandle _handle);
 
 	/// Calculate amount of memory required for texture.
 	///
 	/// @attention C99 equivalent is `bgfx_calc_texture_size`.
 	///
-	void calcTextureSize(
+	BGFX_SHARED_LIB_API void calcTextureSize(
 		  TextureInfo& _info
 		, uint16_t _width
 		, uint16_t _height
@@ -1478,7 +1498,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture`.
 	///
-	TextureHandle createTexture(
+	BGFX_SHARED_LIB_API TextureHandle createTexture(
 		  const Memory* _mem
 		, uint32_t _flags = BGFX_TEXTURE_NONE
 		, uint8_t _skip = 0
@@ -1502,7 +1522,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture_2d`.
 	///
-	TextureHandle createTexture2D(
+	BGFX_SHARED_LIB_API TextureHandle createTexture2D(
 		  uint16_t _width
 		, uint16_t _height
 		, uint8_t _numMips
@@ -1527,7 +1547,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture_2d_scaled`.
 	///
-	TextureHandle createTexture2D(
+	BGFX_SHARED_LIB_API TextureHandle createTexture2D(
 		  BackbufferRatio::Enum _ratio
 		, uint8_t _numMips
 		, TextureFormat::Enum _format
@@ -1552,7 +1572,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture_3d`.
 	///
-	TextureHandle createTexture3D(
+	BGFX_SHARED_LIB_API TextureHandle createTexture3D(
 		  uint16_t _width
 		, uint16_t _height
 		, uint16_t _depth
@@ -1578,7 +1598,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_texture_cube`.
 	///
-	TextureHandle createTextureCube(
+	BGFX_SHARED_LIB_API TextureHandle createTextureCube(
 		  uint16_t _size
 		, uint8_t _numMips
 		, TextureFormat::Enum _format
@@ -1600,7 +1620,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_update_texture_2d`.
 	///
-	void updateTexture2D(
+	BGFX_SHARED_LIB_API void updateTexture2D(
 		  TextureHandle _handle
 		, uint8_t _mip
 		, uint16_t _x
@@ -1625,7 +1645,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_update_texture_3d`.
 	///
-	void updateTexture3D(
+	BGFX_SHARED_LIB_API void updateTexture3D(
 		  TextureHandle _handle
 		, uint8_t _mip
 		, uint16_t _x
@@ -1671,7 +1691,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_update_texture_cube`.
 	///
-	void updateTextureCube(
+	BGFX_SHARED_LIB_API void updateTextureCube(
 		  TextureHandle _handle
 		, uint8_t _side
 		, uint8_t _mip
@@ -1694,7 +1714,7 @@ namespace bgfx
 	/// @attention Availability depends on: `BGFX_CAPS_TEXTURE_READ_BACK`.
 	/// @attention C99 equivalent is `bgfx_read_texture`.
 	///
-	uint32_t readTexture(TextureHandle _handle, void* _data);
+	BGFX_SHARED_LIB_API uint32_t readTexture(TextureHandle _handle, void* _data);
 
 	/// Read back texture content.
 	///
@@ -1708,7 +1728,7 @@ namespace bgfx
 	/// @attention Availability depends on: `BGFX_CAPS_TEXTURE_READ_BACK`.
 	/// @attention C99 equivalent is `bgfx_read_frame_buffer`.
 	///
-	uint32_t readTexture(FrameBufferHandle _handle, uint8_t _attachment, void* _data);
+	BGFX_SHARED_LIB_API uint32_t readTexture(FrameBufferHandle _handle, uint8_t _attachment, void* _data);
 
 	/// Destroy texture.
 	///
@@ -1716,7 +1736,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_texture`.
 	///
-	void destroyTexture(TextureHandle _handle);
+	BGFX_SHARED_LIB_API void destroyTexture(TextureHandle _handle);
 
 	/// Create frame buffer (simple).
 	///
@@ -1734,7 +1754,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer`.
 	///
-	FrameBufferHandle createFrameBuffer(
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(
 		  uint16_t _width
 		, uint16_t _height
 		, TextureFormat::Enum _format
@@ -1758,7 +1778,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer_scaled`.
 	///
-	FrameBufferHandle createFrameBuffer(
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(
 		  BackbufferRatio::Enum _ratio
 		, TextureFormat::Enum _format
 		, uint32_t _textureFlags = BGFX_TEXTURE_U_CLAMP|BGFX_TEXTURE_V_CLAMP
@@ -1775,7 +1795,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer_from_handles`.
 	///
-	FrameBufferHandle createFrameBuffer(
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(
 		  uint8_t _num
 		, const TextureHandle* _handles
 		, bool _destroyTextures = false
@@ -1792,7 +1812,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer_from_handles`.
 	///
-	FrameBufferHandle createFrameBuffer(
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(
 		  uint8_t _num
 		, const Attachment* _attachment
 		, bool _destroyTextures = false
@@ -1812,7 +1832,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_frame_buffer_from_nwh`.
 	///
-	FrameBufferHandle createFrameBuffer(
+	BGFX_SHARED_LIB_API FrameBufferHandle createFrameBuffer(
 		  void* _nwh
 		, uint16_t _width
 		, uint16_t _height
@@ -1823,7 +1843,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_frame_buffer`.
 	///
-	void destroyFrameBuffer(FrameBufferHandle _handle);
+	BGFX_SHARED_LIB_API void destroyFrameBuffer(FrameBufferHandle _handle);
 
 	/// Create shader uniform parameter.
 	///
@@ -1853,7 +1873,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_uniform`.
 	///
-	UniformHandle createUniform(const char* _name, UniformType::Enum _type, uint16_t _num = 1);
+	BGFX_SHARED_LIB_API UniformHandle createUniform(const char* _name, UniformType::Enum _type, uint16_t _num = 1);
 
 	/// Destroy shader uniform parameter.
 	///
@@ -1861,7 +1881,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_uniform`.
 	///
-	void destroyUniform(UniformHandle _handle);
+	BGFX_SHARED_LIB_API void destroyUniform(UniformHandle _handle);
 
 	/// Create occlusion query.
 	///
@@ -1869,7 +1889,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_create_occlusion_query`.
 	///
-	OcclusionQueryHandle createOcclusionQuery();
+	BGFX_SHARED_LIB_API OcclusionQueryHandle createOcclusionQuery();
 
 	/// Retrieve occlusion query result from previous frame.
 	///
@@ -1878,7 +1898,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_get_result`.
 	///
-	OcclusionQueryResult::Enum getResult(OcclusionQueryHandle _handle);
+	BGFX_SHARED_LIB_API OcclusionQueryResult::Enum getResult(OcclusionQueryHandle _handle);
 
 	/// Destroy occlusion query.
 	///
@@ -1886,7 +1906,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_occlusion_query`.
 	///
-	void destroyOcclusionQuery(OcclusionQueryHandle _handle);
+	BGFX_SHARED_LIB_API void destroyOcclusionQuery(OcclusionQueryHandle _handle);
 
 	/// Set palette color value.
 	///
@@ -1895,7 +1915,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_palette_color`.
 	///
-	void setPaletteColor(uint8_t _index, uint32_t _rgba);
+	BGFX_SHARED_LIB_API void setPaletteColor(uint8_t _index, uint32_t _rgba);
 
 	/// Set palette color value.
 	///
@@ -1904,7 +1924,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_palette_color`.
 	///
-	void setPaletteColor(uint8_t _index, float _r, float _g, float _b, float _a);
+	BGFX_SHARED_LIB_API void setPaletteColor(uint8_t _index, float _r, float _g, float _b, float _a);
 
 	/// Set palette color value.
 	///
@@ -1913,7 +1933,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_palette_color`.
 	///
-	void setPaletteColor(uint8_t _index, const float _rgba[4]);
+	BGFX_SHARED_LIB_API void setPaletteColor(uint8_t _index, const float _rgba[4]);
 
 	/// Set view name.
 	///
@@ -1933,7 +1953,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_name`.
 	///
-	void setViewName(uint8_t _id, const char* _name);
+	BGFX_SHARED_LIB_API void setViewName(uint8_t _id, const char* _name);
 
 	/// Set view rectangle. Draw primitive outside view will be clipped.
 	///
@@ -1945,11 +1965,11 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_rect`.
 	///
-	void setViewRect(uint8_t _id, uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height);
+	BGFX_SHARED_LIB_API void setViewRect(uint8_t _id, uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height);
 
 	/// @attention C99 equivalent is `bgfx_set_view_rect_auto`.
 	///
-	void setViewRect(uint8_t _id, uint16_t _x, uint16_t _y, BackbufferRatio::Enum _ratio);
+	BGFX_SHARED_LIB_API void setViewRect(uint8_t _id, uint16_t _x, uint16_t _y, BackbufferRatio::Enum _ratio);
 
 	/// Set view scissor. Draw primitive outside view will be clipped. When
 	/// _x, _y, _width and _height are set to 0, scissor will be disabled.
@@ -1962,7 +1982,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_scissor`.
 	///
-	void setViewScissor(
+	BGFX_SHARED_LIB_API void setViewScissor(
 		  uint8_t _id
 		, uint16_t _x = 0
 		, uint16_t _y = 0
@@ -1981,7 +2001,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_clear`.
 	///
-	void setViewClear(
+	BGFX_SHARED_LIB_API void setViewClear(
 		  uint8_t _id
 		, uint16_t _flags
 		, uint32_t _rgba = 0x000000ff
@@ -2009,7 +2029,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_clear_mrt`.
 	///
-	void setViewClear(
+	BGFX_SHARED_LIB_API void setViewClear(
 		  uint8_t _id
 		, uint16_t _flags
 		, float _depth
@@ -2029,7 +2049,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_seq`.
 	///
-	void setViewSeq(uint8_t _id, bool _enabled);
+	BGFX_SHARED_LIB_API void setViewSeq(uint8_t _id, bool _enabled);
 
 	/// Set view frame buffer.
 	///
@@ -2043,7 +2063,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_frame_buffer`.
 	///
-	void setViewFrameBuffer(uint8_t _id, FrameBufferHandle _handle);
+	BGFX_SHARED_LIB_API void setViewFrameBuffer(uint8_t _id, FrameBufferHandle _handle);
 
 	/// Set view view and projection matrices, all draw primitives in this
 	/// view will use these matrices.
@@ -2060,7 +2080,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent are `bgfx_set_view_transform`, `bgfx_set_view_transform_stereo`.
 	///
-	void setViewTransform(
+	BGFX_SHARED_LIB_API void setViewTransform(
 		  uint8_t _id
 		, const void* _view
 		, const void* _projL
@@ -2077,7 +2097,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_view_remap`.
 	///
-	void setViewRemap(uint8_t _id = 0, uint8_t _num = UINT8_MAX, const void* _remap = NULL);
+	BGFX_SHARED_LIB_API void setViewRemap(uint8_t _id = 0, uint8_t _num = UINT8_MAX, const void* _remap = NULL);
 
 	/// Reset all view settings to default.
 	///
@@ -2085,13 +2105,13 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_reset_view`.
 	///
-	void resetView(uint8_t _id);
+	BGFX_SHARED_LIB_API 	void resetView(uint8_t _id);
 
 	/// Sets debug marker.
 	///
 	/// @attention C99 equivalent is `bgfx_set_marker`.
 	///
-	void setMarker(const char* _marker);
+	BGFX_SHARED_LIB_API void setMarker(const char* _marker);
 
 	/// Set render states for draw primitive.
 	///
@@ -2118,7 +2138,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_state`.
 	///
-	void setState(uint64_t _state, uint32_t _rgba = 0);
+	BGFX_SHARED_LIB_API void setState(uint64_t _state, uint32_t _rgba = 0);
 
 	/// Set condition for rendering.
 	///
@@ -2127,7 +2147,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_condition`.
 	///
-	void setCondition(OcclusionQueryHandle _handle, bool _visible);
+	BGFX_SHARED_LIB_API void setCondition(OcclusionQueryHandle _handle, bool _visible);
 
 	/// Set stencil test state.
 	///
@@ -2137,7 +2157,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_stencil`.
 	///
-	void setStencil(uint32_t _fstencil, uint32_t _bstencil = BGFX_STENCIL_NONE);
+	BGFX_SHARED_LIB_API void setStencil(uint32_t _fstencil, uint32_t _bstencil = BGFX_STENCIL_NONE);
 
 	/// Set scissor for draw primitive. For scissor for all primitives in
 	/// view see `bgfx::setViewScissor`.
@@ -2150,7 +2170,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_scissor`.
 	///
-	uint16_t setScissor(uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height);
+	BGFX_SHARED_LIB_API uint16_t setScissor(uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height);
 
 	/// Set scissor from cache for draw primitive.
 	///
@@ -2159,7 +2179,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_scissor_cached`.
 	///
-	void setScissor(uint16_t _cache = UINT16_MAX);
+	BGFX_SHARED_LIB_API void setScissor(uint16_t _cache = UINT16_MAX);
 
 	/// Set model matrix for draw primitive. If it is not called model will
 	/// be rendered with identity model matrix.
@@ -2171,7 +2191,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_transform`.
 	///
-	uint32_t setTransform(const void* _mtx, uint16_t _num = 1);
+	BGFX_SHARED_LIB_API uint32_t setTransform(const void* _mtx, uint16_t _num = 1);
 
 	/// Reserve `_num` matrices in internal matrix cache. Pointer returned
 	/// can be modifed until `bgfx::frame` is called.
@@ -2182,7 +2202,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transform`.
 	///
-	uint32_t allocTransform(Transform* _transform, uint16_t _num);
+	BGFX_SHARED_LIB_API uint32_t allocTransform(Transform* _transform, uint16_t _num);
 
 	/// Set model matrix from matrix cache for draw primitive.
 	///
@@ -2191,7 +2211,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_transform_cached`.
 	///
-	void setTransform(uint32_t _cache, uint16_t _num = 1);
+	BGFX_SHARED_LIB_API void setTransform(uint32_t _cache, uint16_t _num = 1);
 
 	/// Set shader uniform parameter for draw primitive.
 	///
@@ -2202,7 +2222,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_uniform`.
 	///
-	void setUniform(UniformHandle _handle, const void* _value, uint16_t _num = 1);
+	BGFX_SHARED_LIB_API void setUniform(UniformHandle _handle, const void* _value, uint16_t _num = 1);
 
 	/// Set index buffer for draw primitive.
 	///
@@ -2210,7 +2230,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_index_buffer`.
 	///
-	void setIndexBuffer(IndexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void setIndexBuffer(IndexBufferHandle _handle);
 
 	/// Set index buffer for draw primitive.
 	///
@@ -2220,7 +2240,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_index_buffer`.
 	///
-	void setIndexBuffer(IndexBufferHandle _handle, uint32_t _firstIndex, uint32_t _numIndices);
+	BGFX_SHARED_LIB_API void setIndexBuffer(IndexBufferHandle _handle, uint32_t _firstIndex, uint32_t _numIndices);
 
 	/// Set index buffer for draw primitive.
 	///
@@ -2228,7 +2248,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_dynamic_index_buffer`.
 	///
-	void setIndexBuffer(DynamicIndexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void setIndexBuffer(DynamicIndexBufferHandle _handle);
 
 	/// Set index buffer for draw primitive.
 	///
@@ -2238,7 +2258,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_dynamic_index_buffer`.
 	///
-	void setIndexBuffer(
+	BGFX_SHARED_LIB_API void setIndexBuffer(
 		  DynamicIndexBufferHandle _handle
 		, uint32_t _firstIndex
 		, uint32_t _numIndices
@@ -2250,7 +2270,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_transient_index_buffer`.
 	///
-	void setIndexBuffer(const TransientIndexBuffer* _tib);
+	BGFX_SHARED_LIB_API void setIndexBuffer(const TransientIndexBuffer* _tib);
 
 	/// Set index buffer for draw primitive.
 	///
@@ -2260,7 +2280,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_transient_index_buffer`.
 	///
-	void setIndexBuffer(
+	BGFX_SHARED_LIB_API void setIndexBuffer(
 		  const TransientIndexBuffer* _tib
 		, uint32_t _firstIndex
 		, uint32_t _numIndices
@@ -2272,7 +2292,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_vertex_buffer`.
 	///
-	void setVertexBuffer(VertexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void setVertexBuffer(VertexBufferHandle _handle);
 
 	/// Set vertex buffer for draw primitive.
 	///
@@ -2282,7 +2302,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_vertex_buffer`.
 	///
-	void setVertexBuffer(VertexBufferHandle _handle, uint32_t _startVertex, uint32_t _numVertices);
+	BGFX_SHARED_LIB_API void setVertexBuffer(VertexBufferHandle _handle, uint32_t _startVertex, uint32_t _numVertices);
 
 	/// Set vertex buffer for draw primitive.
 	///
@@ -2290,7 +2310,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_dynamic_vertex_buffer`.
 	///
-	void setVertexBuffer(DynamicVertexBufferHandle _handle);
+	BGFX_SHARED_LIB_API void setVertexBuffer(DynamicVertexBufferHandle _handle);
 
 	/// Set vertex buffer for draw primitive.
 	///
@@ -2300,7 +2320,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_dynamic_vertex_buffer`.
 	///
-	void setVertexBuffer(
+	BGFX_SHARED_LIB_API void setVertexBuffer(
 		  DynamicVertexBufferHandle _handle
 		, uint32_t _startVertex
 		, uint32_t _numVertices
@@ -2312,7 +2332,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_transient_vertex_buffer`.
 	///
-	void setVertexBuffer(const TransientVertexBuffer* _tvb);
+	BGFX_SHARED_LIB_API void setVertexBuffer(const TransientVertexBuffer* _tvb);
 
 	/// Set vertex buffer for draw primitive.
 	///
@@ -2322,7 +2342,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_transient_vertex_buffer`.
 	///
-	void setVertexBuffer(
+	BGFX_SHARED_LIB_API void setVertexBuffer(
 		  const TransientVertexBuffer* _tvb
 		, uint32_t _startVertex
 		, uint32_t _numVertices
@@ -2332,19 +2352,19 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_instance_data_buffer`.
 	///
-	void setInstanceDataBuffer(const InstanceDataBuffer* _idb, uint32_t _num = UINT32_MAX);
+	BGFX_SHARED_LIB_API void setInstanceDataBuffer(const InstanceDataBuffer* _idb, uint32_t _num = UINT32_MAX);
 
 	/// Set instance data buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_instance_data_from_vertex_buffer`.
 	///
-	void setInstanceDataBuffer(VertexBufferHandle _handle, uint32_t _startVertex, uint32_t _num);
+	BGFX_SHARED_LIB_API void setInstanceDataBuffer(VertexBufferHandle _handle, uint32_t _startVertex, uint32_t _num);
 
 	/// Set instance data buffer for draw primitive.
 	///
 	/// @attention C99 equivalent is `bgfx_set_instance_data_from_dynamic_vertex_buffer`.
 	///
-	void setInstanceDataBuffer(
+	BGFX_SHARED_LIB_API void setInstanceDataBuffer(
 		  DynamicVertexBufferHandle _handle
 		, uint32_t _startVertex
 		, uint32_t _num
@@ -2367,7 +2387,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_texture`.
 	///
-	void setTexture(
+	BGFX_SHARED_LIB_API void setTexture(
 		  uint8_t _stage
 		, UniformHandle _sampler
 		, TextureHandle _handle
@@ -2389,7 +2409,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_texture_from_frame_buffer`.
 	///
-	void setTexture(
+	BGFX_SHARED_LIB_API void setTexture(
 		  uint8_t _stage
 		, UniformHandle _sampler
 		, FrameBufferHandle _handle
@@ -2405,7 +2425,7 @@ namespace bgfx
 	/// @param[in] _id View id.
 	/// @returns Number of draw calls.
 	///
-	uint32_t touch(uint8_t _id);
+	BGFX_SHARED_LIB_API uint32_t touch(uint8_t _id);
 
 	/// Submit primitive for rendering.
 	///
@@ -2418,7 +2438,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_submit`.
 	///
-	uint32_t submit(
+	BGFX_SHARED_LIB_API uint32_t submit(
 		  uint8_t _id
 		, ProgramHandle _program
 		, int32_t _depth = 0
@@ -2437,7 +2457,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_submit_occlusion_query.
 	///
-	uint32_t submit(
+	BGFX_SHARED_LIB_API uint32_t submit(
 		  uint8_t _id
 		, ProgramHandle _program
 		, OcclusionQueryHandle _occlusionQuery
@@ -2460,7 +2480,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_submit_indirect`.
 	///
-	uint32_t submit(
+	BGFX_SHARED_LIB_API uint32_t submit(
 		  uint8_t _id
 		, ProgramHandle _program
 		, IndirectBufferHandle _indirectHandle
@@ -2478,7 +2498,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_index_buffer`.
 	///
-	void setBuffer(uint8_t _stage, IndexBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, IndexBufferHandle _handle, Access::Enum _access);
 
 	/// Set compute vertex buffer.
 	///
@@ -2488,7 +2508,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_vertex_buffer`.
 	///
-	void setBuffer(uint8_t _stage, VertexBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, VertexBufferHandle _handle, Access::Enum _access);
 
 	/// Set compute dynamic index buffer.
 	///
@@ -2498,7 +2518,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_dynamic_index_buffer`.
 	///
-	void setBuffer(uint8_t _stage, DynamicIndexBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, DynamicIndexBufferHandle _handle, Access::Enum _access);
 
 	/// Set compute dynamic vertex buffer.
 	///
@@ -2508,7 +2528,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_dynamic_vertex_buffer`.
 	///
-	void setBuffer(uint8_t _stage, DynamicVertexBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, DynamicVertexBufferHandle _handle, Access::Enum _access);
 
 	/// Set compute indirect buffer.
 	///
@@ -2518,7 +2538,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_compute_indirect_buffer`.
 	///
-	void setBuffer(uint8_t _stage, IndirectBufferHandle _handle, Access::Enum _access);
+	BGFX_SHARED_LIB_API void setBuffer(uint8_t _stage, IndirectBufferHandle _handle, Access::Enum _access);
 
 	/// Set compute image from texture.
 	///
@@ -2531,7 +2551,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_image`.
 	///
-	void setImage(
+	BGFX_SHARED_LIB_API void setImage(
 		  uint8_t _stage
 		, UniformHandle _sampler
 		, TextureHandle _handle
@@ -2551,7 +2571,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_image_from_frame_buffer`.
 	///
-	void setImage(
+	BGFX_SHARED_LIB_API void setImage(
 		  uint8_t _stage
 		, UniformHandle _sampler
 		, FrameBufferHandle _handle
@@ -2574,7 +2594,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_dispatch`.
 	///
-	uint32_t dispatch(
+	BGFX_SHARED_LIB_API uint32_t dispatch(
 		  uint8_t _id
 		, ProgramHandle _handle
 		, uint16_t _numX = 1
@@ -2597,7 +2617,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_dispatch_indirect`.
 	///
-	uint32_t dispatch(
+	BGFX_SHARED_LIB_API uint32_t dispatch(
 		  uint8_t _id
 		, ProgramHandle _handle
 		, IndirectBufferHandle _indirectHandle
@@ -2610,7 +2630,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_discard`.
 	///
-	void discard();
+	BGFX_SHARED_LIB_API void discard();
 
 	/// Blit texture 2D region between two 2D textures.
 	///
@@ -2628,7 +2648,7 @@ namespace bgfx
 	/// @attention Availability depends on: `BGFX_CAPS_TEXTURE_BLIT`.
 	/// @attention C99 equivalent is `bgfx_blit`.
 	///
-	void blit(
+	BGFX_SHARED_LIB_API void blit(
 		  uint8_t _id
 		, TextureHandle _dst
 		, uint16_t _dstX
@@ -2657,7 +2677,7 @@ namespace bgfx
 	/// @attention Availability depends on: `BGFX_CAPS_TEXTURE_BLIT`.
 	/// @attention C99 equivalent is `bgfx_blit`.
 	///
-	void blit(
+	BGFX_SHARED_LIB_API void blit(
 		  uint8_t _id
 		, TextureHandle _dst
 		, uint16_t _dstX
@@ -2696,7 +2716,7 @@ namespace bgfx
 	/// @attention Availability depends on: `BGFX_CAPS_TEXTURE_BLIT`.
 	/// @attention C99 equivalent is `bgfx_blit`.
 	///
-	void blit(
+	BGFX_SHARED_LIB_API void blit(
 		  uint8_t _id
 		, TextureHandle _dst
 		, uint8_t _dstMip
@@ -2740,7 +2760,7 @@ namespace bgfx
 	/// @attention Availability depends on: `BGFX_CAPS_TEXTURE_BLIT`.
 	/// @attention C99 equivalent is `bgfx_blit`.
 	///
-	void blit(
+	BGFX_SHARED_LIB_API void blit(
 		  uint8_t _id
 		, TextureHandle _dst
 		, uint8_t _dstMip
@@ -2767,7 +2787,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_save_screen_shot`.
 	///
-	void saveScreenShot(const char* _filePath);
+	BGFX_SHARED_LIB_API void saveScreenShot(const char* _filePath);
 
 } // namespace bgfx
 

--- a/include/bgfx/bgfxplatform.h
+++ b/include/bgfx/bgfxplatform.h
@@ -59,7 +59,7 @@ namespace bgfx
 	///
 	/// @attention C99 equivalent is `bgfx_set_platform_data`.
 	///
-	void setPlatformData(const PlatformData& _data);
+	BGFX_SHARED_LIB_API void setPlatformData(const PlatformData& _data);
 
 	/// Internal data.
 	///

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -136,10 +136,17 @@ function exampleProject(_name)
 		path.join(BGFX_DIR, "examples", _name, "**.bin.h"),
 	}
 
-	links {
-		"bgfx",
-		"example-common",
-	}
+	if _OPTIONS["with-shared-lib"] then
+		links {
+			"bgfx-shared-lib",
+			"example-common",
+		}
+	else
+		links {
+			"bgfx",
+			"example-common",
+		}
+	end
 
 	if _OPTIONS["with-sdl"] then
 		defines { "ENTRY_CONFIG_USE_SDL=1" }
@@ -359,7 +366,6 @@ group "examples"
 dofile "example-common.lua"
 
 group "libs"
-bgfxProject("", "StaticLib", {})
 
 group "examples"
 exampleProject("00-helloworld")
@@ -400,6 +406,8 @@ end
 if _OPTIONS["with-shared-lib"] then
 	group "libs"
 	bgfxProject("-shared-lib", "SharedLib", {})
+else
+	bgfxProject("", "StaticLib", {})
 end
 
 if _OPTIONS["with-tools"] then

--- a/src/vertexdecl.h
+++ b/src/vertexdecl.h
@@ -12,28 +12,28 @@
 namespace bgfx
 {
 	///
-	void initAttribTypeSizeTable(RendererType::Enum _type);
+	BGFX_SHARED_LIB_API void initAttribTypeSizeTable(RendererType::Enum _type);
 
 	/// Returns attribute name.
-	const char* getAttribName(Attrib::Enum _attr);
+	BGFX_SHARED_LIB_API const char* getAttribName(Attrib::Enum _attr);
 
 	/// Dump vertex declaration into debug output.
-	void dump(const VertexDecl& _decl);
+	BGFX_SHARED_LIB_API void dump(const VertexDecl& _decl);
 
 	///
-	Attrib::Enum idToAttrib(uint16_t id);
+	BGFX_SHARED_LIB_API Attrib::Enum idToAttrib(uint16_t id);
 
 	///
-	uint16_t attribToId(Attrib::Enum _attr);
+	BGFX_SHARED_LIB_API uint16_t attribToId(Attrib::Enum _attr);
 
 	///
-	AttribType::Enum idToAttribType(uint16_t id);
+	BGFX_SHARED_LIB_API AttribType::Enum idToAttribType(uint16_t id);
 
 	///
-	int32_t write(bx::WriterI* _writer, const bgfx::VertexDecl& _decl, bx::Error* _err = NULL);
+	BGFX_SHARED_LIB_API int32_t write(bx::WriterI* _writer, const bgfx::VertexDecl& _decl, bx::Error* _err = NULL);
 
 	///
-	int32_t read(bx::ReaderI* _reader, bgfx::VertexDecl& _decl, bx::Error* _err = NULL);
+	BGFX_SHARED_LIB_API int32_t read(bx::ReaderI* _reader, bgfx::VertexDecl& _decl, bx::Error* _err = NULL);
 
 } // namespace bgfx
 


### PR DESCRIPTION
This is my first time using GitHub/Git and doing a pull request, double check I'm doing this all correctly.

Changes:
These changes export the C++ API functions to allow building all the examples with --with-shared-lib.
Only the static bgfx lib is included in the solution for static builds and bgfx-shared-lib for shared(DLL) builds.

I don't know if I got all the public symbols exported, but all the examples build and any future exports should be easy to add.
