### PR TITLE
glInvalidateFramebuffer: iOS (iPad Mini 2, iOS 10.0.1) invalid enum work around

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5965,7 +5965,7 @@ namespace bgfx { namespace gl
 		{
 			if ( (BGFX_CLEAR_DISCARD_DEPTH|BGFX_CLEAR_DISCARD_STENCIL) == dsFlags)
 			{
-				buffers[idx++] = GL_DEPTH_STENCIL_ATTACHMENT;
+				buffers[idx++] = GL_DEPTH_ATTACHMENT|GL_STENCIL_ATTACHMENT;
 			}
 			else if (BGFX_CLEAR_DISCARD_DEPTH == dsFlags)
 			{


### PR DESCRIPTION
example-09-hdr asserts on an iPad Mini 2 running iOS 10.0.1 (14A403) with the following message:

`BGFX CHECK glInvalidateFramebuffer(0x8D40, idx, buffers); GL error 0x500: GL_INVALID_ENUM`

Although it's valid according to the spec (OpenGL ES 3.0.4 (August 27, 2014)), Apple's driver isn't happy with the GL_DEPTH_STENCIL_ATTACHMENT enum. I suspect this has something to do with GL_DEPTH_STENCIL_ATTACHMENT not being supported by GL_EXT_discard_framebuffer (glInvalidateFramebuffer's predecessor).

As I've seen other drivers complain and GL_DEPTH_ATTACHMENT|GL_STENCIL_ATTACHMENT is functionality equivalent, I've replaced the enum assignment.