### PR TITLE
Dont recreate transient vertex and index buffers every frame on OpenGL.

### DIFF
--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -1155,14 +1155,17 @@ namespace bgfx { namespace gl
 		{
 			BX_CHECK(0 != m_id, "Updating invalid index buffer.");
 
-			if (_discard)
-			{
-				// orphan buffer...
-				destroy();
-				create(m_size, NULL, m_flags);
-			}
-
 			GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_id) );
+			if(_discard && m_size < _size + _offset)
+			{
+				// need to grow the buffer
+				m_size = _size + _offset;
+				GL_CHECK(glBufferData(GL_ELEMENT_ARRAY_BUFFER
+					, m_size
+					, NULL
+					, GL_DYNAMIC_DRAW
+					) );
+			}
 			GL_CHECK(glBufferSubData(GL_ELEMENT_ARRAY_BUFFER
 				, _offset
 				, _size
@@ -1209,14 +1212,17 @@ namespace bgfx { namespace gl
 		{
 			BX_CHECK(0 != m_id, "Updating invalid vertex buffer.");
 
-			if (_discard)
-			{
-				// orphan buffer...
-				destroy();
-				create(m_size, NULL, m_decl, 0);
-			}
-
 			GL_CHECK(glBindBuffer(m_target, m_id) );
+			if(_discard && m_size < _size + _offset)
+			{
+				// need to grow the buffer
+				m_size = _size + _offset;
+				GL_CHECK(glBufferData(m_target
+					, m_size
+					, NULL
+					, GL_DYNAMIC_DRAW
+					) );
+			}
 			GL_CHECK(glBufferSubData(m_target
 				, _offset
 				, _size


### PR DESCRIPTION
I have at least two devices (Galaxy S5 and LG G2) where using even the simplest transient vertex buffer (1 sprite per frame) will decrease FPS from 60 to 25-35. Looks like there's a bug in driver implementation on this android devices, and doing gl buffer recreation takes ridiculous amount of time.

Hence why I'm proposing not to recreate buffers in a first place. AFAIK this change should work just fine, but I could be wrong. Probably needs more testing.