### PR TITLE
Fix exporting macros for the C99 API

### DIFF
--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -24,13 +24,8 @@
 #endif // BGFX_SHARED_LIB_USE
 
 #if BX_PLATFORM_WINDOWS
-#   if BX_COMPILER_MSVC
-#       define BGFX_SYMBOL_EXPORT __declspec(dllexport)
-#       define BGFX_SYMBOL_IMPORT __declspec(dllimport)
-#   else
-#       define BGFX_SYMBOL_EXPORT __attribute__((dllexport))
-#       define BGFX_SYMBOL_IMPORT __attribute__((dllimport))
-#   endif // BX_COMPILER_MSVC
+#   define BGFX_SYMBOL_EXPORT __declspec(dllexport)
+#   define BGFX_SYMBOL_IMPORT __declspec(dllimport)
 #else
 #   define BGFX_SYMBOL_EXPORT __attribute__((visibility("default")))
 #   define BGFX_SYMBOL_IMPORT

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -13,6 +13,8 @@
 #include <stdint.h>  // uint32_t
 #include <stdlib.h>  // size_t
 
+#include <bx/platform.h>
+
 #ifndef BGFX_SHARED_LIB_BUILD
 #    define BGFX_SHARED_LIB_BUILD 0
 #endif // BGFX_SHARED_LIB_BUILD
@@ -21,17 +23,26 @@
 #    define BGFX_SHARED_LIB_USE 0
 #endif // BGFX_SHARED_LIB_USE
 
-#if defined(_MSC_VER)
-#   if BGFX_SHARED_LIB_BUILD
-#       define BGFX_SHARED_LIB_API __declspec(dllexport)
-#   elif BGFX_SHARED_LIB_USE
-#       define BGFX_SHARED_LIB_API __declspec(dllimport)
+#if BX_PLATFORM_WINDOWS
+#   if BX_COMPILER_MSVC
+#       define BGFX_SYMBOL_EXPORT __declspec(dllexport)
+#       define BGFX_SYMBOL_IMPORT __declspec(dllimport)
 #   else
-#       define BGFX_SHARED_LIB_API
-#   endif // BGFX_SHARED_LIB_*
+#       define BGFX_SYMBOL_EXPORT __attribute__((dllexport))
+#       define BGFX_SYMBOL_IMPORT __attribute__((dllimport))
+#   endif // BX_COMPILER_MSVC
+#else
+#   define BGFX_SYMBOL_EXPORT __attribute__((visibility("default")))
+#   define BGFX_SYMBOL_IMPORT
+#endif // BX_PLATFORM_WINDOWS
+
+#if BGFX_SHARED_LIB_BUILD
+#   define BGFX_SHARED_LIB_API BGFX_SYMBOL_EXPORT
+#elif BGFX_SHARED_LIB_USE
+#   define BGFX_SHARED_LIB_API BGFX_SYMBOL_IMPORT
 #else
 #   define BGFX_SHARED_LIB_API
-#endif // defined(_MSC_VER)
+#endif // BGFX_SHARED_LIB_*
 
 #if defined(__cplusplus)
 #   define BGFX_C_API extern "C" BGFX_SHARED_LIB_API


### PR DESCRIPTION
when building bgfx as a shared library - now works with MinGW-w64 under windows and also under linux when -fvisibility=hidden is passed to the compiler to hide all symbols by default (which is recommended - it's a good practice)

reworked - using ```<bx/platform.h>```