### PR TITLE
Use a single render target for VR rendering

### DIFF
--- a/src/hmd.cpp
+++ b/src/hmd.cpp
@@ -58,16 +58,22 @@ namespace bgfx
 		m_enabled = false;
 	}
 
-	void VR::renderEyeStart(uint8_t _eye, Rect* _viewport)
+	void VR::getViewport(uint8_t _eye, Rect* _viewport) const
+	{
+		_viewport->m_width = m_desc.m_eyeSize[_eye].m_w;
+		_viewport->m_x = _eye * (m_desc.m_eyeSize[_eye].m_w + 1);
+		_viewport->m_height = (uint16_t)m_desc.m_eyeSize[_eye].m_h;
+		_viewport->m_y = 0;
+	}
+
+	void VR::makeRenderTargetActive()
 	{
 		BX_CHECK(m_enabled, "VR::renderEyeStart called while not enabled - render usage error");
 
-		_viewport->m_x      = 0;
-		_viewport->m_y      = 0;
-		_viewport->m_width  = uint16_t(m_desc.m_eyeSize[_eye].m_w);
-		_viewport->m_height = uint16_t(m_desc.m_eyeSize[_eye].m_h);
-
-		m_impl->renderEyeStart(m_desc, _eye);
+		if (NULL != m_impl)
+		{
+			m_impl->makeRenderTargetActive(m_desc);
+		}
 	}
 
 	void VR::recenter()

--- a/src/hmd.h
+++ b/src/hmd.h
@@ -51,7 +51,7 @@ namespace bgfx
 		virtual bool createSwapChain(const VRDesc& _desc, int _msaaSamples, int _mirrorWidth, int _mirrorHeight);
 		virtual void destroySwapChain() = 0;
 		virtual void destroyMirror() = 0;
-		virtual void renderEyeStart(const VRDesc& _desc, uint8_t _eye) = 0;
+		virtual void makeRenderTargetActive(const VRDesc& _desc) = 0;
 		virtual bool submitSwapChain(const VRDesc& _desc) = 0;
 	};
 
@@ -77,7 +77,8 @@ namespace bgfx
 			return m_enabled;
 		}
 
-		void renderEyeStart(uint8_t _eye, Rect* _viewport);
+		void getViewport(uint8_t _eye, Rect* _viewport) const;
+		void makeRenderTargetActive();
 		void recenter();
 
 		void preReset();

--- a/src/hmd_ovr.cpp
+++ b/src/hmd_ovr.cpp
@@ -117,13 +117,16 @@ namespace bgfx
 		// build constant layer settings
 		m_renderLayer.Header.Type = ovrLayerType_EyeFov;
 		m_renderLayer.Header.Flags = 0;
-		for (int eye = 0; eye < 2; ++eye)
-		{
-			m_renderLayer.Fov[eye] = hmdDesc.DefaultEyeFov[eye];
-			m_renderLayer.Viewport[eye].Pos.x = 0;
-			m_renderLayer.Viewport[eye].Pos.y = 0;
-			m_renderLayer.Viewport[eye].Size = eyeSize[eye];
-		}
+		m_renderLayer.Fov[0] = hmdDesc.DefaultEyeFov[0];
+		m_renderLayer.Fov[1] = hmdDesc.DefaultEyeFov[1];
+		m_renderLayer.Viewport[0].Pos.x = 0;
+		m_renderLayer.Viewport[0].Pos.y = 0;
+		m_renderLayer.Viewport[0].Size.w = _desc->m_eyeSize[0].m_w;
+		m_renderLayer.Viewport[0].Size.h = _desc->m_eyeSize[0].m_h;
+		m_renderLayer.Viewport[1].Pos.x = _desc->m_eyeSize[0].m_w+1;
+		m_renderLayer.Viewport[1].Pos.y = 0;
+		m_renderLayer.Viewport[1].Size.w = _desc->m_eyeSize[1].m_w;
+		m_renderLayer.Viewport[1].Size.h = _desc->m_eyeSize[1].m_h;
 
 		m_viewScale.HmdSpaceToWorldScaleInMeters = 1.0f;
 		for (int eye = 0; eye < 2; ++eye)

--- a/src/hmd_ovr.h
+++ b/src/hmd_ovr.h
@@ -52,7 +52,7 @@ namespace bgfx
 		virtual bool createSwapChain(const VRDesc& _desc, int _msaaSamples, int _mirrorWidth, int _mirrorHeight) BX_OVERRIDE = 0;
 		virtual void destroySwapChain() BX_OVERRIDE = 0;
 		virtual void destroyMirror() BX_OVERRIDE = 0;
-		virtual void renderEyeStart(const VRDesc& _desc, uint8_t _eye) BX_OVERRIDE = 0;
+		virtual void makeRenderTargetActive(const VRDesc& _desc) BX_OVERRIDE = 0;
 		virtual bool submitSwapChain(const VRDesc& _desc) BX_OVERRIDE = 0;
 
 	protected:


### PR DESCRIPTION
This allows the game to render to a single FB and
pass that into existing post process pipeline.