### PR TITLE
removed fastMathEnabled = NO;

### DIFF
--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -224,14 +224,8 @@ namespace bgfx { namespace mtl
 
 		id<MTLLibrary> newLibraryWithSource(const char* _source)
 		{
-			MTLCompileOptions* options = [MTLCompileOptions new];
-			//NOTE: turned of as 'When using the fast variants, math functions execute more quickly,
-			//      but operate over a **LIMITED RANGE** and their behavior when handling NaN values is not defined.'
-			if (BX_ENABLED(BX_PLATFORM_IOS))
-				options.fastMathEnabled = NO;
-
 			NSError* error;
-			id<MTLLibrary> lib = [m_obj newLibraryWithSource:@(_source) options:options error:&error];
+			id<MTLLibrary> lib = [m_obj newLibraryWithSource:@(_source) options:nil error:&error];
 			BX_WARN(NULL == error
 				, "Shader compilation failed: %s"
 				, [error.localizedDescription cStringUsingEncoding:NSASCIIStringEncoding]


### PR DESCRIPTION
This was  the cause of the slow fullscreen blending on metal compared to opengl es on the same hardware. On metal compatible mobile gpus there is no fixed function blending hardware, they are just patching shaders with blending code ( I have checked this with implementing blending with states and programmable blending on metal and gles. the performance was exactly the same). Disabling fastmath caused slower generated code for blending. 