### PR TITLE
Asm js dxx renderer gl init test texture

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1727,7 +1727,7 @@ namespace bgfx { namespace gl
 						s_textureFilter[TextureFormat::RGBA32F] = linear32F;
 					}
 
-					if (BX_ENABLED(BX_PLATFORM_IOS) )
+					if (BX_ENABLED(BX_PLATFORM_IOS) || BX_ENABLED(BX_PLATFORM_EMSCRIPTEN))
 					{
 						setTextureFormat(TextureFormat::D16,   GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT);
 						setTextureFormat(TextureFormat::D24S8, GL_DEPTH_STENCIL,   GL_DEPTH_STENCIL,   GL_UNSIGNED_INT_24_8);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1181,7 +1181,7 @@ namespace bgfx { namespace gl
 		}
 		else
 		{
-			glTexImage2D(GL_TEXTURE_2D, 0, internalFmt, 16, 16, 0, tfi.m_fmt, tfi.m_type, data);
+			glTexImage2D(GL_TEXTURE_2D, 0, internalFmt, 16, 16, 0, tfi.m_fmt, tfi.m_type, NULL);
 			err |= glGetError();
 			if (_mipmaps)
 			{


### PR DESCRIPTION
This fix AsmJS renderer_gl test of Dxx formats.
If pixels are not NULL we get and INVALID_OPERATION ( see https://github.com/bkaradzic/bgfx/issues/963 ) due to render-only nature of Dxx formats on AsmJS platform.

ps : sorry for log garbage