### PR TITLE
Vulkan/Spirv updates

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -1622,14 +1622,6 @@ VK_IMPORT_DEVICE
 				VkCommandBuffer commandBuffer = m_commandBuffers[0];
 				VK_CHECK(vkBeginCommandBuffer(commandBuffer, &cbbi) );
 
-				VkClearValue clearValue[2];
-				clearValue[0].color.float32[0] = 0.0f;
-				clearValue[0].color.float32[1] = 0.0f;
-				clearValue[0].color.float32[2] = 0.0f;
-				clearValue[0].color.float32[3] = 1.0f;
-				clearValue[1].depthStencil.depth   = 0.0f;
-				clearValue[1].depthStencil.stencil = 0;
-
 				VkRenderPassBeginInfo rpbi;
 				rpbi.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
 				rpbi.pNext = NULL;
@@ -1637,8 +1629,8 @@ VK_IMPORT_DEVICE
 				rpbi.renderArea.offset.x = 0;
 				rpbi.renderArea.offset.y = 0;
 				rpbi.renderArea.extent = m_sci.imageExtent;
-				rpbi.clearValueCount = BX_COUNTOF(clearValue);
-				rpbi.pClearValues    = clearValue;
+				rpbi.clearValueCount = 0;
+				rpbi.pClearValues = NULL;
 
 				setImageMemoryBarrier(commandBuffer
 					, m_backBufferDepthStencilImage
@@ -2872,7 +2864,6 @@ VK_IMPORT_DEVICE
 
 			VkClearAttachment attachments[BGFX_CONFIG_MAX_FRAME_BUFFERS];
 			uint32_t mrt = 0;
-			attachments[mrt].aspectMask = 0;
 
 			if (true //NULL != m_currentColor
 			&&  BGFX_CLEAR_COLOR & _clear.m_flags)
@@ -2912,6 +2903,7 @@ VK_IMPORT_DEVICE
 			&& (BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL) & _clear.m_flags)
 			{
 				attachments[mrt].colorAttachment = mrt;
+				attachments[mrt].aspectMask = 0;
 				attachments[mrt].aspectMask |= (_clear.m_flags & BGFX_CLEAR_DEPTH  ) ? VK_IMAGE_ASPECT_DEPTH_BIT   : 0;
 				attachments[mrt].aspectMask |= (_clear.m_flags & BGFX_CLEAR_STENCIL) ? VK_IMAGE_ASPECT_STENCIL_BIT : 0;
 

--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -539,10 +539,9 @@ namespace bgfx { namespace spirv
 		{
 		case 'c': return EShLangCompute;
 		case 'f': return EShLangFragment;
-		default:  break;
+		case 'v': return EShLangVertex;
+		default:  return EShLangCount;
 		}
-
-		return EShLangVertex;
 	}
 
 //	static void printError(spv_message_level_t, const char*, const spv_position_t&, const char* _message)
@@ -554,10 +553,10 @@ namespace bgfx { namespace spirv
 	{
 		BX_UNUSED(_cmdLine, _version, _code, _writer);
 
-		const char* profile = _cmdLine.findOption('p', "profile");
-		if (NULL == profile)
+		const char* type = _cmdLine.findOption('\0', "type");
+		if (NULL == type)
 		{
-			fprintf(stderr, "Error: Shader profile must be specified.\n");
+			fprintf(stderr, "Error: Shader type must be specified.\n");
 			return false;
 		}
 
@@ -565,7 +564,12 @@ namespace bgfx { namespace spirv
 
 		glslang::TProgram* program = new glslang::TProgram;
 
-		EShLanguage stage = getLang(profile[0]);
+		EShLanguage stage = getLang(type[0]);
+		if (EShLangCount == stage)
+		{
+			fprintf(stderr, "Error: Unknown shader type %s.\n", type);
+			return false;
+		}
 		glslang::TShader* shader = new glslang::TShader(stage);
 
 		EShMessages messages = EShMessages(0
@@ -575,14 +579,12 @@ namespace bgfx { namespace spirv
 			| EShMsgSpvRules
 			);
 
-		const char* shaderStrings[] = { _code.c_str() };
-		const char* shaderNames[]   = { "" };
+		shader->setEntryPoint("main");
 
-		shader->setStringsWithLengthsAndNames(
+		const char* shaderStrings[] = { _code.c_str() };
+		shader->setStrings(
 			  shaderStrings
-			, NULL
-			, shaderNames
-			, BX_COUNTOF(shaderNames)
+			, BX_COUNTOF(shaderStrings)
 			);
 		bool compiled = shader->parse(&resourceLimits
 			, 110
@@ -651,7 +653,7 @@ namespace bgfx { namespace spirv
 					uint16_t count = (uint16_t)program->getNumLiveUniformVariables();
 					bx::write(_writer, count);
 
-					uint32_t fragmentBit = profile[0] == 'p' ? BGFX_UNIFORM_FRAGMENTBIT : 0;
+					uint32_t fragmentBit = type[0] == 'f' ? BGFX_UNIFORM_FRAGMENTBIT : 0;
 					for (uint16_t ii = 0; ii < count; ++ii)
 					{
 						Uniform un;
@@ -681,8 +683,7 @@ namespace bgfx { namespace spirv
 						uint8_t nameSize = (uint8_t)un.name.size();
 						bx::write(_writer, nameSize);
 						bx::write(_writer, un.name.c_str(), nameSize);
-						uint8_t type = uint8_t(un.type | fragmentBit);
-						bx::write(_writer, type);
+						bx::write(_writer, uint8_t(un.type | fragmentBit));
 						bx::write(_writer, un.num);
 						bx::write(_writer, un.regIndex);
 						bx::write(_writer, un.regCount);
@@ -696,7 +697,10 @@ namespace bgfx { namespace spirv
 						);
 					}
 				}
-				program->dumpReflection();
+				if (g_verbose)
+				{
+					program->dumpReflection();
+				}
 
 				BX_UNUSED(spv::MemorySemanticsAllMemory);
 


### PR DESCRIPTION
Removed the clear value because the attachment was created with VK_ATTACHMENT_LOAD_OP_DONT_CARE (fixes a validation error).

set the aspectMask correctly.

Set the shader language type correctly.

Set the shader entrypoint name to "main"

Moved reflection dump into "verbose" section