### PR TITLE
rename DxbcOperandModifier::None to DxbcOperandModifier::NoModifier

### DIFF
--- a/src/shader_dxbc.h
+++ b/src/shader_dxbc.h
@@ -452,7 +452,7 @@ namespace bgfx
 	{
 		enum Enum
 		{
-			None,
+			NoModifier,
 			Neg,
 			Abs,
 			AbsNeg,


### PR DESCRIPTION
when compiling bgfx under my unix VM I get the following error with clang:

`
  ==== Building bgfx (debug) ====
  amalgamated.cpp
  In file included from ../../external/bgfx/src/amalgamated.cpp:22:
  In file included from ../../external/bgfx/src/shader_dxbc.cpp:7:
  ../../external/bgfx/src/shader_dxbc.h:455:4: error: expected identifier
                          None,
                          ^
  /usr/include/X11/X.h:115:30: note: expanded from macro 'None'
  #define None                 0L /* universal null resource or null atom */
                               ^
`

Long story short shader_dxbc.h includes X11/X.h which has the lovely macro

  #define None                 0L        /* universal null resource or null atom */

that causes a compile error. 