### PR TITLE
Combine OVRBufferI and OVRMirrorI into a single interface

### DIFF
--- a/src/hmd_ovr.h
+++ b/src/hmd_ovr.h
@@ -27,29 +27,26 @@
 
 namespace bgfx
 {
-	// single eye buffer
-	struct OVRBufferI
+	// render data for both eyes and mirrored output
+	struct BX_NO_VTABLE OVRRenderI
 	{
-		virtual ~OVRBufferI() {};
-		virtual void create(const ovrSession& _session, int _eyeIdx, int _msaaSamples) = 0;
+		virtual ~OVRRenderI() = 0;
+		virtual void create(const ovrSession& _session, int _msaaSamples, int _mirrorWidth, int _mirrorHeight) = 0;
 		virtual void destroy(const ovrSession& _session) = 0;
-		virtual void render(const ovrSession& _session) = 0;
-		virtual void postRender(const ovrSession& _session) = 0;
-		ovrSizei m_eyeTextureSize;
-		ovrTextureSwapChain m_textureSwapChain;
-	};
+		virtual void preReset(const ovrSession& _session) = 0;
+		virtual void startEyeRender(const ovrSession& _session, int _eyeIdx) = 0;
+		virtual void postRender(const ovrSession& _session, int _eyeIdx) = 0;
+		virtual void blitMirror(const ovrSession& _session) = 0;
 
-	// mirrored window output
-	struct OVRMirrorI
-	{
-		virtual ~OVRMirrorI() {};
-		virtual void create(const ovrSession& _session, int windowWidth, int windowHeight) = 0;
-		virtual void destroy(const ovrSession& _session) = 0;
-		virtual void blit(const ovrSession& _session) = 0;
-
-		ovrMirrorTexture     m_mirrorTexture;
+		ovrSizei m_eyeTextureSize[2];
+		ovrTextureSwapChain m_textureSwapChain[2];
+		ovrMirrorTexture m_mirrorTexture;
 		ovrMirrorTextureDesc m_mirrorTextureDesc;
 	};
+
+	inline OVRRenderI::~OVRRenderI()
+	{
+	}
 
 	struct OVR
 	{
@@ -93,8 +90,7 @@ namespace bgfx
 		ovrPosef    m_pose[2];
 		ovrVector3f m_hmdToEyeOffset[2];
 		ovrSizei    m_hmdSize;
-		OVRBufferI *m_eyeBuffers[2];
-		OVRMirrorI *m_mirror;
+		OVRRenderI *m_render;
 		uint64_t    m_frameIndex;
 		double      m_sensorSampleTime;
 		bool m_enabled;

--- a/src/renderer_d3d11.h
+++ b/src/renderer_d3d11.h
@@ -61,26 +61,23 @@ BX_PRAGMA_DIAGNOSTIC_POP()
 namespace bgfx { namespace d3d11
 {
 #if BGFX_CONFIG_USE_OVR
-	struct OVRBufferD3D11 : public OVRBufferI
+	struct OVRRenderD3D11 : public OVRRenderI
 	{
-		virtual void create(const ovrSession& _session, int _eyeIdx, int _msaaSamples) BX_OVERRIDE;
-		virtual void destroy(const ovrSession& _session) BX_OVERRIDE;
-		virtual void render(const ovrSession& _session) BX_OVERRIDE;
-		virtual void postRender(const ovrSession& _session) BX_OVERRIDE;
+		OVRRenderD3D11();
+		virtual void create(const ovrSession& _session, int _msaaSamples, int _mirrorWidth, int _mirrorHeight);
+		virtual void destroy(const ovrSession& _session);
+		virtual void preReset(const ovrSession& _session);
+		virtual void startEyeRender(const ovrSession& _session, int _eyeIdx);
+		virtual void postRender(const ovrSession& _session, int _eyeIdx);
+		virtual void blitMirror(const ovrSession& _session);
 
-		ID3D11RenderTargetView* m_eyeRtv[4];
-		ID3D11DepthStencilView* m_depthBuffer;
-		ID3D11Texture2D* m_msaaTexture;
-		ID3D11ShaderResourceView* m_msaaSv;
-		ID3D11RenderTargetView* m_msaaRtv;
+		ID3D11RenderTargetView* m_eyeRtv[2][4];
+		ID3D11DepthStencilView* m_depthBuffer[2];
+		ID3D11Texture2D* m_msaaTexture[2];
+		ID3D11ShaderResourceView* m_msaaSv[2];
+		ID3D11RenderTargetView* m_msaaRtv[2];
 	};
 
-	struct OVRMirrorD3D11 : public OVRMirrorI
-	{
-		virtual void create(const ovrSession& _session, int _width, int _height) BX_OVERRIDE;
-		virtual void destroy(const ovrSession& session) BX_OVERRIDE;
-		virtual void blit(const ovrSession& session) BX_OVERRIDE;
-	};
 #endif // BGFX_CONFIG_USE_OVR
 
 	struct BufferD3D11

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -951,29 +951,25 @@ namespace bgfx
 namespace bgfx { namespace gl
 {
 #if BGFX_CONFIG_USE_OVR
-	struct OVRBufferGL : public OVRBufferI
+	struct OVRRenderGL : public OVRRenderI
 	{
-		virtual void create(const ovrSession& _session, int _eyeIdx, int _msaaSamples) BX_OVERRIDE;
-		virtual void destroy(const ovrSession& _session) BX_OVERRIDE;
-		virtual void render(const ovrSession& _session) BX_OVERRIDE;
-		virtual void postRender(const ovrSession& _sesion) BX_OVERRIDE;
+		OVRRenderGL();
+		virtual void create(const ovrSession& _session, int _msaaSamples, int _mirrorWidth, int _mirrorHeight);
+		virtual void destroy(const ovrSession& _session);
+		virtual void preReset(const ovrSession& _session);
+		virtual void startEyeRender(const ovrSession& _session, int _eyeIdx);
+		virtual void postRender(const ovrSession& _session, int _eyeIdx);
+		virtual void blitMirror(const ovrSession& _session);
 
-		GLuint m_eyeFbo;
-		GLuint m_eyeTexId;
-		GLuint m_depthBuffer;
-		GLuint m_msaaEyeFbo;
-		GLuint m_msaaEyeTexId;
-		GLuint m_msaaDepthBuffer;
-	};
-
-	struct OVRMirrorGL : public OVRMirrorI
-	{
-		virtual void create(const ovrSession& _session, int _width, int _height) BX_OVERRIDE;
-		virtual void destroy(const ovrSession& _session) BX_OVERRIDE;
-		virtual void blit(const ovrSession& _session) BX_OVERRIDE;
-
+		GLuint m_eyeFbo[2];
+		GLuint m_eyeTexId[2];
+		GLuint m_depthBuffer[2];
+		GLuint m_msaaEyeFbo[2];
+		GLuint m_msaaEyeTexId[2];
+		GLuint m_msaaDepthBuffer[2];
 		GLuint m_mirrorFBO;
 	};
+
 #endif // BGFX_CONFIG_USE_OVR
 
 	void dumpExtensions(const char* _extensions);


### PR DESCRIPTION
Simplify the renderer interface for VR to separate the OVR
implementation from the overall HMD foundation.

Part of merging OpenVR back upstream.