### PR TITLE
Allows to set view id of NanoVG’s framebuffer manually.

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.h
+++ b/examples/common/nanovg/nanovg_bgfx.h
@@ -30,6 +30,7 @@ void nvgViewId(struct NVGcontext* ctx, unsigned char _viewId);
 // Example:
 //		float scale = 2;
 //		NVGLUframebuffer* fb = nvgluCreateFramebuffer(ctx, 100 * scale, 100 * scale, 0);
+//		nvgluSetViewFramebuffer(VIEW_ID, fb);
 //		nvgluBindFramebuffer(fb);
 //		nvgBeginFrame(ctx, 100, 100, scale);
 //		// renders anything offscreen
@@ -44,8 +45,10 @@ void nvgViewId(struct NVGcontext* ctx, unsigned char _viewId);
 //		nvgFillPaint(ctx, paint);
 //		nvgFill(ctx);
 //		nvgEndFrame(ctx);
+NVGLUframebuffer* nvgluCreateFramebuffer(NVGcontext* ctx, int width, int height, int imageFlags, uint8_t viewId);
 NVGLUframebuffer* nvgluCreateFramebuffer(NVGcontext* ctx, int width, int height, int imageFlags);
 void nvgluBindFramebuffer(NVGLUframebuffer* framebuffer);
 void nvgluDeleteFramebuffer(NVGLUframebuffer* framebuffer);
+void nvgluSetViewFramebuffer(uint8_t viewId, NVGLUframebuffer* framebuffer);
 
 #endif // NANOVG_BGFX_H_HEADER_GUARD


### PR DESCRIPTION
This commit changes the `nvgluCreateFramebuffer()` function to not assign a view id automatically as it would easily reach the limit of `uint8_t`. Instead, a new `nvgluSetViewFramebuffer()` function is created to allow users to assign the view id manually as mentioned in #1095.