### PR TITLE
Revert "glInvalidateFramebuffer: iOS (iPad Mini 2, iOS 10.0.1) invalid enum work around"

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5982,7 +5982,7 @@ namespace bgfx { namespace gl
 		{
 			if ( (BGFX_CLEAR_DISCARD_DEPTH|BGFX_CLEAR_DISCARD_STENCIL) == dsFlags)
 			{
-				buffers[idx++] = GL_DEPTH_ATTACHMENT|GL_STENCIL_ATTACHMENT;
+				buffers[idx++] = GL_DEPTH_STENCIL_ATTACHMENT;
 			}
 			else if (BGFX_CLEAR_DISCARD_DEPTH == dsFlags)
 			{


### PR DESCRIPTION
Reverts bkaradzic/bgfx#949