### PR TITLE
improve inter-operability by exposing dbgTextPrintfVargs API

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -1114,6 +1114,19 @@ namespace bgfx
 	///
 	void dbgTextPrintf(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, ...);
 
+	/// Print into internal debug text character-buffer (VGA-compatible text mode).
+	///
+	/// @param[in] _x    X position from top-left.
+	/// @param[in] _y    Y position from top-left.
+	/// @param[in] _attr Color palette. Where top 4-bits represent index of background, and bottom
+	///   4-bits represent foreground color from standard VGA text palette.
+	/// @param[in] _format `printf` style format.
+	/// @param[in] _argList additional arguments for format string
+	///
+	/// @attention C99 equivalent is `bgfx_dbg_text_vprintf`.
+	///
+	void dbgTextPrintfVargs(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, va_list _argList);
+
 	/// Draw image into internal debug text buffer.
 	///
 	/// @param[in] _x      X position from top-left.

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -566,6 +566,9 @@ BGFX_C_API void bgfx_dbg_text_clear(uint8_t _attr, bool _small);
 BGFX_C_API void bgfx_dbg_text_printf(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, ...);
 
 /**/
+BGFX_C_API void bgfx_dbg_text_vprintf(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, va_list _argList);
+
+/**/
 BGFX_C_API void bgfx_dbg_text_image(uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height, const void* _data, uint16_t _pitch);
 
 /**/

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -3954,6 +3954,11 @@ BGFX_C_API void bgfx_dbg_text_printf(uint16_t _x, uint16_t _y, uint8_t _attr, co
 	va_end(argList);
 }
 
+BGFX_C_API void bgfx_dbg_text_vprintf(uint16_t _x, uint16_t _y, uint8_t _attr, const char* _format, va_list _argList)
+{
+	bgfx::dbgTextPrintfVargs(_x, _y, _attr, _format, _argList);
+}
+
 BGFX_C_API void bgfx_dbg_text_image(uint16_t _x, uint16_t _y, uint16_t _width, uint16_t _height, const void* _data, uint16_t _pitch)
 {
 	bgfx::dbgTextImage(_x, _y, _width, _height, _data, _pitch);


### PR DESCRIPTION
Expose debug API using `va_list`, which allows usage in Swift