### PR TITLE
Added support for EGL_ANDROID_recordable

### DIFF
--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -195,6 +195,9 @@ EGL_IMPORT
 			BX_TRACE("Supported EGL extensions:");
 			dumpExtensions(extensions);
 
+      // https://www.khronos.org/registry/EGL/extensions/ANDROID/EGL_ANDROID_recordable.txt
+      const bool hasEglAndroidRecordable = !!bx::findIdentifierMatch(extensions, "EGL_ANDROID_recordable");
+
 			EGLint attrs[] =
 			{
 				EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
@@ -205,6 +208,10 @@ EGL_IMPORT
 				EGL_DEPTH_SIZE, 24,
 #	endif // BX_PLATFORM_
 				EGL_STENCIL_SIZE, 8,
+
+        // Android Recordable surface
+        hasEglAndroidRecordable? 0x3142 : EGL_NONE,
+        hasEglAndroidRecordable? 1      : EGL_NONE,
 
 				EGL_NONE
 			};


### PR DESCRIPTION

EGL_Android_Recordable extension allows to use a surface as an input for recording with extremely low overhead. The current capture method, and in particular the glReadPixels call performs badly when trying to record video, this extensions allows for native video recording.

Enabling the extension, but not using it doesn't seem to have any measurable performance cost.