### PR TITLE
GL Renderer, OSX, no swap chain: Bind back buffer fbo ready for NSOpe…

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2290,6 +2290,9 @@ namespace bgfx { namespace gl
 					m_ovr.flip();
 					m_ovr.swap(_hmd);
 
+					// Ensure the back buffer is bound as the source of the flip
+					GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_backBufferFbo));
+
 					// need to swap GL render context even if OVR is enabled to get
 					// the mirror texture in the output
 					m_glctx.swap();


### PR DESCRIPTION
This one took a while to track down...

On OSX with no swap chain (uses `NSOpenGLContext` path), `flushBuffer` swaps with whatever has been specified by `glBindFramebuffer(GL_FRAMEBUFFER, ...)`.

This bug only shows up when the last view rendered does not target the back buffer.

I can't find *any* official documentation for this behaviour; it was just inferred from an awful lot of trial and error. After locating the problem I found this page which seems to suggest the same thing: http://renderingpipeline.com/2012/05/nsopenglcontext-flushbuffer-might-not-do-what-you-think/

The Metal renderer on iOS does not exhibit this bug so I'm referencing that as expected behaviour.