### PR TITLE
Fix sampler/texture indices for metal

### DIFF
--- a/examples/15-shadowmaps-simple/shadowmaps_simple.cpp
+++ b/examples/15-shadowmaps-simple/shadowmaps_simple.cpp
@@ -82,7 +82,7 @@ public:
 		bgfx::setDebug(m_debug);
 
 		// Uniforms.
-		u_shadowMap = bgfx::createUniform("u_shadowMap", bgfx::UniformType::Int1);
+		s_shadowMap = bgfx::createUniform("s_shadowMap", bgfx::UniformType::Int1);
 		u_lightPos  = bgfx::createUniform("u_lightPos",  bgfx::UniformType::Vec4);
 		u_lightMtx  = bgfx::createUniform("u_lightMtx",  bgfx::UniformType::Mat4);
 
@@ -204,7 +204,7 @@ public:
 		m_state[1]->m_numTextures = 1;
 		m_state[1]->m_textures[0].m_flags = UINT32_MAX;
 		m_state[1]->m_textures[0].m_stage = 0;
-		m_state[1]->m_textures[0].m_sampler = u_shadowMap;
+		m_state[1]->m_textures[0].m_sampler = s_shadowMap;
 		m_state[1]->m_textures[0].m_texture = shadowMapTexture;
 
 		// Set view and projection matrices.
@@ -240,7 +240,7 @@ public:
 
 		bgfx::destroy(m_shadowMapFB);
 
-		bgfx::destroy(u_shadowMap);
+		bgfx::destroy(s_shadowMap);
 		bgfx::destroy(u_lightPos);
 		bgfx::destroy(u_lightMtx);
 		bgfx::destroy(u_depthScaleOffset);
@@ -421,7 +421,7 @@ public:
 	uint32_t m_debug;
 	uint32_t m_reset;
 
-	bgfx::UniformHandle u_shadowMap;
+	bgfx::UniformHandle s_shadowMap;
 	bgfx::UniformHandle u_lightPos;
 	bgfx::UniformHandle u_lightMtx;
 

--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -726,8 +726,7 @@ namespace bgfx { namespace mtl
 			, m_vshConstantBufferAlignmentMask(0)
 			, m_fshConstantBufferSize(0)
 			, m_fshConstantBufferAlignmentMask(0)
-			, m_usedVertexSamplerStages(0)
-			, m_usedFragmentSamplerStages(0)
+			, m_samplerCount(0)
 			, m_numPredefined(0)
 			, m_processedUniforms(false)
 		{
@@ -753,8 +752,16 @@ namespace bgfx { namespace mtl
 		uint32_t m_vshConstantBufferAlignmentMask;
 		uint32_t m_fshConstantBufferSize;
 		uint32_t m_fshConstantBufferAlignmentMask;
-		uint32_t m_usedVertexSamplerStages;
-		uint32_t m_usedFragmentSamplerStages;
+
+		struct SamplerInfo
+		{
+			uint32_t			m_index;
+			bgfx::UniformHandle m_uniform;
+			bool				m_fragment;
+		};
+		SamplerInfo m_samplers[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
+		uint32_t	m_samplerCount;
+
 		PredefinedUniform m_predefined[PredefinedUniform::Count*2];
 		uint8_t m_numPredefined;
 		bool m_processedUniforms;


### PR DESCRIPTION
Fix for https://github.com/bkaradzic/bgfx/issues/1227 .

It gets texture slot from compiled shaders and maps it to Sampler uniform. So sampler uniform MUST be defined before using shader (shadowmap_simple has a bug with invalid uniform name).