### PR TITLE
Partial fix for broken independent blend on DX11

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -2666,7 +2666,9 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 		{
 			_state &= BGFX_D3D11_BLEND_STATE_MASK;
 
-			const uint64_t hash = _state;
+			const uint64_t hash = !!( BGFX_STATE_BLEND_INDEPENDENT & _state ) ?
+				_state | uint64_t( _rgba ) << 36  // NOTE: dropping the top bits of _rgba on the floor here!
+				: _state;
 			ID3D11BlendState* bs = m_blendStateCache.find(hash);
 			if (NULL == bs)
 			{


### PR DESCRIPTION
I noticed that the DX11 renderer is broken when it comes to using independent (per render target) blending. The blendStateCache was being indexed solely with _state, which only contains the information about blending for render target 0. As a partial fix, I tried adding in some of the bits from _rgba (missing the top 4 bits though).

This seems to fix the OIT example on DX11. Before this change, the OIT example had visible differences between "separate" and "independent" modes, and there isn't supposed to be any difference. The difference goes away with this fix.