### PR TITLE
Added UserCallbacks, this allows to execute code from the renderthread.

### DIFF
--- a/examples/07-callback/callback.cpp
+++ b/examples/07-callback/callback.cpp
@@ -365,6 +365,16 @@ private:
 	uint32_t m_maxBlocks;
 };
 
+void TestCallbackFromRenderThread(void *ptr)
+{
+  if ((void*)0xDEADBEEF != ptr)
+  {
+    dbgPrintf("Invalid call...");
+    abort();
+  }
+  dbgPrintf("TestCallbackFromRenderThrea %x", ptr);
+}
+
 int _main_(int _argc, char** _argv)
 {
 	Args args(_argc, _argv);
@@ -496,6 +506,11 @@ int _main_(int _argc, char** _argv)
 		{
 			bgfx::saveScreenShot("temp/frame150");
 		}
+
+    if (175 == frame)
+    {
+      bgfx::userCallback(TestCallbackFromRenderThread, (void*)0xDEADBEEF);
+    }
 
 		// Advance to next frame. Rendering thread will be kicked to
 		// process submitted rendering primitives.

--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -2769,6 +2769,21 @@ namespace bgfx
 	///
 	void saveScreenShot(const char* _filePath);
 
+  /// UserCallback Interface
+  typedef void (*UserCallback_I)(void*);
+
+	/// Adds an user callback command to be executed from the render thread
+	///
+	/// @param[in] _callback
+	/// @param[in] _user_data
+	///
+	/// @remarks
+  ///   This call 
+	///
+	/// @attention C99 equivalent is `bgfx_user_callback`.
+	///
+	void userCallback(UserCallback_I _callback, void *_user_data = NULL);
+
 } // namespace bgfx
 
 #endif // BGFX_H_HEADER_GUARD

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -846,4 +846,7 @@ BGFX_C_API void bgfx_blit_frame_buffer(uint8_t _id, bgfx_texture_handle_t _dst, 
 /**/
 BGFX_C_API void bgfx_save_screen_shot(const char* _filePath);
 
+/**/
+BGFX_C_API void bgfx_user_callback(void (*_callback)(void*), void* _user_data);
+
 #endif // BGFX_C99_H_HEADER_GUARD

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2346,6 +2346,17 @@ namespace bgfx
 				}
 				break;
 
+			case CommandBuffer::UserCallback:
+				{
+          UserCallback_I cb;
+          void *user_data;
+					_cmdbuf.read(cb);
+					_cmdbuf.read(user_data);
+          BX_CHECK(user_data, "Invalid Callback");
+          cb(user_data);
+				}
+				break;
+
 			case CommandBuffer::UpdateViewName:
 				{
 					uint8_t id;
@@ -3649,6 +3660,12 @@ error:
 		BGFX_CHECK_MAIN_THREAD();
 		s_ctx->saveScreenShot(_filePath);
 	}
+
+	void userCallback(UserCallback_I _callback, void *_user_data)
+  {
+		BGFX_CHECK_MAIN_THREAD();
+    s_ctx->userCallback(_callback, _user_data);
+  }
 } // namespace bgfx
 
 #include <bgfx/c99/bgfx.h>
@@ -4573,6 +4590,12 @@ BGFX_C_API void bgfx_save_screen_shot(const char* _filePath)
 {
 	bgfx::saveScreenShot(_filePath);
 }
+
+BGFX_C_API void bgfx_user_callback(void (*_callback)(void*),void* _user_data)
+{
+	bgfx::userCallback(_callback, _user_data);
+}
+
 
 BGFX_C_API bgfx_render_frame_t bgfx_render_frame()
 {

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -627,6 +627,7 @@ namespace bgfx
 			DestroyUniform,
 			ReadTexture,
 			SaveScreenShot,
+      UserCallback,
 		};
 
 		void write(const void* _data, uint32_t _size)
@@ -3447,6 +3448,13 @@ namespace bgfx
 			uint16_t len = (uint16_t)strlen(_filePath)+1;
 			cmdbuf.write(len);
 			cmdbuf.write(_filePath, len);
+		}
+
+		BGFX_API_FUNC(void userCallback(UserCallback_I _callback, void *_user_data) )
+		{
+			CommandBuffer& cmdbuf = getCommandBuffer(CommandBuffer::UserCallback);
+			cmdbuf.write(_callback);
+			cmdbuf.write(_user_data);
 		}
 
 		BGFX_API_FUNC(void setPaletteColor(uint8_t _index, const float _rgba[4]) )


### PR DESCRIPTION
In case you need to execute custom code from the render thread, we can now queue
a command with a callback and a pointer to be executed by the render thread.