### PR TITLE
Add fallthrough comment to avoid -Wimplicit-fallthrough false positives for gcc

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2845,6 +2845,7 @@ error:
 			BX_ALIGNED_DELETE(g_allocator, s_ctx, 64);
 			s_ctx = NULL;
 
+		// FALLTHRU
 		case ErrorState::Default:
 			if (NULL != s_callbackStub)
 			{

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1872,6 +1872,7 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 				DX_RELEASE(m_factory, 0);
 
 #if USE_D3D11_DYNAMIC_LIB
+			// FALLTHRU
 			case ErrorState::LoadedDXGI:
 				if (NULL != m_dxgidebugdll)
 				{
@@ -1888,11 +1889,13 @@ BX_PRAGMA_DIAGNOSTIC_POP();
 				bx::dlclose(m_dxgidll);
 				m_dxgidll = NULL;
 
+			// FALLTHRU
 			case ErrorState::LoadedD3D11:
 				bx::dlclose(m_d3d11dll);
 				m_d3d11dll = NULL;
 #endif // USE_D3D11_DYNAMIC_LIB
 
+			// FALLTHRU
 			case ErrorState::Default:
 			default:
 				m_nvapi.shutdown();

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1448,18 +1448,23 @@ namespace bgfx { namespace d3d12
 			{
 			case ErrorState::CreatedCommandQueue:
 				m_cmd.shutdown();
+			// FALLTHRU
 			case ErrorState::CreatedDXGIFactory:
 				DX_RELEASE(m_device,  0);
 				DX_RELEASE(m_adapter, 0);
 				DX_RELEASE(m_factory, 0);
 #if USE_D3D12_DYNAMIC_LIB
+			// FALLTHRU
 			case ErrorState::LoadedDXGI:
 				bx::dlclose(m_dxgidll);
+			// FALLTHRU
 			case ErrorState::LoadedD3D12:
 				bx::dlclose(m_d3d12dll);
+			// FALLTHRU
 			case ErrorState::LoadedKernel32:
 				bx::dlclose(m_kernel32dll);
 #endif // USE_D3D12_DYNAMIC_LIB
+			// FALLTHRU
 			case ErrorState::Default:
 			default:
 				unloadRenderDoc(m_renderdocdll);

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -870,6 +870,7 @@ namespace bgfx { namespace d3d9
 					DX_RELEASE(m_device, 0);
 				}
 
+			// FALLTHRU
 			case ErrorState::CreatedD3D9:
 				if (NULL != m_d3d9ex)
 				{
@@ -881,10 +882,12 @@ namespace bgfx { namespace d3d9
 					DX_RELEASE(m_d3d9, 0);
 				}
 
+			// FALLTHRU
 			case ErrorState::LoadedD3D9:
 				m_nvapi.shutdown();
 				bx::dlclose(m_d3d9dll);
 
+			// FALLTHRU
 			case ErrorState::Default:
 				break;
 			}

--- a/src/renderer_d3d9.h
+++ b/src/renderer_d3d9.h
@@ -241,6 +241,7 @@ namespace bgfx { namespace d3d9
 			switch (m_type)
 			{
 			case 0:  DX_RELEASE(m_vertexShader, 0);
+			// FALLTHRU
 			default: DX_RELEASE(m_pixelShader,  0);
 			}
 		}

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -1767,11 +1767,13 @@ VK_IMPORT_DEVICE
 				vkDestroy(m_descriptorSetLayout);
 				vkDestroy(m_descriptorPool);
 
+			// FALLTHRU
 			case ErrorState::CommandBuffersCreated:
 				vkFreeCommandBuffers(m_device, m_commandPool, BX_COUNTOF(m_commandBuffers), m_commandBuffers);
 				vkDestroy(m_commandPool);
 				vkDestroy(m_fence);
 
+			// FALLTHRU
 			case ErrorState::SwapchainCreated:
 				for (uint32_t ii = 0; ii < BX_COUNTOF(m_backBufferColorImageView); ++ii)
 				{
@@ -1792,15 +1794,19 @@ VK_IMPORT_DEVICE
 				}
 				vkDestroy(m_swapchain);
 
+			// FALLTHRU
 			case ErrorState::SurfaceCreated:
 				vkDestroySurfaceKHR(m_instance, m_surface, m_allocatorCb);
 
+			// FALLTHRU
 			case ErrorState::RenderPassCreated:
 				vkDestroy(m_renderPass);
 
+			// FALLTHRU
 			case ErrorState::DeviceCreated:
 				vkDestroyDevice(m_device, m_allocatorCb);
 
+			// FALLTHRU
 			case ErrorState::InstanceCreated:
 				if (VK_NULL_HANDLE != m_debugReportCallback)
 				{
@@ -1809,12 +1815,14 @@ VK_IMPORT_DEVICE
 
 				vkDestroyInstance(m_instance, m_allocatorCb);
 
+			// FALLTHRU
 			case ErrorState::LoadedVulkan1:
 				bx::dlclose(m_vulkan1dll);
 				m_vulkan1dll  = NULL;
 				m_allocatorCb = NULL;
 				unloadRenderDoc(m_renderdocdll);
 
+			// FALLTHRU
 			case ErrorState::Default:
 				break;
 			};


### PR DESCRIPTION
Gcc reports many `implicit-fallthrough` warnings . I think these are false positives. We can add comments to avoid them.

See https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/

ps. There are also some `maybe-uninitialized` false positives . 

```
../../../src/shader_dxbc.cpp:829:25: warning: 'subOperand.bgfx::DxbcSubOperand::type' may be used uninitialized in this function [-Wmaybe-uninitialized]
   token |= (_subOperand.type         << 12) & UINT32_C(0x000ff000);
             ~~~~~~~~~~~~^~~~
```

```
In file included from ../../../../bx/include/bx/math.h:570:0,
                 from ../../../examples/common/common.h:10,
                 from ../../../examples/14-shadowvolumes/shadowvolumes.cpp:13:
../../../../bx/include/bx/inline/math.inl: In member function 'virtual bool {anonymous}::ExampleShadowVolumes::update()':
../../../../bx/include/bx/inline/math.inl:318:22: error: '*((void*)& corners +-12)' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   _result[0] = _a[0] - _b[0];
                ~~~~~~^~~~~~~
../../../examples/14-shadowvolumes/shadowvolumes.cpp:1729:8: note: '*((void*)& corners +-12)' was declared here
  float corners[4][3];
        ^~~~~~~
```

It's a gcc bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=19430) , but shall we disable it by these ?
```C
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
// ...
#pragma GCC diagnostic pop
```
I can't build now by mingw-gcc because of ` all warnings being treated as errors` .
