### PR TITLE
fix ios11 black screen when using postprocess

### DIFF
--- a/src/glcontext_eagl.mm
+++ b/src/glcontext_eagl.mm
@@ -189,6 +189,7 @@ namespace bgfx { namespace gl
 
 		m_context = (void*)context;
 		[EAGLContext setCurrentContext:context];
+		[CATransaction flush];
 
 		GL_CHECK(glGenFramebuffers(1, &m_fbo) );
 		GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_fbo) );


### PR DESCRIPTION
ios11 requires to flush transactions before creating a new
framebuffer for full screen postproceses.