### PR TITLE
Fix opengl OVR texture lifetime issues

### DIFF
--- a/src/hmd_ovr.h
+++ b/src/hmd_ovr.h
@@ -30,6 +30,7 @@ namespace bgfx
 	// render data for both eyes and mirrored output
 	struct BX_NO_VTABLE OVRRenderI
 	{
+		OVRRenderI();
 		virtual ~OVRRenderI() = 0;
 		virtual void create(const ovrSession& _session, int _msaaSamples, int _mirrorWidth, int _mirrorHeight) = 0;
 		virtual void destroy(const ovrSession& _session) = 0;
@@ -43,6 +44,12 @@ namespace bgfx
 		ovrMirrorTexture m_mirrorTexture;
 		ovrMirrorTextureDesc m_mirrorTextureDesc;
 	};
+
+	inline OVRRenderI::OVRRenderI()
+		: m_mirrorTexture(NULL)
+	{
+		memset(&m_textureSwapChain, 0, sizeof(m_textureSwapChain));
+	}
 
 	inline OVRRenderI::~OVRRenderI()
 	{

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -3610,12 +3610,6 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 	}
 
 #if BGFX_CONFIG_USE_OVR
-	OVRRenderD3D11::OVRRenderD3D11()
-	{
-		m_mirrorTexture = NULL;
-		memset(m_textureSwapChain, 0, sizeof(m_textureSwapChain));
-	}
-
 	void OVRRenderD3D11::create(const ovrSession& _session, int _msaaSamples, int _mirrorWidth, int _mirrorHeight)
 	{
 		ovrHmdDesc hmdDesc = ovr_GetHmdDesc(_session);

--- a/src/renderer_d3d11.h
+++ b/src/renderer_d3d11.h
@@ -63,7 +63,6 @@ namespace bgfx { namespace d3d11
 #if BGFX_CONFIG_USE_OVR
 	struct OVRRenderD3D11 : public OVRRenderI
 	{
-		OVRRenderD3D11();
 		virtual void create(const ovrSession& _session, int _msaaSamples, int _mirrorWidth, int _mirrorHeight);
 		virtual void destroy(const ovrSession& _session);
 		virtual void preReset(const ovrSession& _session);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3545,7 +3545,7 @@ namespace bgfx { namespace gl
 		ovr_GetTextureSwapChainCurrentIndex(_session, m_textureSwapChain[_eyeIdx], &curIndex);
 		ovr_GetTextureSwapChainBufferGL(_session, m_textureSwapChain[_eyeIdx], curIndex, &m_eyeTexId[_eyeIdx]);
 
-		if (0 != m_msaaEyeFbo)
+		if (0 != m_msaaEyeFbo[_eyeIdx])
 		{
 			GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_msaaEyeFbo[_eyeIdx]) );
 			GL_CHECK(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, m_msaaEyeTexId[_eyeIdx], 0) );


### PR DESCRIPTION
Clear mirror and eye textures of OVRRenderI at startup
instead of in the individual renderer interfaces