### PR TITLE
Metal: Add support of setting CAMetalLayer as PlatformData.nwh (OSX)

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -401,10 +401,16 @@ namespace bgfx { namespace mtl
 				}
 #elif BX_PLATFORM_OSX
 				{
-					NSWindow* nsWindow = (NSWindow*)g_platformData.nwh;
-					[nsWindow.contentView setWantsLayer:YES];
-					m_metalLayer = [CAMetalLayer layer];
-					[nsWindow.contentView setLayer:m_metalLayer];
+                    NSObject* nvh = (NSObject*)g_platformData.nwh;
+                    if ([nvh isKindOfClass:[CAMetalLayer class]]) {
+                        CAMetalLayer* metalLayer = (CAMetalLayer*)g_platformData.nwh;
+                        m_metalLayer = metalLayer;
+                    } else {
+                        NSWindow* nsWindow = (NSWindow*)g_platformData.nwh;
+                        [nsWindow.contentView setWantsLayer:YES];
+                        m_metalLayer = [CAMetalLayer layer];
+                        [nsWindow.contentView setLayer:m_metalLayer];
+                    }
 				}
 #endif // BX_PLATFORM_*
 


### PR DESCRIPTION
Metal: Add support of setting CAMetalLayer as PlatformData.nwh for macOS(OSX) platform