### PR TITLE
fix warning in mingw gcc

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4623,7 +4623,7 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 		deviceCtx->CopyResource(m_texture3d, *_gpuTexture3d);
 
 		D3D11_MAPPED_SUBRESOURCE mappedResource;
-		deviceCtx->Map(m_texture3d, 0, D3D11_MAP_WRITE, NULL, &mappedResource);
+		deviceCtx->Map(m_texture3d, 0, D3D11_MAP_WRITE, 0, &mappedResource);
 		m_descriptor = reinterpret_cast<IntelDirectAccessResourceDescriptor*>(mappedResource.pData);
 
 		return m_descriptor->ptr;

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -4966,8 +4966,8 @@ data.NumQualityLevels = 0;
  				box.bottom = blit.m_srcY + height;;
  				box.back   = blit.m_srcZ + bx::uint32_imax(1, depth);
 
-				D3D12_TEXTURE_COPY_LOCATION dstLocation = { dst.m_ptr, D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX, {{}} };
-				D3D12_TEXTURE_COPY_LOCATION srcLocation = { src.m_ptr, D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX, {{}} };
+				D3D12_TEXTURE_COPY_LOCATION dstLocation = { dst.m_ptr, D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX, {{0,{DXGI_FORMAT_UNKNOWN,0,0,0,0}}} };
+				D3D12_TEXTURE_COPY_LOCATION srcLocation = { src.m_ptr, D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX, {{0,{DXGI_FORMAT_UNKNOWN,0,0,0,0}}} };
 				m_commandList->CopyTextureRegion(&dstLocation
 					, blit.m_dstX
 					, blit.m_dstY


### PR DESCRIPTION
```
../../../src/renderer_d3d11.cpp: In member function 'void* bgfx::d3d11::DirectAccessResourceD3D11::createTexture3D(const D3D11_TEXTURE3D_DESC*, const D3D11_SUBRESOURCE_DATA*, ID3D11Texture3D**)':
../../../src/renderer_d3d11.cpp:4626:72: warning: passing NULL to non-pointer argument 4 of 'virtual HRESULT ID3D11DeviceContext::Map(ID3D11Resource*, UINT, D3D11_MAP, UINT, D3D11_MAPPED_SUBRESOURCE*)' [-Wconversion-null]
   deviceCtx->Map(m_texture3d, 0, D3D11_MAP_WRITE, NULL, &mappedResource);
```
See https://msdn.microsoft.com/zh-cn/library/windows/desktop/ff476457(v=vs.85).aspx

```
../../../src/renderer_d3d12.cpp: In member function 'void bgfx::d3d12::RendererContextD3D12::submitBlit(bgfx::BlitState&, uint16_t)':
../../../src/renderer_d3d12.cpp:4969:108: warning: missing initializer for member 'D3D12_PLACED_SUBRESOURCE_FOOTPRINT::Offset' [-Wmissing-field-initializers]
     D3D12_TEXTURE_COPY_LOCATION dstLocation = { dst.m_ptr, D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX, {{}} };
```
