### PR TITLE
maxTextureLayers limit for Metal

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -525,6 +525,7 @@ namespace bgfx { namespace mtl
 				g_caps.limits.maxFBAttachments = 8;
 				g_caps.supported |= BGFX_CAPS_TEXTURE_CUBE_ARRAY;
 			}
+			g_caps.limits.maxTextureLayers = 2048;
 
 			//todo: vendor id, device id, gpu enum
 


### PR DESCRIPTION
Source:
https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf

At Resources/Maximum number of layers per 1D texture array, 2D texture array, or 3D texture