### PR TITLE
Adds iOS device's Retina screen support for nanovg.

### DIFF
--- a/examples/common/entry/entry_ios.mm
+++ b/examples/common/entry/entry_ios.mm
@@ -312,7 +312,7 @@ static	void* m_device = NULL;
 
 	[m_window makeKeyAndVisible];
 
-	//float scaleFactor = [[UIScreen mainScreen] scale]; // should use this, but ui is too small on ipad retina
+	//float scaleFactor = [[UIScreen mainScreen] scale]; // should use this, but needs to further pass the value to the `nvgBeginFrame()` call's `devicePixelRatio` parameter in `ExampleNanoVG` class' `update()` method so it can actually work properly.
 	float scaleFactor = 1.0f;
 	[m_view setContentScaleFactor: scaleFactor ];
 

--- a/examples/common/nanovg/nanovg.cpp
+++ b/examples/common/nanovg/nanovg.cpp
@@ -339,7 +339,7 @@ void nvgBeginFrame(NVGcontext* ctx, int windowWidth, int windowHeight, float dev
 
 	nvg__setDevicePixelRatio(ctx, devicePixelRatio);
 
-	ctx->params.renderViewport(ctx->params.userPtr, windowWidth, windowHeight);
+	ctx->params.renderViewport(ctx->params.userPtr, windowWidth, windowHeight, devicePixelRatio);
 
 	ctx->drawCallCount = 0;
 	ctx->fillTriCount = 0;

--- a/examples/common/nanovg/nanovg.h
+++ b/examples/common/nanovg/nanovg.h
@@ -590,7 +590,7 @@ struct NVGparams {
 	int (*renderDeleteTexture)(void* uptr, int image);
 	int (*renderUpdateTexture)(void* uptr, int image, int x, int y, int w, int h, const unsigned char* data);
 	int (*renderGetTextureSize)(void* uptr, int image, int* w, int* h);
-	void (*renderViewport)(void* uptr, int width, int height);
+	void (*renderViewport)(void* uptr, int width, int height, float devicePixelRatio);
 	void (*renderCancel)(void* uptr);
 	void (*renderFlush)(void* uptr);
 	void (*renderFill)(void* uptr, NVGpaint* paint, NVGscissor* scissor, float fringe, const float* bounds, const NVGpath* paths, int npaths);

--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -545,12 +545,12 @@ namespace
 		gl->th = handle;
 	}
 
-	static void nvgRenderViewport(void* _userPtr, int width, int height)
+	static void nvgRenderViewport(void* _userPtr, int width, int height, float devicePixelRatio)
 	{
 		struct GLNVGcontext* gl = (struct GLNVGcontext*)_userPtr;
 		gl->view[0] = (float)width;
 		gl->view[1] = (float)height;
-		bgfx::setViewRect(gl->m_viewId, 0, 0, width, height);
+		bgfx::setViewRect(gl->m_viewId, 0, 0, width * devicePixelRatio, height * devicePixelRatio);
 	}
 
 	static void fan(uint32_t _start, uint32_t _count)


### PR DESCRIPTION
This commit fixes the bug that the bgfx does not respect the `devicePixelRatio` parameter passed to nanovg's `nvgBeginFrame()` function. The problem is caused by the `bgfx::setViewRect()` call defined in the `nvgRenderViewport()` function, as it should take size in consideration of the `devicePixelRatio` value.

However, this commit does not fix nanovg's example app because currently there is no easy way to pass the scale value to the `ExampleNanoVG::update()` method as it calls `nvgBeginFrame()`.

PS. I also requested a pull request for forwarding the `devicePixelRatio` parameter in the original `nanovg` project and it's already merged. https://github.com/memononen/nanovg/pull/297