### PR TITLE
Fixing macOS build (new warnings/errors).

### DIFF
--- a/3rdparty/stb/stb_rect_pack.h
+++ b/3rdparty/stb/stb_rect_pack.h
@@ -1,11 +1,18 @@
 #if defined(__GNUC__) || defined(__clang__)
-#   if defined(__clang__)
-#	    pragma clang diagnostic ignored "-Wunknown-pragmas"
-#   endif // defined(__clang__)
+#	if defined(__has_warning)
+#		define STB_HAS_WARNING __has_warning
+# 	else
+#		define STB_HAS_WARNING(w)	1
+#	endif
+#	if defined(__clang__)
+#		pragma clang diagnostic ignored "-Wunknown-pragmas"
+#	endif // defined(__clang__)
 #	pragma GCC diagnostic ignored "-Wtype-limits"
 #	pragma GCC diagnostic ignored "-Wunused-function"
 #	pragma GCC diagnostic ignored "-Wunused-parameter"
-#	pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#	if STB_HAS_WARNING("-Wunused-but-set-variable")
+#		pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#	endif
 #else
 #	pragma warning(disable:4100) // C4100: 'c': unreferenced formal parameter
 #endif

--- a/3rdparty/stb/stb_truetype.h
+++ b/3rdparty/stb/stb_truetype.h
@@ -1,3 +1,9 @@
+#if defined(__has_warning)
+#	if __has_warning("-Wcomma")
+#		pragma GCC diagnostic ignored "-Wcomma" // Possible misuse of comma operator here
+#	endif
+#endif
+
 // stb_truetype.h - v1.15 - public domain
 // authored from 2009-2016 by Sean Barrett / RAD Game Tools
 //

--- a/examples/common/entry/entry_osx.mm
+++ b/examples/common/entry/entry_osx.mm
@@ -227,7 +227,7 @@ namespace entry
 			*_pressedChar = (uint8_t)keyChar;
 
 			int keyCode = keyChar;
-			*specialKeys = translateModifiers([event modifierFlags]);
+			*specialKeys = translateModifiers(int([event modifierFlags]));
 
 			// if this is a unhandled key just return None
 			if (keyCode < 256)

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -626,13 +626,13 @@ BGFX_C_API const char* bgfx_get_renderer_name(bgfx_renderer_type_t _type);
 BGFX_C_API bool bgfx_init(bgfx_renderer_type_t _type, uint16_t _vendorId, uint16_t _deviceId, bgfx_callback_interface_t* _callback, bgfx_allocator_interface_t* _allocator);
 
 /**/
-BGFX_C_API void bgfx_shutdown();
+BGFX_C_API void bgfx_shutdown(void);
 
 /**/
 BGFX_C_API void bgfx_reset(uint32_t _width, uint32_t _height, uint32_t _flags);
 
 /**/
-BGFX_C_API struct bgfx_encoder* bgfx_begin();
+BGFX_C_API struct bgfx_encoder* bgfx_begin(void);
 
 /**/
 BGFX_C_API void bgfx_end(struct bgfx_encoder* _encoder);
@@ -641,16 +641,16 @@ BGFX_C_API void bgfx_end(struct bgfx_encoder* _encoder);
 BGFX_C_API uint32_t bgfx_frame(bool _capture);
 
 /**/
-BGFX_C_API bgfx_renderer_type_t bgfx_get_renderer_type();
+BGFX_C_API bgfx_renderer_type_t bgfx_get_renderer_type(void);
 
 /**/
-BGFX_C_API const bgfx_caps_t* bgfx_get_caps();
+BGFX_C_API const bgfx_caps_t* bgfx_get_caps(void);
 
 /**/
-BGFX_C_API const bgfx_hmd_t* bgfx_get_hmd();
+BGFX_C_API const bgfx_hmd_t* bgfx_get_hmd(void);
 
 /**/
-BGFX_C_API const bgfx_stats_t* bgfx_get_stats();
+BGFX_C_API const bgfx_stats_t* bgfx_get_stats(void);
 
 /**/
 BGFX_C_API const bgfx_memory_t* bgfx_alloc(uint32_t _size);
@@ -833,7 +833,7 @@ BGFX_C_API bgfx_uniform_handle_t bgfx_create_uniform(const char* _name, bgfx_uni
 BGFX_C_API void bgfx_destroy_uniform(bgfx_uniform_handle_t _handle);
 
 /**/
-BGFX_C_API bgfx_occlusion_query_handle_t bgfx_create_occlusion_query();
+BGFX_C_API bgfx_occlusion_query_handle_t bgfx_create_occlusion_query(void);
 
 /**/
 BGFX_C_API bgfx_occlusion_query_result_t bgfx_get_result(bgfx_occlusion_query_handle_t _handle, int32_t* _result);
@@ -977,7 +977,7 @@ BGFX_C_API void bgfx_dispatch(bgfx_view_id_t _id, bgfx_program_handle_t _handle,
 BGFX_C_API void bgfx_dispatch_indirect(bgfx_view_id_t _id, bgfx_program_handle_t _handle, bgfx_indirect_buffer_handle_t _indirectHandle, uint16_t _start, uint16_t _num, uint8_t _flags);
 
 /**/
-BGFX_C_API void bgfx_discard();
+BGFX_C_API void bgfx_discard(void);
 
 /**/
 BGFX_C_API void bgfx_blit(bgfx_view_id_t _id, bgfx_texture_handle_t _dst, uint8_t _dstMip, uint16_t _dstX, uint16_t _dstY, uint16_t _dstZ, bgfx_texture_handle_t _src, uint8_t _srcMip, uint16_t _srcX, uint16_t _srcY, uint16_t _srcZ, uint16_t _width, uint16_t _height, uint16_t _depth);

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4663,7 +4663,7 @@ BGFX_C_API bool bgfx_init(bgfx_renderer_type_t _type, uint16_t _vendorId, uint16
 		);
 }
 
-BGFX_C_API void bgfx_shutdown()
+BGFX_C_API void bgfx_shutdown(void)
 {
 	return bgfx::shutdown();
 }
@@ -4678,22 +4678,22 @@ BGFX_C_API uint32_t bgfx_frame(bool _capture)
 	return bgfx::frame(_capture);
 }
 
-BGFX_C_API bgfx_renderer_type_t bgfx_get_renderer_type()
+BGFX_C_API bgfx_renderer_type_t bgfx_get_renderer_type(void)
 {
 	return bgfx_renderer_type_t(bgfx::getRendererType() );
 }
 
-BGFX_C_API const bgfx_caps_t* bgfx_get_caps()
+BGFX_C_API const bgfx_caps_t* bgfx_get_caps(void)
 {
 	return (const bgfx_caps_t*)bgfx::getCaps();
 }
 
-BGFX_C_API const bgfx_hmd_t* bgfx_get_hmd()
+BGFX_C_API const bgfx_hmd_t* bgfx_get_hmd(void)
 {
 	return (const bgfx_hmd_t*)bgfx::getHMD();
 }
 
-BGFX_C_API const bgfx_stats_t* bgfx_get_stats()
+BGFX_C_API const bgfx_stats_t* bgfx_get_stats(void)
 {
 	return (const bgfx_stats_t*)bgfx::getStats();
 }
@@ -5084,7 +5084,7 @@ BGFX_C_API void bgfx_destroy_uniform(bgfx_uniform_handle_t _handle)
 	bgfx::destroy(handle.cpp);
 }
 
-BGFX_C_API bgfx_occlusion_query_handle_t bgfx_create_occlusion_query()
+BGFX_C_API bgfx_occlusion_query_handle_t bgfx_create_occlusion_query(void)
 {
 	union { bgfx_occlusion_query_handle_t c; bgfx::OcclusionQueryHandle cpp; } handle;
 	handle.cpp = bgfx::createOcclusionQuery();
@@ -5353,7 +5353,7 @@ BGFX_C_API void bgfx_dispatch_indirect(bgfx_view_id_t _id, bgfx_program_handle_t
 	bgfx::dispatch(_id, handle.cpp, indirectHandle.cpp, _start, _num, _flags);
 }
 
-BGFX_C_API void bgfx_discard()
+BGFX_C_API void bgfx_discard(void)
 {
 	bgfx::discard();
 }


### PR DESCRIPTION
- Fixing compiler errors from C functions with missing argument lists.
- Silencing warning about `-Wunused-but-set-variable` being unknown.
- Silencing warnings about comma mis-use.
- Silencing warning about implicit cast from unsigned to int.