### PR TITLE
glInvalidateFramebuffer: iOS (iPad Mini 2, iOS 10.0.1) invalid enum work around (v2)

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5982,7 +5982,8 @@ namespace bgfx { namespace gl
 		{
 			if ( (BGFX_CLEAR_DISCARD_DEPTH|BGFX_CLEAR_DISCARD_STENCIL) == dsFlags)
 			{
-				buffers[idx++] = GL_DEPTH_STENCIL_ATTACHMENT;
+				buffers[idx++] = GL_DEPTH_ATTACHMENT;
+				buffers[idx++] = GL_STENCIL_ATTACHMENT;
 			}
 			else if (BGFX_CLEAR_DISCARD_DEPTH == dsFlags)
 			{


### PR DESCRIPTION
_FYI, this is a corrected version of pull #949, where I'd been a melon and assumed the last glInvalidateFramebuffer() argument was a bitfield like glClearColor()_

example-09-hdr asserts on an iPad Mini 2 running iOS 10.0.1 (14A403) with the following message:

BGFX CHECK glInvalidateFramebuffer(0x8D40, idx, buffers); GL error 0x500: GL_INVALID_ENUM

Although it's valid according to the spec (OpenGL ES 3.0.4 (August 27, 2014)), Apple's driver isn't happy with the GL_DEPTH_STENCIL_ATTACHMENT enum. I suspect this has something to do with GL_DEPTH_STENCIL_ATTACHMENT not being supported by GL_EXT_discard_framebuffer (glInvalidateFramebuffer's predecessor).

I've workaround the issue by passing GL_DEPTH_ATTACHMENT & GL_STENCIL_ATTACHMENT in the attachment enums list separately instead of using GL_DEPTH_STENCIL_ATTACHMENT.

Relevant part of the ES 3.0 spec:

> Note that if a specified attachment has base internal format DEPTH_STENCIL but the attachments list does not include DEPTH_STENCIL_ATTACHMENT **or both DEPTH_ATTACHMENT and STENCIL_ATTACHMENT...**