### PR TITLE
Minor Fixing Compile Error on vs2012 express

### DIFF
--- a/3rdparty/ocornut-imgui/widgets/gizmo.inl
+++ b/3rdparty/ocornut-imgui/widgets/gizmo.inl
@@ -495,10 +495,10 @@ namespace ImGuizmo
    {
       Context() : mbUsing(false), mbEnable(true), mbUsingBounds(false)
       {
-	      mX=0;
-	      mY=0;
-	      mWidth=0;
-	      mHeight=0;
+	      mX=0.f;
+	      mY=0.f;
+	      mWidth=0.f;
+	      mHeight=0.f;
       }
 
       ImDrawList* mDrawList;

--- a/3rdparty/ocornut-imgui/widgets/gizmo.inl
+++ b/3rdparty/ocornut-imgui/widgets/gizmo.inl
@@ -495,6 +495,10 @@ namespace ImGuizmo
    {
       Context() : mbUsing(false), mbEnable(true), mbUsingBounds(false)
       {
+	      mX=0;
+	      mY=0;
+	      mWidth=0;
+	      mHeight=0;
       }
 
       ImDrawList* mDrawList;
@@ -561,10 +565,13 @@ namespace ImGuizmo
       //
       int mCurrentOperation;
 
+      float mX,mY,mWidth,mHeight;
+	   /*
 	  float mX = 0.f;
 	  float mY = 0.f;
 	  float mWidth = 0.f;
 	  float mHeight = 0.f;
+	  */
    };
 
    static Context gContext;


### PR DESCRIPTION
Thanks For This Great Library . There Were One Build Error Using vs2012 express compiler that it can't initialize class members outside of constructor.  Minor Fix in  "struct Context" in imgui's gizmo.inl.
 .