### PR TITLE
Read pixels for renderer gl

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -1838,6 +1838,17 @@ namespace bgfx
 	///
 	uint32_t readTexture(TextureHandle _handle, void* _data, uint8_t _mip = 0);
 
+  	/// Read back frame buffer pixels content.
+	///
+	/// @param[in] _handle Frame buffer handle.
+	/// @param[in] _data Destination buffer.
+	///
+	/// @returns Frame number when the result will be available. See: `bgfx::frame`.
+	///
+	/// @attention C99 equivalent is `bgfx_read_frame_buffer_pixels`.
+	///
+	uint32_t readPixels(FrameBufferHandle _handle, void* _data);
+    
 	/// Read back texture content.
 	///
 	/// @param[in] _handle Frame buffer handle.

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2251,6 +2251,18 @@ namespace bgfx
 				}
 				break;
 
+            case CommandBuffer::ReadPixels:
+                {
+                    FrameBufferHandle handle;
+                    _cmdbuf.read(handle);
+
+                    void* data;
+                    _cmdbuf.read(data);
+
+                    m_renderCtx->readPixels(handle, data);
+                }
+                break;
+                
 			case CommandBuffer::ResizeTexture:
 				{
 					TextureHandle handle;
@@ -3232,6 +3244,13 @@ error:
 		return s_ctx->readTexture(_handle, _attachment, _data);
 	}
 
+	uint32_t readPixels(FrameBufferHandle _handle, void* _data)
+	{
+		BGFX_CHECK_MAIN_THREAD();
+		BX_CHECK(NULL != _data, "_data can't be NULL");
+		return s_ctx->readPixels(_handle, _data);
+	}
+    
 	FrameBufferHandle createFrameBuffer(uint16_t _width, uint16_t _height, TextureFormat::Enum _format, uint32_t _textureFlags)
 	{
 		_textureFlags |= _textureFlags&BGFX_TEXTURE_RT_MSAA_MASK ? 0 : BGFX_TEXTURE_RT;

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -3257,7 +3257,7 @@ namespace bgfx
 			cmdbuf.write(_mip);
 			return m_frames + 2;
 		}
-        
+
 		BGFX_API_FUNC(uint32_t readTexture(FrameBufferHandle _handle, uint8_t _attachment, void* _data) )
 		{
 			const FrameBufferRef& ref = m_frameBufferRef[_handle.idx];
@@ -3269,9 +3269,9 @@ namespace bgfx
 			return readTexture(textureHandle, _data,0);
 		}
 
-        BGFX_API_FUNC(uint32_t readPixels(FrameBufferHandle _handle, void* _data))
-        {
-            const FrameBufferRef& ref = m_frameBufferRef[_handle.idx];
+		BGFX_API_FUNC(uint32_t readPixels(FrameBufferHandle _handle, void* _data))
+		{
+			const FrameBufferRef& ref = m_frameBufferRef[_handle.idx];
 			BX_CHECK(!ref.m_window, "Can't sample window frame buffer.");
 
 			CommandBuffer& cmdbuf = getCommandBuffer(CommandBuffer::ReadPixels);

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -637,6 +637,7 @@ namespace bgfx
 			DestroyFrameBuffer,
 			DestroyUniform,
 			ReadTexture,
+            ReadPixels,
 			SaveScreenShot,
 		};
 
@@ -2145,6 +2146,7 @@ namespace bgfx
 		virtual void updateTexture(TextureHandle _handle, uint8_t _side, uint8_t _mip, const Rect& _rect, uint16_t _z, uint16_t _depth, uint16_t _pitch, const Memory* _mem) = 0;
 		virtual void updateTextureEnd() = 0;
 		virtual void readTexture(TextureHandle _handle, void* _data, uint8_t _mip) = 0;
+        virtual void readPixels(FrameBufferHandle _handle, void* _data) = 0;
 		virtual void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) = 0;
 		virtual void overrideInternal(TextureHandle _handle, uintptr_t _ptr) = 0;
 		virtual uintptr_t getInternal(TextureHandle _handle) = 0;
@@ -3255,7 +3257,7 @@ namespace bgfx
 			cmdbuf.write(_mip);
 			return m_frames + 2;
 		}
-
+        
 		BGFX_API_FUNC(uint32_t readTexture(FrameBufferHandle _handle, uint8_t _attachment, void* _data) )
 		{
 			const FrameBufferRef& ref = m_frameBufferRef[_handle.idx];
@@ -3265,6 +3267,17 @@ namespace bgfx
 			BGFX_CHECK_HANDLE("readTexture", m_textureHandle, textureHandle);
 
 			return readTexture(textureHandle, _data,0);
+		}
+
+        BGFX_API_FUNC(uint32_t readPixels(FrameBufferHandle _handle, void* _data))
+        {
+            const FrameBufferRef& ref = m_frameBufferRef[_handle.idx];
+			BX_CHECK(!ref.m_window, "Can't sample window frame buffer.");
+
+			CommandBuffer& cmdbuf = getCommandBuffer(CommandBuffer::ReadPixels);
+			cmdbuf.write(_handle);
+			cmdbuf.write(_data);
+			return m_frames + 2;
 		}
 
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips)

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -637,7 +637,7 @@ namespace bgfx
 			DestroyFrameBuffer,
 			DestroyUniform,
 			ReadTexture,
-            ReadPixels,
+			ReadPixels,
 			SaveScreenShot,
 		};
 
@@ -2146,7 +2146,7 @@ namespace bgfx
 		virtual void updateTexture(TextureHandle _handle, uint8_t _side, uint8_t _mip, const Rect& _rect, uint16_t _z, uint16_t _depth, uint16_t _pitch, const Memory* _mem) = 0;
 		virtual void updateTextureEnd() = 0;
 		virtual void readTexture(TextureHandle _handle, void* _data, uint8_t _mip) = 0;
-        virtual void readPixels(FrameBufferHandle _handle, void* _data) = 0;
+		virtual void readPixels(FrameBufferHandle _handle, void* _data) = 0;
 		virtual void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) = 0;
 		virtual void overrideInternal(TextureHandle _handle, uintptr_t _ptr) = 0;
 		virtual uintptr_t getInternal(TextureHandle _handle) = 0;

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -3272,7 +3272,7 @@ namespace bgfx
 		BGFX_API_FUNC(uint32_t readPixels(FrameBufferHandle _handle, void* _data))
 		{
 			const FrameBufferRef& ref = m_frameBufferRef[_handle.idx];
-			BX_CHECK(!ref.m_window, "Can't sample window frame buffer.");
+			BX_CHECK(!ref.m_window, "Can't sample window frame buffer."); BX_UNUSED(ref);
 
 			CommandBuffer& cmdbuf = getCommandBuffer(CommandBuffer::ReadPixels);
 			cmdbuf.write(_handle);

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1867,6 +1867,11 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 
 			m_deviceCtx->Unmap(texture.m_ptr, _mip);
 		}
+        
+        void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+		{
+			BX_WARN(false, "readPixels d3d12 is not implemented.");
+		}
 
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) BX_OVERRIDE
 		{

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1870,6 +1870,7 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 
 		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
+			BX_UNUSED(_handle, _data);
 			BX_WARN(false, "readPixels d3d11 is not implemented.");
 		}
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1870,7 +1870,7 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 
 		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
-			BX_WARN(false, "readPixels d3d12 is not implemented.");
+			BX_WARN(false, "readPixels d3d11 is not implemented.");
 		}
 
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) BX_OVERRIDE

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1867,8 +1867,8 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 
 			m_deviceCtx->Unmap(texture.m_ptr, _mip);
 		}
-        
-        void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+
+		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
 			BX_WARN(false, "readPixels d3d12 is not implemented.");
 		}

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1464,6 +1464,7 @@ namespace bgfx { namespace d3d12
 
 		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
+			BX_UNUSED(_handle, _data);
 			BX_WARN(false, "readPixels d3d12 is not implemented.");
 		}
 

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1462,11 +1462,11 @@ namespace bgfx { namespace d3d12
 			DX_RELEASE(readback, 0);
 		}
 
-        void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
 			BX_WARN(false, "readPixels d3d12 is not implemented.");
 		}
-        
+
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) BX_OVERRIDE
 		{
 			TextureD3D12& texture = m_textures[_handle.idx];

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1462,6 +1462,11 @@ namespace bgfx { namespace d3d12
 			DX_RELEASE(readback, 0);
 		}
 
+        void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+		{
+			BX_WARN(false, "readPixels d3d12 is not implemented.");
+		}
+        
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) BX_OVERRIDE
 		{
 			TextureD3D12& texture = m_textures[_handle.idx];

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1019,6 +1019,11 @@ namespace bgfx { namespace d3d9
 
 			DX_CHECK(texture.m_texture2d->UnlockRect(_mip) );
 		}
+        
+        void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+		{
+			BX_WARN(false, "readPixels d3d12 is not implemented.");
+		}
 
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) BX_OVERRIDE
 		{

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1022,7 +1022,7 @@ namespace bgfx { namespace d3d9
 
 		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
-			BX_WARN(false, "readPixels d3d12 is not implemented.");
+			BX_WARN(false, "readPixels d3d9 is not implemented.");
 		}
 
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) BX_OVERRIDE

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1022,6 +1022,7 @@ namespace bgfx { namespace d3d9
 
 		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
+			BX_UNUSED(_handle, _data);
 			BX_WARN(false, "readPixels d3d9 is not implemented.");
 		}
 

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1019,8 +1019,8 @@ namespace bgfx { namespace d3d9
 
 			DX_CHECK(texture.m_texture2d->UnlockRect(_mip) );
 		}
-        
-        void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+
+		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
 			BX_WARN(false, "readPixels d3d12 is not implemented.");
 		}

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2419,7 +2419,7 @@ namespace bgfx { namespace gl
 			}
 		}
 
-        void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
 		{
 			if (isValid(_handle))
 			{

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1727,7 +1727,7 @@ namespace bgfx { namespace gl
 						s_textureFilter[TextureFormat::RGBA32F] = linear32F;
 					}
 
-					if (BX_ENABLED(BX_PLATFORM_IOS) )
+					if (BX_ENABLED(BX_PLATFORM_IOS) || BX_ENABLED(BX_PLATFORM_EMSCRIPTEN))
 					{
 						setTextureFormat(TextureFormat::D16,   GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT);
 						setTextureFormat(TextureFormat::D24S8, GL_DEPTH_STENCIL,   GL_DEPTH_STENCIL,   GL_UNSIGNED_INT_24_8);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2419,6 +2419,32 @@ namespace bgfx { namespace gl
 			}
 		}
 
+        void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+		{
+			if (isValid(_handle))
+			{
+				uint16_t discardFlags = BGFX_CLEAR_NONE;
+
+				FrameBufferGL& frameBuffer = m_frameBuffers[_handle.idx];
+				uint32_t width = frameBuffer.m_width;
+				uint32_t height = frameBuffer.m_height;
+
+				height = setFrameBuffer(_handle, height, discardFlags);
+
+				if (!BX_ENABLED(BX_PLATFORM_EMSCRIPTEN))
+					GL_CHECK(glReadBuffer(GL_COLOR_ATTACHMENT0));
+                
+				GL_CHECK(glReadPixels(0
+					, 0
+					, width
+					, height
+					, m_readPixelsFmt
+					, GL_UNSIGNED_BYTE
+					, _data
+					));
+			}
+		}
+        
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) BX_OVERRIDE
 		{
 			TextureGL& texture = m_textures[_handle.idx];

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1727,7 +1727,7 @@ namespace bgfx { namespace gl
 						s_textureFilter[TextureFormat::RGBA32F] = linear32F;
 					}
 
-					if (BX_ENABLED(BX_PLATFORM_IOS) || BX_ENABLED(BX_PLATFORM_EMSCRIPTEN))
+					if (BX_ENABLED(BX_PLATFORM_IOS) )
 					{
 						setTextureFormat(TextureFormat::D16,   GL_DEPTH_COMPONENT, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT);
 						setTextureFormat(TextureFormat::D24S8, GL_DEPTH_STENCIL,   GL_DEPTH_STENCIL,   GL_UNSIGNED_INT_24_8);

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -820,6 +820,12 @@ namespace bgfx { namespace mtl
 			retain(m_commandBuffer); //NOTE: keep alive to be useable at 'flip'
 		}
 
+		void readPixels(FrameBufferHandle _handle, void* _data) BX_OVERRIDE
+		{
+			BX_UNUSED(_handle, _data);
+			BX_WARN(false, "readPixels mtl is not implemented.");
+		}
+
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips) BX_OVERRIDE
 		{
 			TextureMtl& texture = m_textures[_handle.idx];


### PR DESCRIPTION
Implementation of readPixels for renderer_gl.
Tested and working on win32 and asmJs platforms.
Other renderers indicate functionality is not implemented.

