### PR TITLE
metal: synchronize textures with READ flag

### DIFF
--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -87,6 +87,16 @@ namespace bgfx { namespace mtl
 				 destinationSlice:_destinationSlice destinationLevel:_destinationLevel destinationOrigin:_destinationOrigin];
 		}
 
+		void synchronizeTexture(id<MTLTexture> _texture, NSUInteger _slice, NSUInteger _level)
+		{
+			[m_obj synchronizeTexture:_texture slice:_slice level:_level];
+		}
+
+		void synchronizeResource(id<MTLResource> _resource)
+		{
+			[m_obj synchronizeResource:_resource];
+		}
+
 		void endEncoding()
 		{
 			[m_obj endEncoding];

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3023,16 +3023,23 @@ namespace bgfx { namespace mtl
 						uint32_t width     = bx::uint32_min(srcWidth,  dstWidth);
 						uint32_t height    = bx::uint32_min(srcHeight, dstHeight);
 						uint32_t depth     = bx::uint32_min(srcDepth,  dstDepth);
+						bool     readBack  = !!(dst.m_flags & BGFX_TEXTURE_READ_BACK);
 
 						if ( MTLTextureType3D == src.m_ptr.textureType())
 						{
 							m_blitCommandEncoder.copyFromTexture(src.m_ptr, 0, 0, MTLOriginMake(blit.m_srcX, blit.m_srcY, blit.m_srcZ), MTLSizeMake(width, height, bx::uint32_imax(depth, 1)),
 																 dst.m_ptr, 0, 0, MTLOriginMake(blit.m_dstX, blit.m_dstY, blit.m_dstZ));
+							if (readBack) {
+								m_blitCommandEncoder.synchronizeResource(dst.m_ptr);
+							}
 						}
 						else
 						{
 							m_blitCommandEncoder.copyFromTexture(src.m_ptr, blit.m_srcZ, blit.m_srcMip, MTLOriginMake(blit.m_srcX, blit.m_srcY, 0), MTLSizeMake(width, height, 1),
 																 dst.m_ptr, blit.m_dstZ, blit.m_dstMip, MTLOriginMake(blit.m_dstX, blit.m_dstY, 0));
+							if (readBack) {
+								m_blitCommandEncoder.synchronizeTexture(dst.m_ptr, 0, blit.m_dstMip);
+							}
 						}
 					}
 

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3029,7 +3029,7 @@ namespace bgfx { namespace mtl
 						{
 							m_blitCommandEncoder.copyFromTexture(src.m_ptr, 0, 0, MTLOriginMake(blit.m_srcX, blit.m_srcY, blit.m_srcZ), MTLSizeMake(width, height, bx::uint32_imax(depth, 1)),
 																 dst.m_ptr, 0, 0, MTLOriginMake(blit.m_dstX, blit.m_dstY, blit.m_dstZ));
-							if (readBack) {
+							if (m_macOS11Runtime &&readBack) {
 								m_blitCommandEncoder.synchronizeResource(dst.m_ptr);
 							}
 						}
@@ -3037,7 +3037,7 @@ namespace bgfx { namespace mtl
 						{
 							m_blitCommandEncoder.copyFromTexture(src.m_ptr, blit.m_srcZ, blit.m_srcMip, MTLOriginMake(blit.m_srcX, blit.m_srcY, 0), MTLSizeMake(width, height, 1),
 																 dst.m_ptr, blit.m_dstZ, blit.m_dstMip, MTLOriginMake(blit.m_dstX, blit.m_dstY, 0));
-							if (readBack) {
+							if (m_macOS11Runtime && readBack) {
 								m_blitCommandEncoder.synchronizeTexture(dst.m_ptr, 0, blit.m_dstMip);
 							}
 						}


### PR DESCRIPTION
Synchronize textures with read back flag. 

example-30-picking now works for Metal renderer