### PR TITLE
Use m_mz in ButtonPress mouse event instead of 0

### DIFF
--- a/examples/common/entry/entry_x11.cpp
+++ b/examples/common/entry/entry_x11.cpp
@@ -459,7 +459,7 @@ namespace entry
 									m_eventQueue.postMouseEvent(handle
 										, xbutton.x
 										, xbutton.y
-										, 0
+										, m_mz
 										, mb
 										, event.type == ButtonPress
 										);


### PR DESCRIPTION
For consistency with other platforms (Windows, at least)