### PR TITLE
Fixed link reference for Lightweight Java Lib

### DIFF
--- a/overview.html
+++ b/overview.html
@@ -222,7 +222,7 @@ licensed under permissive BSD-2 clause open source license.</p>
 <li><a class="reference external" href="https://github.com/DerelictOrg/DerelictBgfx">D language API bindings</a></li>
 <li><a class="reference external" href="https://github.com/james4k/go-bgfx">Go language API bindings</a></li>
 <li><a class="reference external" href="https://github.com/haskell-game/bgfx">Haskell language API bindings</a></li>
-<li><a class="reference external" href="https://github.com/LWJGL/lwjgl3)">Lightweight Java Game Library 3 bindings</a></li>
+<li><a class="reference external" href="https://github.com/LWJGL/lwjgl3">Lightweight Java Game Library 3 bindings</a></li>
 <li><a class="reference external" href="https://github.com/excessive/lua-bgfx">Lua language API bindings</a></li>
 <li><a class="reference external" href="https://github.com/Halsys/nim-bgfx">Nim language API bindings</a></li>
 <li><a class="reference external" href="https://github.com/jnadro/pybgfx#pybgfx">Python language API bindings</a></li>


### PR DESCRIPTION
Fixed link reference for Lightweight Java Game Library 3 bindings. Link to it had an extra parenthesis