### PR TITLE
Ensure we get a debug context as appropriate in glx.

### DIFF
--- a/src/glcontext_glx.cpp
+++ b/src/glcontext_glx.cpp
@@ -155,10 +155,12 @@ namespace bgfx { namespace gl
 			if (NULL != glXCreateContextAttribsARB)
 			{
 				BX_TRACE("Create GL 3.1 context.");
+				int32_t flags = BGFX_CONFIG_DEBUG ? GLX_CONTEXT_DEBUG_BIT_ARB : 0;
 				const int contextAttrs[] =
 				{
 					GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
 					GLX_CONTEXT_MINOR_VERSION_ARB, 1,
+					GLX_CONTEXT_FLAGS_ARB, flags,
 					GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_CORE_PROFILE_BIT_ARB,
 					0,
 				};


### PR DESCRIPTION
If BGFX_CONFIG_DEBUG is defined, get a GL debug context. This mirrors the
behavior from wgl, and allows KHR_debug/ARB_debug_output messages to work.