### PR TITLE
fix mingw gcc error

### DIFF
--- a/3rdparty/glslang/glslang/Include/Common.h
+++ b/3rdparty/glslang/glslang/Include/Common.h
@@ -39,7 +39,6 @@
 
 #if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/) || defined MINGW_HAS_SECURE_API
     #include <basetsd.h>
-    #define snprintf sprintf_s
     #define safe_vsprintf(buf,max,format,args) vsnprintf_s((buf), (max), (max), (format), (args))
 #elif defined (solaris)
     #define safe_vsprintf(buf,max,format,args) vsnprintf((buf), (max), (format), (args))
@@ -99,6 +98,10 @@ inline long long int atoll (const char* str)
 #include <string>
 #include <cstdio>
 #include <cassert>
+
+#if (defined(_MSC_VER) && _MSC_VER < 1900 /*vs2015*/) || defined MINGW_HAS_SECURE_API
+    #define snprintf sprintf_s
+#endif
 
 #include "PoolAlloc.h"
 


### PR DESCRIPTION
I can't build glslang by mingw-gcc , the error message is:
```
In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/stdio.h:1469:0,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/locale.h:12,
                 from C:/msys64/mingw64/include/c++/7.2.0/clocale:42,
                 from C:/msys64/mingw64/include/c++/7.2.0/x86_64-w64-mingw32/bits/c++locale.h:41,
                 from C:/msys64/mingw64/include/c++/7.2.0/bits/localefwd.h:40,
                 from C:/msys64/mingw64/include/c++/7.2.0/string:43,
                 from C:/msys64/mingw64/include/c++/7.2.0/stdexcept:39,
                 from C:/msys64/mingw64/include/c++/7.2.0/array:39,
                 from C:/msys64/mingw64/include/c++/7.2.0/tuple:39,
                 from C:/msys64/mingw64/include/c++/7.2.0/unordered_set:41,
                 from E:/opensource/bgfx/3rdparty/glslang/glslang/Include/Common.h:93,
                 from ../../../3rdparty/glslang/SPIRV/../glslang/Include/intermediate.h:55,
                 from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.h:41,
                 from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp:43:
C:/msys64/mingw64/x86_64-w64-mingw32/include/sec_api/stdio_s.h:57:23: error: conflicting declaration of 'int sprintf_s(char*, size_t, const char*, ...)' with 'C' linkage
   _SECIMP int __cdecl sprintf_s(char *_DstBuf,size_t _DstSize,const char *_Format,...);
                       ^~~~~~~~~
In file included from ../../../3rdparty/glslang/SPIRV/../glslang/Include/intermediate.h:55:0,
                 from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.h:41,
                 from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp:43:
E:/opensource/bgfx/3rdparty/glslang/glslang/Include/Common.h:42:22: note: previous declaration with 'C++' linkage
     #define snprintf sprintf_s
                      ^
In file included from C:/msys64/mingw64/include/c++/7.2.0/ext/string_conversions.h:43:0,
                 from C:/msys64/mingw64/include/c++/7.2.0/bits/basic_string.h:6159,
                 from C:/msys64/mingw64/include/c++/7.2.0/string:52,
                 from C:/msys64/mingw64/include/c++/7.2.0/stdexcept:39,
                 from C:/msys64/mingw64/include/c++/7.2.0/array:39,
                 from C:/msys64/mingw64/include/c++/7.2.0/tuple:39,
                 from C:/msys64/mingw64/include/c++/7.2.0/unordered_set:41,
                 from E:/opensource/bgfx/3rdparty/glslang/glslang/Include/Common.h:93,
                 from ../../../3rdparty/glslang/SPIRV/../glslang/Include/intermediate.h:55,
                 from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.h:41,
                 from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp:43:
C:/msys64/mingw64/include/c++/7.2.0/cstdio:175:11: error: '::snprintf' has not been declared
   using ::snprintf;
           ^~~~~~~~
C:/msys64/mingw64/include/c++/7.2.0/cstdio:185:22: error: '__gnu_cxx::snprintf' has not been declared
   using ::__gnu_cxx::snprintf;
                      ^~~~~~~~
In file included from ../../../3rdparty/glslang/SPIRV/../glslang/MachineIndependent/SymbolTable.h:69:0,
                 from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp:69:
E:/opensource/bgfx/3rdparty/glslang/glslang/Include/InfoSink.h: In member function 'glslang::TInfoSinkBase& glslang::TInfoSinkBase::operator<<(float)':
E:/opensource/bgfx/3rdparty/glslang/glslang/Include/InfoSink.h:78:58: error: 'snprintf' was not declared in this scope
                                                          snprintf(buf, size, (fabs(n) > 1e-8 && fabs(n) < 1e8) || n == 0.0f ? "%f" : "%g", n);
                                                          ^~~~~~~~
E:/opensource/bgfx/3rdparty/glslang/glslang/Include/InfoSink.h:78:58: note: suggested alternative: '_snprintf'
                                                          snprintf(buf, size, (fabs(n) > 1e-8 && fabs(n) < 1e8) || n == 0.0f ? "%f" : "%g", n);
                                                          ^~~~~~~~
                                                          _snprintf
In file included from ../../../3rdparty/glslang/SPIRV/../glslang/MachineIndependent/SymbolTable.h:69:0,
                 from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp:69:
E:/opensource/bgfx/3rdparty/glslang/glslang/Include/InfoSink.h: In member function 'void glslang::TInfoSinkBase::location(const glslang::TSourceLoc&)':
E:/opensource/bgfx/3rdparty/glslang/glslang/Include/InfoSink.h:100:9: error: 'snprintf' was not declared in this scope
         snprintf(locText, maxSize, ":%d", loc.line);
         ^~~~~~~~
E:/opensource/bgfx/3rdparty/glslang/glslang/Include/InfoSink.h:100:9: note: suggested alternative: '_snprintf'
         snprintf(locText, maxSize, ":%d", loc.line);
         ^~~~~~~~
         _snprintf
In file included from ../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp:69:0:
../../../3rdparty/glslang/SPIRV/../glslang/MachineIndependent/SymbolTable.h: In member function 'bool glslang::TSymbolTableLevel::insert(glslang::TSymbol&, bool)':
../../../3rdparty/glslang/SPIRV/../glslang/MachineIndependent/SymbolTable.h:377:13: error: 'snprintf' was not declared in this scope
             snprintf(buf, 20, "%s%d", AnonymousPrefix, symbol.getAsVariable()->getAnonId());
             ^~~~~~~~
../../../3rdparty/glslang/SPIRV/../glslang/MachineIndependent/SymbolTable.h:377:13: note: suggested alternative: '_snprintf'
             snprintf(buf, 20, "%s%d", AnonymousPrefix, symbol.getAsVariable()->getAnonId());
             ^~~~~~~~
             _snprintf
../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp: In function 'void glslang::GetSpirvVersion(std::__cxx11::string&)':
../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp:6613:5: error: 'snprintf' was not declared in this scope
     snprintf(buf, bufSize, "0x%08x, Revision %d", spv::Version, spv::Revision);
     ^~~~~~~~
../../../3rdparty/glslang/SPIRV/GlslangToSpv.cpp:6613:5: note: suggested alternative: '_snprintf'
     snprintf(buf, bufSize, "0x%08x, Revision %d", spv::Version, spv::Revision);
     ^~~~~~~~
     _snprintf
```
