### PR TITLE
Usable GLFW entry backend

### DIFF
--- a/examples/common/entry/entry_glfw.cpp
+++ b/examples/common/entry/entry_glfw.cpp
@@ -412,7 +412,7 @@ namespace entry
 
 			while (!glfwWindowShouldClose(m_windows[0]))
 			{
-				glfwPollEvents();
+				glfwWaitEvents();
 
 				for (uint32_t ii = 0; ii < ENTRY_CONFIG_MAX_GAMEPADS; ++ii)
 				{
@@ -670,11 +670,13 @@ namespace entry
 
 	const Event* poll()
 	{
+		glfwPostEmptyEvent();
 		return s_ctx.m_eventQueue.poll();
 	}
 
 	const Event* poll(WindowHandle _handle)
 	{
+		glfwPostEmptyEvent();
 		return s_ctx.m_eventQueue.poll(_handle);
 	}
 
@@ -694,6 +696,7 @@ namespace entry
 		msg->m_title = _title;
 		msg->m_handle.idx = s_ctx.m_windowAlloc.alloc();
 		s_ctx.m_msgs.push(msg);
+		glfwPostEmptyEvent();
 		return msg->m_handle;
 	}
 
@@ -702,6 +705,7 @@ namespace entry
 		Msg* msg = new Msg(GLFW_WINDOW_DESTROY);
 		msg->m_handle = _handle;
 		s_ctx.m_msgs.push(msg);
+		glfwPostEmptyEvent();
 	}
 
 	void setWindowPos(WindowHandle _handle, int32_t _x, int32_t _y)
@@ -711,6 +715,7 @@ namespace entry
 		msg->m_y = _y;
 		msg->m_handle = _handle;
 		s_ctx.m_msgs.push(msg);
+		glfwPostEmptyEvent();
 	}
 
 	void setWindowSize(WindowHandle _handle, uint32_t _width, uint32_t _height)
@@ -720,6 +725,7 @@ namespace entry
 		msg->m_height = _height;
 		msg->m_handle = _handle;
 		s_ctx.m_msgs.push(msg);
+		glfwPostEmptyEvent();
 	}
 
 	void setWindowTitle(WindowHandle _handle, const char* _title)
@@ -728,6 +734,7 @@ namespace entry
 		msg->m_title = _title;
 		msg->m_handle = _handle;
 		s_ctx.m_msgs.push(msg);
+		glfwPostEmptyEvent();
 	}
 
 	void toggleWindowFrame(WindowHandle _handle)
@@ -735,6 +742,7 @@ namespace entry
 		Msg* msg = new Msg(GLFW_WINDOW_TOGGLE_FRAME);
 		msg->m_handle = _handle;
 		s_ctx.m_msgs.push(msg);
+		glfwPostEmptyEvent();
 	}
 
 	void toggleFullscreen(WindowHandle _handle)
@@ -742,6 +750,7 @@ namespace entry
 		Msg* msg = new Msg(GLFW_WINDOW_TOGGLE_FULL_SCREEN);
 		msg->m_handle = _handle;
 		s_ctx.m_msgs.push(msg);
+		glfwPostEmptyEvent();
 	}
 
 	void setMouseLock(WindowHandle _handle, bool _lock)
@@ -750,6 +759,7 @@ namespace entry
 		msg->m_value = _lock;
 		msg->m_handle = _handle;
 		s_ctx.m_msgs.push(msg);
+		glfwPostEmptyEvent();
 	}
 
 	int32_t MainThreadEntry::threadFunc(void* _userData)


### PR DESCRIPTION
This fills in the GLFW implementation of the example entry code. It requires GLFW 3.2 and has been tested with VS2015 and MinGW-w64, with Clang on OS X and GCC on Linux.

I think it includes all features except `ENTRY_WINDOW_FLAG_FRAME`. Context creation has been left entirely to bgfx, analogous to the SDL2 backend. The gamepad input is currently a terrible hack implemented on top of the joystick API. I didn't putting a lot of effort into it now as I'm about to add a real gamepad API for 3.3, which solves the problem properly.

The second commit is an optional optimization, kept separate for now as it may introduce some gamepad input lag.