### PR TITLE
Remove hyphen in shaderc.lua (s/linux-*/linux*/)

### DIFF
--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -226,7 +226,7 @@ project "shaderc"
 		dofile(path.join(BGFX_DIR, "../bgfx-ext/scripts/shaderc.lua") )
 	end
 
-	configuration { "osx or linux-*" }
+	configuration { "osx or linux*" }
 		links {
 			"pthread",
 		}


### PR DESCRIPTION
I assume this is a safe change? My builds on Linux were failing due to pthread not being linked.