### PR TITLE
Samples cleanup

### DIFF
--- a/examples/02-metaballs/metaballs.cpp
+++ b/examples/02-metaballs/metaballs.cpp
@@ -490,7 +490,7 @@ public:
 
 		m_width  = _width;
 		m_height = _height;
-		m_debug  = BGFX_DEBUG_NONE;
+		m_debug  = BGFX_DEBUG_TEXT;
 		m_reset  = BGFX_RESET_VSYNC;
 
 		bgfx::init(args.m_type, args.m_pciId);
@@ -758,11 +758,12 @@ public:
 			bgfx::submit(0, m_program);
 
 			// Display stats.
-			bgfx::dbgTextPrintf(1, 4, 0x0f, "Num vertices: %5d (%6.4f%%)", numVertices, float(numVertices)/maxVertices * 100);
-			bgfx::dbgTextPrintf(1, 5, 0x0f, "      Update: % 7.3f[ms]", double(profUpdate)*toMs);
-			bgfx::dbgTextPrintf(1, 6, 0x0f, "Calc normals: % 7.3f[ms]", double(profNormal)*toMs);
-			bgfx::dbgTextPrintf(1, 7, 0x0f, " Triangulate: % 7.3f[ms]", double(profTriangulate)*toMs);
-			bgfx::dbgTextPrintf(1, 8, 0x0f, "       Frame: % 7.3f[ms]", double(frameTime)*toMs);
+			int row = 18;
+			bgfx::dbgTextPrintf(1, row++, 0x0f, "Num vertices: %5d (%6.4f%%)", numVertices, float(numVertices)/maxVertices * 100);
+			bgfx::dbgTextPrintf(1, row++, 0x0f, "      Update: % 7.3f[ms]", double(profUpdate)*toMs);
+			bgfx::dbgTextPrintf(1, row++, 0x0f, "Calc normals: % 7.3f[ms]", double(profNormal)*toMs);
+			bgfx::dbgTextPrintf(1, row++, 0x0f, " Triangulate: % 7.3f[ms]", double(profTriangulate)*toMs);
+			bgfx::dbgTextPrintf(1, row++, 0x0f, "       Frame: % 7.3f[ms]", double(frameTime)*toMs);
 
 			// Advance to next frame. Rendering thread will be kicked to
 			// process submitted rendering primitives.

--- a/examples/05-instancing/instancing.cpp
+++ b/examples/05-instancing/instancing.cpp
@@ -73,7 +73,7 @@ public:
 
 		m_width  = _width;
 		m_height = _height;
-		m_debug  = BGFX_DEBUG_NONE;
+		m_debug  = BGFX_DEBUG_TEXT;
 		m_reset  = BGFX_RESET_VSYNC;
 
 		bgfx::init(args.m_type, args.m_pciId);

--- a/examples/08-update/update.cpp
+++ b/examples/08-update/update.cpp
@@ -549,7 +549,7 @@ public:
 
 			for (uint32_t ii = 0; ii < m_numTextures3d; ++ii)
 			{
-				bx::mtxTranslate(mtx, xpos + ii*2.1f, -size+6.5f, 0.0f);
+				bx::mtxTranslate(mtx, xpos + (ii+3)*2.1f, -size+6.5f, 0.0f);
 
 				// Set model matrix for rendering.
 				bgfx::setTransform(mtx);

--- a/examples/14-shadowvolumes/shadowvolumes.cpp
+++ b/examples/14-shadowvolumes/shadowvolumes.cpp
@@ -1882,7 +1882,7 @@ public:
 		m_viewState   = ViewState(_width, _height);
 		m_clearValues = { 0x00000000, 1.0f, 0 };
 
-		m_debug = BGFX_DEBUG_NONE;
+		m_debug = BGFX_DEBUG_TEXT;
 		m_reset = BGFX_RESET_VSYNC;
 
 		bgfx::init(args.m_type, args.m_pciId);
@@ -2341,7 +2341,7 @@ public:
 
 			if (m_showHelp)
 			{
-				uint8_t row = 5;
+				uint8_t row = 18;
 				bgfx::dbgTextPrintf(3, row++, 0x0f, "Stencil buffer implementation:");
 				bgfx::dbgTextPrintf(8, row++, 0x0f, "Depth fail - Robust, but slower than 'Depth pass'. Requires computing and drawing of shadow volume caps.");
 				bgfx::dbgTextPrintf(8, row++, 0x0f, "Depth pass - Faster, but not stable. Shadows are wrong when camera is in the shadow.");
@@ -2356,6 +2356,10 @@ public:
 				bgfx::dbgTextPrintf(3, row++, 0x0f, "Stencil:");
 				bgfx::dbgTextPrintf(8, row++, 0x0f, "Stencil buffer     - Faster, but capable only of +1 incr.");
 				bgfx::dbgTextPrintf(8, row++, 0x0f, "Texture as stencil - Slower, but capable of +2 incr.");
+			}
+			else
+			{
+				bgfx::dbgTextClear();
 			}
 
 			// Setup instances

--- a/examples/21-deferred/deferred.cpp
+++ b/examples/21-deferred/deferred.cpp
@@ -204,7 +204,7 @@ public:
 
 		m_width  = _width;
 		m_height = _height;
-		m_debug  = BGFX_DEBUG_NONE;
+		m_debug  = BGFX_DEBUG_TEXT;
 		m_reset  = BGFX_RESET_VSYNC;
 
 		bgfx::init(args.m_type, args.m_pciId);

--- a/examples/22-windows/windows.cpp
+++ b/examples/22-windows/windows.cpp
@@ -80,7 +80,7 @@ public:
 
 		m_width  = _width;
 		m_height = _height;
-		m_debug  = BGFX_DEBUG_NONE;
+		m_debug  = BGFX_DEBUG_TEXT;
 		m_reset  = BGFX_RESET_VSYNC;
 
 		bgfx::init(args.m_type, args.m_pciId);
@@ -167,17 +167,16 @@ public:
 
 	bool update() override
 	{
-		entry::WindowState state;
-		if (!entry::processWindowEvents(state, m_debug, m_reset) )
+		if ( !entry::processWindowEvents(m_state, m_debug, m_reset) )
 		{
-			m_mouseState = state.m_mouse;
+			entry::MouseState mouseState = m_state.m_mouse;
 
-			imguiBeginFrame(m_mouseState.m_mx
-				,  m_mouseState.m_my
-				, (m_mouseState.m_buttons[entry::MouseButton::Left  ] ? IMGUI_MBUT_LEFT   : 0)
-				| (m_mouseState.m_buttons[entry::MouseButton::Right ] ? IMGUI_MBUT_RIGHT  : 0)
-				| (m_mouseState.m_buttons[entry::MouseButton::Middle] ? IMGUI_MBUT_MIDDLE : 0)
-				,  m_mouseState.m_mz
+			imguiBeginFrame(mouseState.m_mx
+				,  mouseState.m_my
+				, (mouseState.m_buttons[entry::MouseButton::Left  ] ? IMGUI_MBUT_LEFT   : 0)
+				| (mouseState.m_buttons[entry::MouseButton::Right ] ? IMGUI_MBUT_RIGHT  : 0)
+				| (mouseState.m_buttons[entry::MouseButton::Middle] ? IMGUI_MBUT_MIDDLE : 0)
+				,  mouseState.m_mz
 				, uint16_t(m_width)
 				, uint16_t(m_height)
 				);
@@ -186,21 +185,21 @@ public:
 
 			imguiEndFrame();
 
-			if (isValid(state.m_handle) )
+			if (isValid(m_state.m_handle) )
 			{
-				if (0 == state.m_handle.idx)
+				if (0 == m_state.m_handle.idx)
 				{
-					m_width  = state.m_width;
-					m_height = state.m_height;
+					m_width  = m_state.m_width;
+					m_height = m_state.m_height;
 				}
 				else
 				{
-					uint8_t viewId = (uint8_t)state.m_handle.idx;
+					uint8_t viewId = (uint8_t)m_state.m_handle.idx;
 					entry::WindowState& win = m_windows[viewId];
 
-					if (win.m_nwh    != state.m_nwh
-					|| (win.m_width  != state.m_width
-					||  win.m_height != state.m_height) )
+					if (win.m_nwh    != m_state.m_nwh
+					|| (win.m_width  != m_state.m_width
+					||  win.m_height != m_state.m_height) )
 					{
 						// When window changes size or native window handle changed
 						// frame buffer must be recreated.
@@ -210,9 +209,9 @@ public:
 							m_fbh[viewId].idx = bgfx::kInvalidHandle;
 						}
 
-						win.m_nwh    = state.m_nwh;
-						win.m_width  = state.m_width;
-						win.m_height = state.m_height;
+						win.m_nwh    = m_state.m_nwh;
+						win.m_width  = m_state.m_width;
+						win.m_height = m_state.m_height;
 
 						if (NULL != win.m_nwh)
 						{
@@ -270,7 +269,7 @@ public:
 
 			if (NULL != m_bindings)
 			{
-				bgfx::dbgTextPrintf(0, 5, 0x2f, "Press 'c' to create or 'd' to destroy window.");
+				bgfx::dbgTextPrintf(0, 1, 0x2f, "Press 'c' to create or 'd' to destroy window.");
 			}
 			else
 			{
@@ -352,7 +351,7 @@ public:
 		}
 	}
 
-	entry::MouseState m_mouseState;
+	entry::WindowState m_state;
 
 	uint32_t m_width;
 	uint32_t m_height;

--- a/examples/26-occlusion/occlusion.cpp
+++ b/examples/26-occlusion/occlusion.cpp
@@ -76,7 +76,7 @@ public:
 
 		m_width  = _width;
 		m_height = _height;
-		m_debug  = BGFX_DEBUG_NONE;
+		m_debug  = BGFX_DEBUG_TEXT;
 		m_reset  = BGFX_RESET_VSYNC;
 
 		bgfx::init(args.m_type, args.m_pciId);
@@ -286,12 +286,12 @@ public:
 
 				for (uint16_t xx = 0; xx < CUBES_DIM; ++xx)
 				{
-					bgfx::dbgTextImage(5 + xx*2, 5, 1, CUBES_DIM, img + xx*2, CUBES_DIM*2);
+					bgfx::dbgTextImage(5 + xx*2, 20, 1, CUBES_DIM, img + xx*2, CUBES_DIM*2);
 				}
 
 				int32_t numPixels = 0;
 				bgfx::getResult(m_occlusionQueries[0], &numPixels);
-				bgfx::dbgTextPrintf(5, 5 + CUBES_DIM + 1, 0xf, "%d", numPixels);
+				bgfx::dbgTextPrintf(5, 20 + CUBES_DIM + 1, 0xf, "Passing pixels count: %d", numPixels);
 			}
 
 			// Advance to next frame. Rendering thread will be kicked to


### PR DESCRIPTION
``bgfx::dbgTextPrintf(...)`` calls weren't showing up in most of the samples since they didn't have ```BGFX_DEBUG_TEXT``` set.

I rearranged the screen-space elements on a few of these from the top-left area so that they wouldn't be drawing over/under the ImGui diagnostic window. 

Fixed a couple localized bugs.