### PR TITLE
Fix OSX initial window size event.

### DIFF
--- a/examples/common/entry/entry_osx.mm
+++ b/examples/common/entry/entry_osx.mm
@@ -472,7 +472,10 @@ namespace entry
 			thread.init(mte.threadFunc, &mte);
 
 			WindowHandle handle = { 0 };
-			m_eventQueue.postSizeEvent(handle, ENTRY_DEFAULT_WIDTH, ENTRY_DEFAULT_HEIGHT);
+			NSRect contentRect = [window contentRectForFrameRect: m_windowFrame];
+			uint32_t width = uint32_t(contentRect.size.width);
+			uint32_t height = uint32_t(contentRect.size.height);
+			m_eventQueue.postSizeEvent(handle, width, height);
 
 			while (!(m_exit = [dg applicationHasTerminated]) )
 			{


### PR DESCRIPTION
The height returned by contentRectForFrameRect is not exactly the same as the ENTRY_DEFAULT_HEIGHT if the screen size is not big enough.
For example, on my Mac, rect.height equals 702, which is 18 less than ENTRY_DEFAULT_HEIGHT(720).
This will cause the imgui’s cord system offset by 18, so even the cursor is not on the button, the imgui will still think the mouse is hover the button, also, the top of imgui’s window will also offset a little bit.
However, these symptom will gone when the window is resized.
In short, this fix unify the behavior of window size event in initial state with resize.