### PR TITLE
Expose vsnprintf to shared lib

### DIFF
--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -911,4 +911,7 @@ BGFX_C_API void bgfx_blit(uint8_t _id, bgfx_texture_handle_t _dst, uint8_t _dstM
 /**/
 BGFX_C_API void bgfx_save_screen_shot(const char* _filePath);
 
+/**/
+BGFX_C_API int32_t bgfx_vsnprintf(char* _str, size_t _count, const char* _format, va_list _argList);
+
 #endif // BGFX_C99_H_HEADER_GUARD

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4825,6 +4825,11 @@ BGFX_C_API uintptr_t bgfx_override_internal_texture(bgfx_texture_handle_t _handl
 	return bgfx::overrideInternal(handle.cpp, _width, _height, _numMips, bgfx::TextureFormat::Enum(_format), _flags);
 }
 
+BGFX_C_API int32_t bgfx_vsnprintf(char* _str, size_t _count, const char* _format, va_list _argList)
+{
+	return bx::vsnprintf(_str, _count, _format, _argList);
+}
+
 BGFX_C_API bgfx_interface_vtbl_t* bgfx_get_interface(uint32_t _version)
 {
 	if (_version == BGFX_API_VERSION)


### PR DESCRIPTION
This makes it much easier for languages that don't have direct access to a vsnprintf implementation to do something useful with the trace callback method.