### PR TITLE
new function TextMetrics::clearText()

### DIFF
--- a/examples/common/font/text_metrics.cpp
+++ b/examples/common/font/text_metrics.cpp
@@ -10,12 +10,13 @@
 
 TextMetrics::TextMetrics(FontManager* _fontManager)
 	: m_fontManager(_fontManager)
-	, m_width(0)
-	, m_height(0)
-	, m_x(0)
-	, m_lineHeight(0)
-	, m_lineGap(0)
 {
+	clearText();
+}
+
+void TextMetrics::clearText()
+{
+	m_width = m_height = m_x = m_lineHeight = m_lineGap = 0;
 }
 
 void TextMetrics::appendText(FontHandle _fontHandle, const char* _string)

--- a/examples/common/font/text_metrics.h
+++ b/examples/common/font/text_metrics.h
@@ -25,6 +25,9 @@ public:
 	/// Return the height of the measured text.
 	float getHeight() const { return m_height; }
 
+	/// Clear the width and height of the measured text.
+	void clearText();
+
 private:
 	FontManager* m_fontManager;
 	float m_width;


### PR DESCRIPTION
I don't want new/delete TextMetrics instance every time I need calculate text width/height.