### PR TITLE
Allow user-provided ovrSession via PlatformData

### DIFF
--- a/include/bgfx/bgfxplatform.h
+++ b/include/bgfx/bgfxplatform.h
@@ -51,6 +51,7 @@ namespace bgfx
 		void* context;      //!< GL context, or D3D device.
 		void* backBuffer;   //!< GL backbuffer, or D3D render target view.
 		void* backBufferDS; //!< Backbuffer depth/stencil.
+		void* session;      //!< ovrSession, for Oculus SDK
 	};
 
 	/// Set platform data.

--- a/include/bgfx/c99/bgfxplatform.h
+++ b/include/bgfx/c99/bgfxplatform.h
@@ -39,6 +39,7 @@ typedef struct bgfx_platform_data
     void* context;
     void* backBuffer;
     void* backBufferDS;
+    void* session;
 
 } bgfx_platform_data_t;
 

--- a/src/hmd.h
+++ b/src/hmd.h
@@ -26,7 +26,6 @@ namespace bgfx
 
 	struct VRDesc
 	{
-		uint64_t m_adapterLuid;
 		uint32_t m_deviceType;
 		float m_refreshRate;
 		VRSize m_deviceSize;


### PR DESCRIPTION
Without the ovrSession, you are unable to call any functions in LibOVR (and there's a lot in there which BGFX *shouldn't* cover).

This also removes the unused adapter LUID from the VRDesc struct.

Usage:
```cpp
bgfx::PlatformData pd;
pd.session = NULL;
// [...]
if (OVR_SUCCESS(ovr_Initialize(NULL))) {
	ovrSession session;
	ovrGraphicsLuid luid;
	ovr_Create(&session, &luid);
	pd.session = (void*)session;
}
bgfx::setPlatformData(pd);
// later...
ovr_Shutdown();
```