### PR TITLE
misc metal fix/optim

### DIFF
--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -326,6 +326,12 @@ namespace bgfx { namespace mtl
 
 	MTL_CLASS(Function)
 		NSArray* vertexAttributes() { return m_obj.vertexAttributes; }
+
+		void setLabel(const char* _label)
+		{
+			if ([m_obj respondsToSelector:@selector(setLabel:)])
+				[m_obj setLabel:@(_label)];
+		}
 	MTL_CLASS_END
 
 	MTL_CLASS(Library)
@@ -497,6 +503,11 @@ namespace bgfx { namespace mtl
 		MTLTextureType textureType() const
 		{
 			return m_obj.textureType;
+		}
+
+		void setLabel(const char* _label)
+		{
+			[m_obj setLabel:@(_label)];
 		}
 	MTL_CLASS_END
 

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -33,7 +33,6 @@
       <program source>:6:23: error: type 'half4' (aka 'vector_half4') is not valid for attribute 'position'
       half4 gl_Position [[position]];
 
-
 Known issues(driver problems??):
   OSX mac mini(late 2014), OSX10.11.3 : nanovg-rendering: color writemask off causes problem...
   03-raymarch: OSX nothing is visible  ( depth/color order should be swapped in fragment output struct)
@@ -43,6 +42,8 @@ Known issues(driver problems??):
   Only on this device ( no problem on iPad Air 2 with iOS9.3.1)
 
   TODOs:
+ - support multiple vertex buffers: 34-mvs
+
  - framebufferMtl and TextureMtl resolve
 
  - FrameBufferMtl::postReset recreate framebuffer???
@@ -998,11 +999,11 @@ namespace bgfx { namespace mtl
 			switch (_handle.type)
 			{
 			case Handle::Shader:
-//				m_shaders[_handle.idx].m_function.m_obj.label = [NSString stringWithUTF8String:_name];
+				m_shaders[_handle.idx].m_function.setLabel(_name);
 				break;
 
 			case Handle::Texture:
-				m_textures[_handle.idx].m_ptr.m_obj.label = [NSString stringWithUTF8String:_name];
+				m_textures[_handle.idx].m_ptr.setLabel(_name);
 				break;
 
 			default:
@@ -2075,7 +2076,7 @@ namespace bgfx { namespace mtl
 			FrameBufferMtl& frameBuffer = s_renderMtl->m_frameBuffers[_fbHandle.idx];
 			murmur.add(frameBuffer.m_pixelFormatHash);
 		}
-		murmur.add(_declHandle.idx);
+		murmur.add(s_renderMtl->m_vertexDecls[_declHandle.idx].m_hash);
 		murmur.add(_numInstanceData);
 		uint32_t hash = murmur.end();
 
@@ -2543,7 +2544,7 @@ namespace bgfx { namespace mtl
 			desc.width  = textureWidth;
 			desc.height = textureHeight;
 			desc.depth  = bx::uint32_max(1,imageContainer.m_depth);
-			desc.mipmapLevelCount = imageContainer.m_numMips;
+			desc.mipmapLevelCount = numMips;
 			desc.sampleCount      = 1;
 			desc.arrayLength = numLayers;
 
@@ -3046,6 +3047,9 @@ namespace bgfx { namespace mtl
 
 	void RendererContextMtl::submitBlit(BlitState& _bs, uint16_t _view)
 	{
+		if (!_bs.hasItem(_view))
+			return;
+
 		if (0 != m_renderCommandEncoder)
 		{
 			m_renderCommandEncoder.endEncoding();


### PR DESCRIPTION
- setLabel now in 'wrapper' I have tested this and it compiles on older sdks ( gives warning). It is compatible with iOS8 devices, where Function setLabel is not available.
- fixed texture skip
- fixed performance issue related to submitBlit. It caused problem because it closed active rendercommand encoder even when blit was not used, so device had to store/load framebuffer. ( thanks to @jazzbre)