### PR TITLE
Implements nanovg's framebuffer helper functions.

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.h
+++ b/examples/common/nanovg/nanovg_bgfx.h
@@ -6,13 +6,47 @@
 #ifndef NANOVG_BGFX_H_HEADER_GUARD
 #define NANOVG_BGFX_H_HEADER_GUARD
 
+#include "bgfx/bgfx.h"
+
 namespace bx { struct AllocatorI; }
 
 struct NVGcontext;
 
+struct NVGLUframebuffer {
+  NVGcontext* ctx;
+  bgfx::FrameBufferHandle handle;
+  int image;
+  uint8_t viewId;
+};
+typedef struct NVGLUframebuffer NVGLUframebuffer;
+
 NVGcontext* nvgCreate(int edgeaa, unsigned char _viewId, bx::AllocatorI* _allocator);
 NVGcontext* nvgCreate(int edgeaa, unsigned char _viewId);
-void nvgViewId(struct NVGcontext* ctx, unsigned char _viewId);
 void nvgDelete(struct NVGcontext* ctx);
+void nvgState(struct NVGcontext* ctx, uint64_t state);
+uint8_t nvgViewId(struct NVGcontext* ctx);
+void nvgViewId(struct NVGcontext* ctx, unsigned char _viewId);
+
+// Helper functions to create bgfx framebuffer to render to.
+// Example:
+//		float scale = 2;
+//		NVGLUframebuffer* fb = nvgluCreateFramebuffer(ctx, 100 * scale, 100 * scale, 0);
+//		nvgluBindFramebuffer(fb);
+//		nvgBeginFrame(ctx, 100, 100, scale);
+//		// renders anything offscreen
+//		nvgEndFrame(ctx);
+//		nvgluBindFramebuffer(NULL);
+//
+//		// Pastes the framebuffer rendering.
+//		nvgBeginFrame(ctx, 1024, 768, scale);
+//		NVGpaint paint = nvgImagePattern(ctx, 0, 0, 100, 100, 0, fb->image, 1);
+//		nvgBeginPath(ctx);
+//		nvgRect(ctx, 0, 0, 100, 100);
+//		nvgFillPaint(ctx, paint);
+//		nvgFill(ctx);
+//		nvgEndFrame(ctx);
+NVGLUframebuffer* nvgluCreateFramebuffer(NVGcontext* ctx, int width, int height, int imageFlags);
+void nvgluBindFramebuffer(NVGLUframebuffer* framebuffer);
+void nvgluDeleteFramebuffer(NVGLUframebuffer* framebuffer);
 
 #endif // NANOVG_BGFX_H_HEADER_GUARD


### PR DESCRIPTION
This commit ports nanovg's helper functions for rendering stuff in framebuffer defined in `nanovg_gl_utils.h`. Also, a new `nvgState()` function is created for bgfx backend so it is possible to blend between framebuffers, which feature is long requested but not yet supported in original nanovg. The `nvgState()` function can be called between `nvgBeginFrame()` and `nvgEndFrame()`.

Example:

    float scale = 2;
    NVGLUframebuffer* fb = nvgluCreateFramebuffer(ctx, 100 * scale, 100 * scale, 0);
    nvgluBindFramebuffer(fb);
    nvgBeginFrame(ctx, 100, 100, scale);
    // renders anything offscreen
    nvgEndFrame(ctx);
    nvgluBindFramebuffer(NULL);

    // Pastes the framebuffer rendering.
    nvgBeginFrame(ctx, 1024, 768, scale);
    NVGpaint paint = nvgImagePattern(ctx, 0, 0, 100, 100, 0, fb->image, 1);
    nvgBeginPath(ctx);
    nvgRect(ctx, 0, 0, 100, 100);
    nvgFillPaint(ctx, paint);
    nvgFill(ctx);
    nvgEndFrame(cox);
