### PR TITLE
Moves additional bgfx nanovg functions to a separate header file.

### DIFF
--- a/examples/common/nanovg/nanovg.h
+++ b/examples/common/nanovg/nanovg.h
@@ -19,6 +19,8 @@
 #ifndef NANOVG_H
 #define NANOVG_H
 
+#include "nanovg_bgfx.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -597,12 +599,6 @@ struct NVGparams {
 	void (*renderDelete)(void* uptr);
 };
 typedef struct NVGparams NVGparams;
-
-namespace bx { struct AllocatorI; }
-
-NVGcontext* nvgCreate(int edgeaa, unsigned char _viewId, bx::AllocatorI* _allocator = NULL);
-void nvgViewId(struct NVGcontext* ctx, unsigned char _viewId);
-void nvgDelete(struct NVGcontext* ctx);
 
 // Constructor and destructor, called by the render back-end.
 NVGcontext* nvgCreateInternal(NVGparams* params);

--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -1088,6 +1088,10 @@ error:
 	return NULL;
 }
 
+NVGcontext* nvgCreate(int edgeaa, unsigned char _viewId) {
+  return nvgCreate(edgeaa, _viewId, NULL);
+}
+
 void nvgViewId(struct NVGcontext* ctx, unsigned char _viewId)
 {
 	struct NVGparams* params = nvgInternalParams(ctx);

--- a/examples/common/nanovg/nanovg_bgfx.h
+++ b/examples/common/nanovg/nanovg_bgfx.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2011-2016 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#ifndef NANOVG_BGFX_H_HEADER_GUARD
+#define NANOVG_BGFX_H_HEADER_GUARD
+
+namespace bx { struct AllocatorI; }
+
+struct NVGcontext;
+
+NVGcontext* nvgCreate(int edgeaa, unsigned char _viewId, bx::AllocatorI* _allocator);
+NVGcontext* nvgCreate(int edgeaa, unsigned char _viewId);
+void nvgViewId(struct NVGcontext* ctx, unsigned char _viewId);
+void nvgDelete(struct NVGcontext* ctx);
+
+#endif // NANOVG_BGFX_H_HEADER_GUARD


### PR DESCRIPTION
This commit moves the additional nanovg functions for bgfx to a separate header file, so it is possible to compile the original nanovg  source files with bgfx in a custom build environment.