### PR TITLE
Fixed flag ImGuiWindowFlags_AlwaysAutoResize been passed as alpha argument

### DIFF
--- a/examples/common/example-glue.cpp
+++ b/examples/common/example-glue.cpp
@@ -19,9 +19,9 @@ void showExampleDialog(entry::AppI* _app, const char* _errorText)
 		  ImVec2(10.0f, 50.0f)
 		, ImGuiSetCond_FirstUseEver
 		);
+	ImGui::SetNextWindowSize(ImVec2(256.0f, 200.0f));
 	ImGui::Begin(temp
 		, NULL
-		, ImVec2(256.0f, 200.0f)
 		, ImGuiWindowFlags_AlwaysAutoResize
 		);
 


### PR DESCRIPTION
The obsolete `ImGui::Begin` takes `float bg_alpha` as a fourth argument, but `ImGuiWindowFlags_AlwaysAutoResize` was passed as the fourth argument.