### PR TITLE
Updating code to match bx changes.

### DIFF
--- a/examples/common/entry/entry_sdl.cpp
+++ b/examples/common/entry/entry_sdl.cpp
@@ -487,13 +487,13 @@ namespace entry
 			setWindowSize(defaultWindow, m_width, m_height, true);
 
 			bx::FileReaderI* reader = getFileReader();
-			if (bx::open(&reader, "gamecontrollerdb.txt") )
+			if (bx::open(reader, "gamecontrollerdb.txt") )
 			{
 				bx::AllocatorI* allocator = getAllocator();
-				uint32_t size = (uint32_t)bx::getSize(&reader);
+				uint32_t size = (uint32_t)bx::getSize(reader);
 				void* data = BX_ALLOC(allocator, size);
-				bx::read(&reader, data, size);
-				bx::close(&reader);
+				bx::read(reader, data, size);
+				bx::close(reader);
 
 				SDL_GameControllerAddMapping( (char*)data);
 


### PR DESCRIPTION
I noticed that the SDL version no longer built due to changes to `bx:open`, `bs::close` and `bx:read`.