### PR TITLE
Example 27 Terrain: Fixed incorrect height display in mode Height Texture

### DIFF
--- a/examples/27-terrain/terrain.cpp
+++ b/examples/27-terrain/terrain.cpp
@@ -298,14 +298,14 @@ public:
 			{
 				int32_t brush_x = _x + area_x;
 				if (brush_x < 0
-				||  brush_x > (int32_t)s_terrainSize)
+				||  brush_x >= (int32_t)s_terrainSize)
 				{
 					continue;
 				}
 
 				int32_t brush_y = _y + area_y;
 				if (brush_y < 0
-				||  brush_y > (int32_t)s_terrainSize)
+				||  brush_y >= (int32_t)s_terrainSize)
 				{
 					continue;
 				}
@@ -365,9 +365,9 @@ public:
 			bx::vec3Add(pos, pos, ray_dir);
 
 			if (pos[0] < 0
-			||  pos[0] > s_terrainSize
+			||  pos[0] >= s_terrainSize
 			||  pos[2] < 0
-			||  pos[2] > s_terrainSize)
+			||  pos[2] >= s_terrainSize)
 			{
 				continue;
 			}

--- a/examples/27-terrain/terrain.cpp
+++ b/examples/27-terrain/terrain.cpp
@@ -197,8 +197,8 @@ public:
 				vert->m_x = (float)x;
 				vert->m_y = m_terrain.m_heightMap[(y * s_terrainSize) + x];
 				vert->m_z = (float)y;
-				vert->m_u = (float)x / (float)s_terrainSize;
-				vert->m_v = (float)y / (float)s_terrainSize;
+				vert.m_u = (x + 0.5f) / s_terrainSize_x;
+				vert.m_v = (y + 0.5f) / s_terrainSize_y;
 
 				m_terrain.m_vertexCount++;
 			}

--- a/examples/27-terrain/terrain.cpp
+++ b/examples/27-terrain/terrain.cpp
@@ -197,8 +197,8 @@ public:
 				vert->m_x = (float)x;
 				vert->m_y = m_terrain.m_heightMap[(y * s_terrainSize) + x];
 				vert->m_z = (float)y;
-				vert.m_u = (x + 0.5f) / s_terrainSize_x;
-				vert.m_v = (y + 0.5f) / s_terrainSize_y;
+				vert->m_u = (x + 0.5f) / s_terrainSize;
+				vert->m_v = (y + 0.5f) / s_terrainSize;
 
 				m_terrain.m_vertexCount++;
 			}


### PR DESCRIPTION
In Example 27 Terrain:
When selecting the **Height Texture** rendering mode, the visible height (if not 0) changes for no reason (small shifting/tilting).
I narrowed the problem down to the mapping of the function `texture2DLod`.
I do not know what coordinates it expects, but I guessed, that it might do something like:
int x = (int)(x_float * size_x)
This can lead to accidental rounding down, so I added `0.5` before diving by the size to make the position be "in the middle of the pixel" (I guess (0.0, 0.0) is the upper left corner of the first pixel).
I am not really familiar with graphics stuff. I can only say, that it fixed the problem for me.
I also fixed some incorrect out of bounds checks.