### PR TITLE
Fixed order of fields in bgfx_caps_t not matching bgfx::Caps

### DIFF
--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -418,11 +418,11 @@ typedef struct bgfx_caps
     uint16_t maxViews;
     uint8_t  maxFBAttachments;
     uint8_t  numGPUs;
+    uint16_t vendorId;
+    uint16_t deviceId;
     bool     homogeneousDepth;
     bool     originBottomLeft;
 
-    uint16_t vendorId;
-    uint16_t deviceId;
     bgfx_caps_gpu_t gpu[4];
 
     uint16_t formats[BGFX_TEXTURE_FORMAT_COUNT];


### PR DESCRIPTION
c4fa560 added two new fields to different positions in the C++ and C99 headers