### PR TITLE
Fix shaderc leaks

### DIFF
--- a/3rdparty/fcpp/cpp1.c
+++ b/3rdparty/fcpp/cpp1.c
@@ -42,6 +42,7 @@ int fppPreProcess(struct fppTag *tags)
 {
   size_t i=0;
   ReturnCode ret;       /* cpp return code */
+  int retVal;           /* fppPreProcess return code */
   struct Global *global;
 
   global=(struct Global *)malloc(sizeof(struct Global));
@@ -144,10 +145,16 @@ int fppPreProcess(struct fppTag *tags)
   }
   fflush(stdout);
 // BK -  fclose(stdout);
+  delalldefines(global);
 
+  retVal = IO_NORMAL;
   if (global->errors > 0 && !global->eflag)
-    return(IO_ERROR);
-  return(IO_NORMAL);       /* No errors or -E option set   */
+    retVal = IO_ERROR;
+  free(global->tokenbuf);
+  free(global->functionname);
+  free(global->spacebuf);
+  free(global);
+  return retVal;       /* No errors or -E option set   */
 }
 
 INLINE FILE_LOCAL

--- a/3rdparty/fcpp/cpp3.c
+++ b/3rdparty/fcpp/cpp3.c
@@ -363,7 +363,7 @@ ReturnCode initdefines(struct Global *global)
   return(FPP_OK);
 }
 
-void deldefines(struct Global *global)
+void delbuiltindefines(struct Global *global)
 {
   /*
    * Delete the built-in #define's.

--- a/3rdparty/fcpp/cpp6.c
+++ b/3rdparty/fcpp/cpp6.c
@@ -619,12 +619,35 @@ DEFBUF *defendel(struct Global *global,
 }
 
 
+void delalldefines(struct Global *global)
+{
+  /*
+   * Delete all the defines in the tables and free memory
+   */
+
+  DEFBUF *dp;
+  DEFBUF *prevp;
+  int i;
+
+  for (i = 0; i < SBSIZE; ++i)
+  {
+    prevp = global->symtab[i];
+    while ((dp = prevp) != (DEFBUF *)NULL) {
+      prevp = dp->link;
+      free(dp->repl);                /* Free the replacement */
+      free((char *)dp);              /* Free the symbol      */
+    }
+    global->symtab[i] = NULL;
+  }
+}
+
+
 void outdefines(struct Global *global)
 {
   DEFBUF *dp;
   DEFBUF **syp;
 
-  deldefines(global);                   /* Delete built-in #defines     */
+  delbuiltindefines(global);                   /* Delete built-in #defines     */
   for (syp = global->symtab; syp < &global->symtab[SBSIZE]; syp++) {
     if ((dp = *syp) != (DEFBUF *) NULL) {
       do {

--- a/3rdparty/fcpp/cppadd.h
+++ b/3rdparty/fcpp/cppadd.h
@@ -407,7 +407,8 @@ void dumpadef(char *, register DEFBUF *);
 #endif
 ReturnCode openfile(struct Global *,char *);
 int cget(struct Global *);
-void deldefines(struct Global *);
+void delbuiltindefines(struct Global *);
+void delalldefines(struct Global *);
 char *Getmem(struct Global *, int);
 ReturnCode openinclude(struct Global *, char *, int);
 ReturnCode expstuff(struct Global *, char *, char *);

--- a/3rdparty/glsl-optimizer/src/glsl/glsl_optimizer.cpp
+++ b/3rdparty/glsl-optimizer/src/glsl/glsl_optimizer.cpp
@@ -170,6 +170,10 @@ struct glslopt_shader
 	{
 		for (unsigned i = 0; i < MESA_SHADER_STAGES; i++)
 			ralloc_free(whole_program->_LinkedShaders[i]);
+		for(GLuint i =0;i< whole_program->NumShaders;i++)
+			ralloc_free(whole_program->Shaders[i]);
+		ralloc_free(whole_program->Shaders);
+		ralloc_free(whole_program->InfoLog);
 		ralloc_free(whole_program);
 		ralloc_free(rawOutput);
 		ralloc_free(optimizedOutput);

--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -62,6 +62,7 @@ namespace bgfx { namespace glsl
 
 			printCode(_code.c_str(), line, start, end, column);
 			fprintf(stderr, "Error: %s\n", log);
+			glslopt_shader_delete(shader);
 			glslopt_cleanup(ctx);
 			return false;
 		}
@@ -298,6 +299,7 @@ namespace bgfx { namespace glsl
 			writeFile(disasmfp.c_str(), optimizedShader, shaderSize);
 		}
 
+		glslopt_shader_delete(shader);
 		glslopt_cleanup(ctx);
 
 		return true;


### PR DESCRIPTION
This commit fixes memory leaks in shaderc.

Upstream PR for fcpp : https://github.com/bagder/fcpp/pull/2
Upstream PR for glsl-optimizer : https://github.com/aras-p/glsl-optimizer/pull/142

I didn't see any other leaks with my simple shaders, but there might still be a few lying around.