### PR TITLE
Do not render VR mirror texture is the headset is not rendering

### DIFF
--- a/src/hmd_ovr.cpp
+++ b/src/hmd_ovr.cpp
@@ -197,7 +197,10 @@ namespace bgfx
 		}
 
 		// perform mirror texture blit right after the entire frame is submitted to HMD
-		m_mirror->blit(m_hmd);
+		if (result != ovrSuccess_NotVisible)
+		{
+			m_mirror->blit(m_hmd);
+		}
 
 		m_hmdToEyeOffset[0] = m_erd[0].HmdToEyeOffset;
 		m_hmdToEyeOffset[1] = m_erd[1].HmdToEyeOffset;


### PR DESCRIPTION
DX11 will signal an error on the mirror present if the compositor
is not serving the application frames to the hardware.