### PR TITLE
Fix doc for shaderc

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -710,7 +710,7 @@ namespace bgfx
 			  "\n"
 			  "Options:\n"
 			  "  -f <file path>                Input file path.\n"
-			  "  -i <include path>             Include path (for multiple paths use semicolon).\n"
+			  "  -i <include path>             Include path (for multiple paths use use -i multiple times).\n"
 			  "  -o <file path>                Output file path.\n"
 			  "      --bin2c <file path>       Generate C header file.\n"
 			  "      --depends                 Generate makefile style depends file.\n"


### PR DESCRIPTION
Current help when running shaderc says

```
-i <include path>             Include path (for multiple paths use semicolon).
```

I took this to mean that one should do:

```
shaderc -i path1;path2
```

when in reality it's 

```
shaderc -i path1 -i path2
```

so I changed the text to 
```
-i <include path>             Include path (for multiple paths use use -i multiple times).
```

There's probably better language, but this is at least not misleading.