### PR TITLE
Added flag to control building examples.

### DIFF
--- a/makefile
+++ b/makefile
@@ -39,17 +39,17 @@ clean: ## Clean all intermediate files.
 	@mkdir .build
 
 projgen: ## Generate project files for all configurations.
-	$(GENIE) --with-tools --with-shared-lib vs2008
-	$(GENIE) --with-tools --with-shared-lib vs2010
-	$(GENIE) --with-tools --with-shared-lib vs2012
-	$(GENIE) --with-tools --with-shared-lib vs2013
-	$(GENIE) --with-tools --with-shared-lib vs2015
-	$(GENIE) --with-tools --with-shared-lib --gcc=mingw-gcc gmake
-	$(GENIE) --with-tools --with-shared-lib --gcc=linux-gcc gmake
-	$(GENIE) --with-tools --with-shared-lib --gcc=osx gmake
-	$(GENIE) --with-tools --with-shared-lib --xcode=osx xcode4
-	$(GENIE) --with-tools --with-shared-lib --xcode=ios xcode4
-	$(GENIE) --with-shared-lib --gcc=freebsd gmake
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2008
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2010
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2012
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2013
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2015
+	$(GENIE) --with-tools --with-examples --with-shared-lib --gcc=mingw-gcc gmake
+	$(GENIE) --with-tools --with-examples --with-shared-lib --gcc=linux-gcc gmake
+	$(GENIE) --with-tools --with-examples --with-shared-lib --gcc=osx gmake
+	$(GENIE) --with-tools --with-examples --with-shared-lib --xcode=osx xcode4
+	$(GENIE) --with-tools --with-examples --with-shared-lib --xcode=ios xcode4
+	$(GENIE) --with-examples --with-shared-lib --gcc=freebsd gmake
 
 	$(GENIE) --gcc=android-arm gmake
 	$(GENIE) --gcc=android-mips gmake
@@ -95,7 +95,7 @@ asmjs-release: .build/projects/gmake-asmjs ## Build - Emscripten Release
 asmjs: asmjs-debug asmjs-release ## Build - Emscripten Debug and Release
 
 .build/projects/gmake-linux:
-	$(GENIE) --with-tools --with-shared-lib --gcc=linux-gcc gmake
+	$(GENIE) --with-tools --with-examples --with-shared-lib --gcc=linux-gcc gmake
 linux-debug32: .build/projects/gmake-linux ## Build - Linux x86 Debug
 	$(MAKE) -R -C .build/projects/gmake-linux config=debug32
 linux-release32: .build/projects/gmake-linux ## Build - Linux x86 Release
@@ -107,7 +107,7 @@ linux-release64: .build/projects/gmake-linux ## Build - Linux x64 Release
 linux: linux-debug32 linux-release32 linux-debug64 linux-release64 ## Build - Linux x86/x64 Debug and Release
 
 .build/projects/gmake-freebsd:
-	$(GENIE) --with-tools --with-shared-lib --gcc=freebsd gmake
+	$(GENIE) --with-tools --with-examples --with-shared-lib --gcc=freebsd gmake
 freebsd-debug32: .build/projects/gmake-freebsd ## Build - FreeBSD x86 Debug
 	$(MAKE) -R -C .build/projects/gmake-freebsd config=debug32
 freebsd-release32: .build/projects/gmake-freebsd ## Build - FreeBSD x86 Release
@@ -119,7 +119,7 @@ freebsd-release64: .build/projects/gmake-freebsd ## Build - FreeBSD x86 Release
 freebsd: freebsd-debug32 freebsd-release32 freebsd-debug64 freebsd-release64 ## Build - FreeBSD x86/x64 Debug and Release
 
 .build/projects/gmake-mingw-gcc:
-	$(GENIE) --with-tools --with-shared-lib --gcc=mingw-gcc gmake
+	$(GENIE) --with-tools --with-examples --with-shared-lib --gcc=mingw-gcc gmake
 mingw-gcc-debug32: .build/projects/gmake-mingw-gcc ## Build - MinGW GCC x86 Debug
 	$(MAKE) -R -C .build/projects/gmake-mingw-gcc config=debug32
 mingw-gcc-release32: .build/projects/gmake-mingw-gcc ## Build - MinGW GCC x86 Release
@@ -143,7 +143,7 @@ mingw-clang-release64: .build/projects/gmake-mingw-clang ## Build - MinGW Clang 
 mingw-clang: mingw-clang-debug32 mingw-clang-release32 mingw-clang-debug64 mingw-clang-release64 ## Build - MinGW Clang x86/x64 Debug and Release
 
 .build/projects/vs2008:
-	$(GENIE) --with-tools --with-shared-lib vs2008
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2008
 vs2008-debug32: .build/projects/vs2008 ## Build - VS2008 x86 Debug
 	devenv .build/projects/vs2008/bgfx.sln /Build "Debug|Win32"
 vs2008-release32: .build/projects/vs2008 ## Build - VS2008 x86 Release
@@ -155,7 +155,7 @@ vs2008-release64: .build/projects/vs2008 ## Build - VS2008 x64 Release
 vs2008: vs2008-debug32 vs2008-release32 vs2008-debug64 vs2008-release64 ## Build - VS2008 x86/x64 Debug and Release
 
 .build/projects/vs2010:
-	$(GENIE) --with-tools --with-shared-lib vs2010
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2010
 vs2010-debug32: .build/projects/vs2010 ## Build - VS2010 x86 Debug
 	devenv .build/projects/vs2010/bgfx.sln /Build "Debug|Win32"
 vs2010-release32: .build/projects/vs2010 ## Build - VS2010 x86 Release
@@ -167,7 +167,7 @@ vs2010-release64: .build/projects/vs2010 ## Build - VS2010 x64 Release
 vs2010: vs2010-debug32 vs2010-release32 vs2010-debug64 vs2010-release64 ## Build - VS2010 x86/x64 Debug and Release
 
 .build/projects/vs2012:
-	$(GENIE) --with-tools --with-shared-lib vs2012
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2012
 vs2012-debug32: .build/projects/vs2012 ## Build - VS2012 x86 Debug
 	devenv .build/projects/vs2012/bgfx.sln /Build "Debug|Win32"
 vs2012-release32: .build/projects/vs2012 ## Build - VS2012 x86 Release
@@ -179,7 +179,7 @@ vs2012-release64: .build/projects/vs2012 ## Build - VS2012 x64 Release
 vs2012: vs2012-debug32 vs2012-release32 vs2012-debug64 vs2012-release64 ## Build - VS2012 x86/x64 Debug and Release
 
 .build/projects/vs2013:
-	$(GENIE) --with-tools --with-shared-lib vs2013
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2013
 vs2013-debug32: .build/projects/vs2013 ## Build - VS2013 x86 Debug
 	devenv .build/projects/vs2013/bgfx.sln /Build "Debug|Win32"
 vs2013-release32: .build/projects/vs2013 ## Build - VS2013 x86 Release
@@ -191,7 +191,7 @@ vs2013-release64: .build/projects/vs2013 ## Build - VS2013 x64 Release
 vs2013: vs2013-debug32 vs2013-release32 vs2013-debug64 vs2013-release64 ## Build - VS2013 x86/x64 Debug and Release
 
 .build/projects/vs2015:
-	$(GENIE) --with-tools --with-shared-lib vs2015
+	$(GENIE) --with-tools --with-examples --with-shared-lib vs2015
 vs2015-debug32: .build/projects/vs2015 ## Build - VS2015 x86 Debug
 	devenv .build/projects/vs2015/bgfx.sln /Build "Debug|Win32"
 vs2015-release32: .build/projects/vs2015 ## Build - VS2015 x86 Release
@@ -231,7 +231,7 @@ pnacl-release: .build/projects/gmake-pnacl ## Build - Portable Native Client Rel
 pnacl: pnacl-debug pnacl-release ## Build - Portable Native Client Debug and Release
 
 .build/projects/gmake-osx:
-	$(GENIE) --with-tools --with-shared-lib --gcc=osx gmake
+	$(GENIE) --with-tools --with-examples --with-shared-lib --gcc=osx gmake
 osx-debug32: .build/projects/gmake-osx ## Build - OSX x86 Debug
 	$(MAKE) -C .build/projects/gmake-osx config=debug32
 osx-release32: .build/projects/gmake-osx ## Build - OSX x86 Release

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -43,6 +43,11 @@ newoption {
 	description = "Enable building tools.",
 }
 
+newoption {
+	trigger = "with-examples",
+	description = "Enable building examples.",
+}
+
 solution "bgfx"
 	configurations {
 		"Debug",
@@ -355,48 +360,51 @@ end
 
 dofile "bgfx.lua"
 
+-- Always build 'example-common' because 'texturev' uses it as well.
 group "examples"
 dofile "example-common.lua"
 
 group "libs"
 bgfxProject("", "StaticLib", {})
 
-group "examples"
-exampleProject("00-helloworld")
-exampleProject("01-cubes")
-exampleProject("02-metaballs")
-exampleProject("03-raymarch")
-exampleProject("04-mesh")
-exampleProject("05-instancing")
-exampleProject("06-bump")
-exampleProject("07-callback")
-exampleProject("08-update")
-exampleProject("09-hdr")
-exampleProject("10-font")
-exampleProject("11-fontsdf")
-exampleProject("12-lod")
-exampleProject("13-stencil")
-exampleProject("14-shadowvolumes")
-exampleProject("15-shadowmaps-simple")
-exampleProject("16-shadowmaps")
-exampleProject("17-drawstress")
-exampleProject("18-ibl")
-exampleProject("19-oit")
-exampleProject("20-nanovg")
-exampleProject("21-deferred")
-exampleProject("22-windows")
-exampleProject("23-vectordisplay")
-exampleProject("24-nbody")
-exampleProject("26-occlusion")
-exampleProject("27-terrain")
-exampleProject("28-wireframe")
-exampleProject("29-debugdraw")
-exampleProject("30-picking")
-exampleProject("31-rsm")
+if _OPTIONS["with-examples"] then
+	group "examples"
+	exampleProject("00-helloworld")
+	exampleProject("01-cubes")
+	exampleProject("02-metaballs")
+	exampleProject("03-raymarch")
+	exampleProject("04-mesh")
+	exampleProject("05-instancing")
+	exampleProject("06-bump")
+	exampleProject("07-callback")
+	exampleProject("08-update")
+	exampleProject("09-hdr")
+	exampleProject("10-font")
+	exampleProject("11-fontsdf")
+	exampleProject("12-lod")
+	exampleProject("13-stencil")
+	exampleProject("14-shadowvolumes")
+	exampleProject("15-shadowmaps-simple")
+	exampleProject("16-shadowmaps")
+	exampleProject("17-drawstress")
+	exampleProject("18-ibl")
+	exampleProject("19-oit")
+	exampleProject("20-nanovg")
+	exampleProject("21-deferred")
+	exampleProject("22-windows")
+	exampleProject("23-vectordisplay")
+	exampleProject("24-nbody")
+	exampleProject("26-occlusion")
+	exampleProject("27-terrain")
+	exampleProject("28-wireframe")
+	exampleProject("29-debugdraw")
+	exampleProject("30-picking")
+	exampleProject("31-rsm")
 
--- C99 source doesn't compile under WinRT settings
-if not premake.vstudio.iswinrt() then
-	exampleProject("25-c99")
+	-- C99 source doesn't compile under WinRT settings
+	if not premake.vstudio.iswinrt() then
+		exampleProject("25-c99")
+	end
 end
 
 if _OPTIONS["with-shared-lib"] then


### PR DESCRIPTION
This PR adds a new flag to `genie.lua` called `--with-examples` and uses it to control whether the example binaries are built or not. It also changes the default options in `makefile` to include this flag, such that the default behavior of `bgfx` compilation is unchanged.

This allows users who are building with CI systems or as part of a larger automated build process to avoid having to compile examples each time they build `bgfx`.  They can instead use `genie` directly to configure their project to build without examples.

I think this change matches the style of your other configuration options, @bkaradzic, but please feel free to correct it if not.