### PR TITLE
Add a new platform agnostic bgfx::VR internal class

### DIFF
--- a/src/hmd.cpp
+++ b/src/hmd.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2011-2016 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#include "hmd.h"
+
+namespace bgfx
+{
+	VR::VR()
+		: m_framesUntilReconnect(0)
+		, m_enabled(false)
+	{
+	}
+
+	void VR::init(VRImplI* _impl)
+	{
+		if (!_impl)
+		{
+			return;
+		}
+
+		if (!_impl->init())
+		{
+			return;
+		}
+
+		m_impl = _impl;
+		m_impl->connect(&m_desc);
+		if (!m_impl->isConnected())
+		{
+			connectFailed();
+			return;
+		}
+
+		m_hmdSize.m_w = m_desc.m_eyeSize[0].m_w + m_desc.m_eyeSize[1].m_w;
+		m_hmdSize.m_h = bx::uint32_max(m_desc.m_eyeSize[0].m_h, m_desc.m_eyeSize[1].m_h);
+	}
+
+	void VR::shutdown()
+	{
+		if (!m_impl)
+		{
+			return;
+		}
+
+		m_impl->destroySwapChain();
+		if (m_impl->isConnected())
+		{
+			m_impl->disconnect();
+		}
+
+		m_impl->shutdown();
+		m_impl = NULL;
+		m_enabled = false;
+	}
+
+	void VR::renderEyeStart(uint8_t _eye, Rect* _viewport)
+	{
+		BX_CHECK(m_enabled, "VR::renderEyeStart called while not enabled - render usage error");
+
+		_viewport->m_x      = 0;
+		_viewport->m_y      = 0;
+		_viewport->m_width  = m_desc.m_eyeSize[_eye].m_w;
+		_viewport->m_height = m_desc.m_eyeSize[_eye].m_h;
+
+		m_impl->renderEyeStart(m_desc, _eye);
+	}
+
+	void VR::recenter()
+	{
+		if (m_impl)
+		{
+			m_impl->recenter();
+		}
+	}
+
+	void VR::preReset()
+	{
+		if (m_impl)
+		{
+			m_impl->destroyMirror();
+		}
+
+		m_enabled = false;
+	}
+
+	void VR::postReset(int _msaaSamples, int _mirrorWidth, int _mirrorHeight)
+	{
+		if (m_impl && m_impl->createSwapChain(m_desc, _msaaSamples, _mirrorWidth, _mirrorHeight))
+		{
+			m_enabled = true;
+		}
+	}
+
+	void VR::flip()
+	{
+		if (!m_impl || !m_enabled)
+		{
+			return;
+		}
+		else if (!m_impl->isConnected() && !tryReconnect())
+		{
+			return;
+		}
+
+		if (!m_impl->submitSwapChain(m_desc))
+		{
+			m_impl->destroySwapChain();
+			m_impl->disconnect();
+			return;
+		}
+	}
+
+	void VR::swap(HMD& _hmd)
+	{
+		_hmd.flags = BGFX_HMD_NONE;
+
+		if (!m_impl)
+		{
+			return;
+		}
+
+		_hmd.flags = BGFX_HMD_DEVICE_RESOLUTION;
+		_hmd.deviceWidth = m_desc.m_deviceSize.m_w;
+		_hmd.deviceHeight = m_desc.m_deviceSize.m_h;
+		_hmd.width = m_hmdSize.m_w;
+		_hmd.height = m_hmdSize.m_h;
+
+		if (!m_impl->updateTracking(_hmd))
+		{
+			m_impl->destroySwapChain();
+			m_impl->disconnect();
+		}
+
+		if (!m_impl->isConnected())
+		{
+			return;
+		}
+
+		for (int eye = 0; eye < 2; ++eye)
+		{
+			_hmd.eye[eye].fov[0] = m_desc.m_eyeFov[eye].m_up;
+			_hmd.eye[eye].fov[1] = m_desc.m_eyeFov[eye].m_down;
+			_hmd.eye[eye].fov[2] = m_desc.m_eyeFov[eye].m_left;
+			_hmd.eye[eye].fov[3] = m_desc.m_eyeFov[eye].m_right;
+		}
+
+		m_impl->updateInput(_hmd);
+		if (m_enabled)
+		{
+			_hmd.flags |= BGFX_HMD_RENDERING;
+		}
+	}
+
+	bool VR::tryReconnect()
+	{
+		if (!m_impl)
+		{
+			return false;
+		}
+
+		BX_CHECK(!m_impl->isConnected(), "VR::tryReconnect called when already connected. Usage error");
+
+		--m_framesUntilReconnect;
+		if (m_framesUntilReconnect > 0)
+		{
+			return false;
+		}
+
+		m_framesUntilReconnect = 90;
+		m_impl->connect(&m_desc);
+		if (!m_impl->isConnected())
+		{
+			connectFailed();
+			return false;
+		}
+
+		m_hmdSize.m_w = m_desc.m_eyeSize[0].m_w + m_desc.m_eyeSize[1].m_w;
+		m_hmdSize.m_h = bx::uint32_max(m_desc.m_eyeSize[0].m_h, m_desc.m_eyeSize[1].m_h);
+		return true;
+	}
+
+	void VR::connectFailed()
+	{
+		// sane defaults
+		m_desc.m_deviceSize.m_w = 2160;
+		m_desc.m_deviceSize.m_h = 1200;
+		m_desc.m_deviceType = 0;
+		m_desc.m_refreshRate = 90.0f;
+		m_desc.m_neckOffset[0] = 0.0805f;
+		m_desc.m_neckOffset[1] = 0.075f;
+
+		for (int eye = 0; eye < 2; ++eye)
+		{
+			m_desc.m_eyeFov[eye].m_up = 1.32928634f;
+			m_desc.m_eyeFov[eye].m_down = 1.32928634f;
+		}
+		m_desc.m_eyeFov[0].m_left = 1.05865765f;
+		m_desc.m_eyeFov[0].m_right = 1.09236801f;
+		m_desc.m_eyeFov[1].m_left = 1.09236801f;
+		m_desc.m_eyeFov[1].m_right = 1.05865765f;
+	}
+
+} // namesapce bgfx

--- a/src/hmd.h
+++ b/src/hmd.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2011-2016 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#ifndef BGFX_HMD_H_HEADER_GUARD
+#define BGFX_HMD_H_HEADER_GUARD
+
+#include "bgfx_p.h"
+
+namespace bgfx
+{
+	struct VRSize
+	{
+		uint32_t m_w;
+		uint32_t m_h;
+	};
+
+	struct VRFovTan
+	{
+		float m_up;
+		float m_down;
+		float m_left;
+		float m_right;
+	};
+
+	struct VRDesc
+	{
+		uint64_t m_adapterLuid;
+		uint32_t m_deviceType;
+		float m_refreshRate;
+		VRSize m_deviceSize;
+		VRSize m_eyeSize[2];
+		VRFovTan m_eyeFov[2];
+		float m_neckOffset[2];
+	};
+
+	struct BX_NO_VTABLE VRImplI
+	{
+		virtual ~VRImplI() = 0;
+
+		virtual bool init() = 0;
+		virtual void shutdown() = 0;
+		virtual void connect(VRDesc* _desc) = 0;
+		virtual void disconnect() = 0;
+		virtual bool isConnected() const = 0;
+
+		virtual bool updateTracking(HMD& _hmd) = 0;
+		virtual void updateInput(HMD& _hmd) = 0;
+		virtual void recenter() = 0;
+
+		virtual bool createSwapChain(const VRDesc& _desc, int _msaaSamples, int _mirrorWidth, int _mirrorHeight);
+		virtual void destroySwapChain() = 0;
+		virtual void destroyMirror() = 0;
+		virtual void renderEyeStart(const VRDesc& _desc, uint8_t _eye) = 0;
+		virtual bool submitSwapChain(const VRDesc& _desc) = 0;
+	};
+
+	inline VRImplI::~VRImplI()
+	{
+	}
+
+	class VR
+	{
+	public:
+		VR();
+
+		void init(VRImplI* _impl);
+		void shutdown();
+
+		bool isInitialized() const
+		{
+			return NULL != m_impl;
+		}
+
+		bool isEnabled() const
+		{
+			return m_enabled;
+		}
+
+		void renderEyeStart(uint8_t _eye, Rect* _viewport);
+		void recenter();
+
+		void preReset();
+		void postReset(int _msaaSamples, int _mirrorWidth, int _mirrorHeight);
+		void flip();
+		void swap(HMD& _hmd);
+
+	private:
+		bool tryReconnect();
+		void connectFailed();
+
+		VRDesc m_desc;
+		VRSize m_hmdSize;
+		VRImplI* m_impl;
+		uint32_t m_framesUntilReconnect;
+		bool m_enabled;
+	};
+
+} // namespace bgfx
+
+#endif // BGFX_HMD_H_HEADER_GUARD

--- a/src/renderer_d3d11.h
+++ b/src/renderer_d3d11.h
@@ -32,7 +32,7 @@ BX_PRAGMA_DIAGNOSTIC_POP()
 #include "renderer.h"
 #include "renderer_d3d.h"
 #include "shader_dxbc.h"
-#include "hmd_ovr.h"
+#include "hmd.h"
 #include "hmd_openvr.h"
 #include "debug_renderdoc.h"
 
@@ -60,25 +60,6 @@ BX_PRAGMA_DIAGNOSTIC_POP()
 
 namespace bgfx { namespace d3d11
 {
-#if BGFX_CONFIG_USE_OVR
-	struct OVRRenderD3D11 : public OVRRenderI
-	{
-		virtual void create(const ovrSession& _session, int _msaaSamples, int _mirrorWidth, int _mirrorHeight);
-		virtual void destroy(const ovrSession& _session);
-		virtual void preReset(const ovrSession& _session);
-		virtual void startEyeRender(const ovrSession& _session, int _eyeIdx);
-		virtual void postRender(const ovrSession& _session, int _eyeIdx);
-		virtual void blitMirror(const ovrSession& _session);
-
-		ID3D11RenderTargetView* m_eyeRtv[2][4];
-		ID3D11DepthStencilView* m_depthBuffer[2];
-		ID3D11Texture2D* m_msaaTexture[2];
-		ID3D11ShaderResourceView* m_msaaSv[2];
-		ID3D11RenderTargetView* m_msaaRtv[2];
-	};
-
-#endif // BGFX_CONFIG_USE_OVR
-
 	struct BufferD3D11
 	{
 		BufferD3D11()

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -107,7 +107,7 @@ typedef uint64_t GLuint64;
 #endif // BGFX_CONFIG_RENDERER_OPENGL
 
 #include "renderer.h"
-#include "hmd_ovr.h"
+#include "hmd.h"
 #include "hmd_openvr.h"
 #include "debug_renderdoc.h"
 
@@ -950,28 +950,6 @@ namespace bgfx
 
 namespace bgfx { namespace gl
 {
-#if BGFX_CONFIG_USE_OVR
-	struct OVRRenderGL : public OVRRenderI
-	{
-		OVRRenderGL();
-		virtual void create(const ovrSession& _session, int _msaaSamples, int _mirrorWidth, int _mirrorHeight);
-		virtual void destroy(const ovrSession& _session);
-		virtual void preReset(const ovrSession& _session);
-		virtual void startEyeRender(const ovrSession& _session, int _eyeIdx);
-		virtual void postRender(const ovrSession& _session, int _eyeIdx);
-		virtual void blitMirror(const ovrSession& _session);
-
-		GLuint m_eyeFbo[2];
-		GLuint m_eyeTexId[2];
-		GLuint m_depthBuffer[2];
-		GLuint m_msaaEyeFbo[2];
-		GLuint m_msaaEyeTexId[2];
-		GLuint m_msaaDepthBuffer[2];
-		GLuint m_mirrorFBO;
-	};
-
-#endif // BGFX_CONFIG_USE_OVR
-
 	void dumpExtensions(const char* _extensions);
 
 	const char* glEnumName(GLenum _enum);


### PR DESCRIPTION
The new platform agnositic class bgfx::VR manages the
functionality that is shared across the various VR platforms.

The individual platform renderers no longer need
to interface with the internal VR tpyes (OVRRenderI) directly

This greatly simplifies the OVR object's surface area which
is now provided by the VRImplI interface. bgfx::VR now manages
core lifecycle issues of the headset.

The notable renderer API changes are the separation of sensor
sampling and rendering. We need these separate so we can control
the timing (later commit) of camera sampling with finer granularity
than at the start of the video frame.