### PR TITLE
bugfix: restore old flags when skip zero scissor rect

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6900,10 +6900,12 @@ namespace bgfx { namespace gl
 					continue;
 				}
 
+				const uint64_t oldFlags = currentState.m_stateFlags;
 				const uint64_t newFlags = draw.m_stateFlags;
 				uint64_t changedFlags = currentState.m_stateFlags ^ draw.m_stateFlags;
 				currentState.m_stateFlags = newFlags;
 
+				const uint64_t oldStencil = currentState.m_stencil;
 				const uint64_t newStencil = draw.m_stencil;
 				uint64_t changedStencil = currentState.m_stencil ^ draw.m_stencil;
 				currentState.m_stencil = newStencil;
@@ -6947,6 +6949,8 @@ namespace bgfx { namespace gl
 						scissorRect.setIntersect(viewScissorRect, _render->m_frameCache.m_rectCache.m_cache[scissor]);
 						if (scissorRect.isZeroArea() )
 						{
+							currentState.m_stateFlags = oldFlags;
+							currentState.m_stencil = oldStencil;
 							continue;
 						}
 


### PR DESCRIPTION
I test 21-deferred under OPENGL renderer , it shows blank  sometimes.

I checked opengl renderer source, and found when the scissor rect is zero, it just continue to next item.  https://github.com/cloudwu/bgfx/blob/master/src/renderer_gl.cpp#L6948-L6951   (https://github.com/bkaradzic/bgfx/commit/8b3f752af50e6c700ac46db34adff36a66165223)

 In this case, currentState.m_stateFlags is changed , but it doesn't call the associated opengl api :
 `glDisable(GL_DEPTH_TEST)`  .

This patch can fix this bug, but I guess other renderers should also need fix this problem.
