### PR TITLE
Allows to change the `opaque` property of `CAEAGLLayer`.

### DIFF
--- a/src/glcontext_eagl.mm
+++ b/src/glcontext_eagl.mm
@@ -27,7 +27,7 @@ namespace bgfx { namespace gl
 		{
 			_layer.contentsScale = [UIScreen mainScreen].scale;
 
-			_layer.opaque = true;
+			_layer.opaque = [_layer.style valueForKey:@"opaque"] == nil ? true : [[_layer.style valueForKey:@"opaque"] boolValue];
 
 			_layer.drawableProperties = [NSDictionary dictionaryWithObjectsAndKeys
 											: [NSNumber numberWithBool:false]
@@ -158,7 +158,7 @@ namespace bgfx { namespace gl
 
 		BX_UNUSED(_width, _height);
 		CAEAGLLayer* layer = (CAEAGLLayer*)g_platformData.nwh;
-		layer.opaque = true;
+		layer.opaque = [layer.style valueForKey:@"opaque"] == nil ? true : [[layer.style valueForKey:@"opaque"] boolValue];
 
 		layer.drawableProperties = [NSDictionary dictionaryWithObjectsAndKeys
 										: [NSNumber numberWithBool:false]


### PR DESCRIPTION
This commit gives custom `CAEAGLLayer` instance a chance to set the `opaque` property through the `style` property. Currently, the `GlContext` implementation for `CAEAGLLayer` always sets the layer's `opaque` property to `true` explicitly no matter what the original value is. Though setting the layer as opaque does help for performance, there are times this option should be turned off by decision. Now the `opaque` property is respected if setting in the `style` dictionary.