### PR TITLE
Add ability to rebuild an existing ProgramHandle

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -1518,6 +1518,41 @@ namespace bgfx
 		, bool _destroyShader = false
 		);
 
+	/// Links an existing program with a new VS/FS pair
+	///
+	/// @param[in] _handle existing Program.
+	/// @param[in] _vsh Vertex shader.
+	/// @param[in] _fsh Fragment shader.
+	/// @param[in] _destroyShaders If true, shaders will be destroyed when
+	///   program is destroyed.
+	/// @returns True if vertex shader output and fragment shader input
+	///   are matching, otherwise false
+	///
+	/// @attention C99 equivalent is `bgfx_link_program`.
+	///
+	bool linkProgram(
+		  ProgramHandle _handle
+		, ShaderHandle _vsh
+		, ShaderHandle _fsh
+		, bool _destroyShaders = false
+		);
+
+	/// Links an existing program with a new compute shader
+	///
+	/// @param[in] _handle existing Program.
+	/// @param[in] _csh Vertex shader.
+	/// @param[in] _destroyShaders If true, shaders will be destroyed when
+	///   program is destroyed.
+	/// @returns True if the shader and program handles are valid.
+	///
+	/// @attention C99 equivalent is `bgfx_link_compute_program`.
+	///
+	bool linkProgram(
+		  ProgramHandle _handle
+		, ShaderHandle _csh
+		, bool _destroyShaders = false
+		);
+
 	/// Destroy program.
 	///
 	/// @attention C99 equivalent is `bgfx_destroy_program`.

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2143,6 +2143,7 @@ namespace bgfx
 				break;
 
 			case CommandBuffer::DestroyProgram:
+			case CommandBuffer::DestroyProgramForRelink:
 				{
 					ProgramHandle handle;
 					_cmdbuf.read(handle);
@@ -2868,6 +2869,18 @@ error:
 	{
 		BGFX_CHECK_MAIN_THREAD();
 		return s_ctx->createProgram(_csh, _destroyShader);
+	}
+
+	bool linkProgram(ProgramHandle _handle, ShaderHandle _vsh, ShaderHandle _fsh, bool _destroyShader)
+	{
+		BGFX_CHECK_MAIN_THREAD();
+		return s_ctx->linkProgram(_handle, _vsh, _fsh, _destroyShader);
+	}
+
+	bool linkProgram(ProgramHandle _handle, ShaderHandle _csh, bool _destroyShader)
+	{
+		BGFX_CHECK_MAIN_THREAD();
+		return s_ctx->linkProgram(_handle, _csh, _destroyShader);
 	}
 
 	void destroyProgram(ProgramHandle _handle)

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -628,6 +628,7 @@ namespace bgfx
 			CreateFrameBuffer,
 			CreateUniform,
 			UpdateViewName,
+			DestroyProgramForRelink,
 			End,
 			RendererShutdownEnd,
 			DestroyVertexDecl,
@@ -3089,6 +3090,112 @@ namespace bgfx
 			}
 
 			return handle;
+		}
+
+		BGFX_API_FUNC(bool linkProgram(ProgramHandle _handle, ShaderHandle _vsh, ShaderHandle _fsh, bool _destroyShaders) )
+		{
+			if (!isValid(_handle))
+			{
+				BX_WARN(false, "Program is invlid (handle %d).", _handle.idx);
+				return false;
+			}
+
+			if (!isValid(_vsh)
+			||  !isValid(_fsh))
+			{
+				BX_WARN(false, "Vertex/fragment shader is invalid (vsh: %d, fsh: %d).", _vsh.idx, _fsh.idx);
+				return false;
+			}
+
+			const ShaderRef& vsr = m_shaderRef[_vsh.idx];
+			const ShaderRef& fsr = m_shaderRef[_fsh.idx];
+			if (vsr.m_hash != fsr.m_hash)
+			{
+				BX_WARN(false, "Vertex shader output doesn't match fragment shader input.");
+				return false;
+			}
+
+			ProgramRef& pr = m_programRef[_handle.idx];
+			CommandBuffer& destroyCmdbuf = getCommandBuffer(CommandBuffer::DestroyProgramForRelink);
+			destroyCmdbuf.write(_handle);
+
+			shaderDecRef(pr.m_vsh);
+			if (isValid(pr.m_fsh))
+			{
+				shaderDecRef(pr.m_fsh);
+			}
+
+			m_programHashMap.removeByHandle(_handle.idx);
+
+			shaderIncRef(_vsh);
+			shaderIncRef(_fsh);
+			pr.m_vsh = _vsh;
+			pr.m_fsh = _fsh;
+
+			const uint32_t key = uint32_t(_fsh.idx<<16)|_vsh.idx;
+			bool ok = m_programHashMap.insert(key, _handle.idx);
+			BX_CHECK(ok, "Program already exists (key: %x, handle: %3d)!", key, _handle.idx); BX_UNUSED(ok);
+
+			CommandBuffer& cmdbuf = getCommandBuffer(CommandBuffer::CreateProgram);
+			cmdbuf.write(_handle);
+			cmdbuf.write(_vsh);
+			cmdbuf.write(_fsh);
+
+			if (_destroyShaders)
+			{
+				shaderTakeOwnership(_vsh);
+				shaderTakeOwnership(_fsh);
+			}
+
+			return true;
+		}
+
+		BGFX_API_FUNC(bool linkProgram(ProgramHandle _handle, ShaderHandle _csh, bool _destroyShaders) )
+		{
+			if (!isValid(_handle))
+			{
+				BX_WARN(false, "Program is invlid (handle %d).", _handle.idx);
+				return false;
+			}
+
+			if (!isValid(_csh))
+			{
+				BX_WARN(false, "Compute shader is invalid (csh: %d).", _csh.idx);
+				return false;
+			}
+
+			ProgramRef& pr = m_programRef[_handle.idx];
+			CommandBuffer& destroyCmdbuf = getCommandBuffer(CommandBuffer::DestroyProgramForRelink);
+			destroyCmdbuf.write(_handle);
+
+			shaderDecRef(pr.m_vsh);
+			if (isValid(pr.m_fsh))
+			{
+				shaderDecRef(pr.m_fsh);
+			}
+
+			m_programHashMap.removeByHandle(_handle.idx);
+
+			shaderIncRef(_csh);
+			pr.m_vsh = _csh;
+			ShaderHandle fsh = BGFX_INVALID_HANDLE;
+			pr.m_fsh = fsh;
+
+			const uint32_t key = uint32_t(_csh.idx);
+			bool ok = m_programHashMap.insert(key, _handle.idx);
+			BX_CHECK(ok, "Program already exists (key: %x, handle: %3d)!", key, _handle.idx); BX_UNUSED(ok);
+
+			CommandBuffer& cmdbuf = getCommandBuffer(CommandBuffer::CreateProgram);
+			cmdbuf.write(_handle);
+			cmdbuf.write(_csh);
+			cmdbuf.write(fsh);
+
+			if (_destroyShaders)
+			{
+				shaderTakeOwnership(_csh);
+			}
+
+			return true;
 		}
 
 		BGFX_API_FUNC(void destroyProgram(ProgramHandle _handle) )


### PR DESCRIPTION
bgfx::linkProgram will release any attached shaders, then
attach and relink the program with the provided shader
handles.

This allows materials to be reloaded without the program
handle index changing. Keeping the same index allows higher
level engine functionality to remove a layer of indirection
when dealing with "reloadable" materials.