### PR TITLE
Add 2D Texture layer attachment support in GL and D3D11

### DIFF
--- a/src/glimports.h
+++ b/src/glimports.h
@@ -112,6 +112,7 @@ typedef void           (GL_APIENTRYP PFNGLFINISHPROC) ();
 typedef void           (GL_APIENTRYP PFNGLFLUSHPROC) ();
 typedef void           (GL_APIENTRYP PFNGLFRAMEBUFFERRENDERBUFFERPROC) (GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
 typedef void           (GL_APIENTRYP PFNGLFRAMEBUFFERTEXTURE2DPROC) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+typedef void           (GL_APIENTRYP PFNGLFRAMEBUFFERTEXTURELAYERPROC) (GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer);
 typedef void           (GL_APIENTRYP PFNGLGENBUFFERSPROC) (GLsizei n, GLuint *buffers);
 typedef void           (GL_APIENTRYP PFNGLGENERATEMIPMAPPROC) (GLenum target);
 typedef void           (GL_APIENTRYP PFNGLGENFRAMEBUFFERSPROC) (GLsizei n, GLuint *framebuffers);
@@ -302,6 +303,7 @@ GL_IMPORT______(false, PFNGLFINISHPROC,                            glFinish);
 GL_IMPORT______(false, PFNGLFLUSHPROC,                             glFlush);
 GL_IMPORT______(true,  PFNGLFRAMEBUFFERRENDERBUFFERPROC,           glFramebufferRenderbuffer);
 GL_IMPORT______(true,  PFNGLFRAMEBUFFERTEXTURE2DPROC,              glFramebufferTexture2D);
+GL_IMPORT______(true,  PFNGLFRAMEBUFFERTEXTURELAYERPROC,           glFramebufferTextureLayer);
 GL_IMPORT______(false, PFNGLGENBUFFERSPROC,                        glGenBuffers);
 GL_IMPORT______(true,  PFNGLGENERATEMIPMAPPROC,                    glGenerateMipmap);
 GL_IMPORT______(true,  PFNGLGENFRAMEBUFFERSPROC,                   glGenFramebuffers);
@@ -342,7 +344,6 @@ GL_IMPORT______(false, PFNGLGETSHADERIVPROC,                       glGetShaderiv
 GL_IMPORT______(false, PFNGLGETSHADERINFOLOGPROC,                  glGetShaderInfoLog);
 GL_IMPORT______(false, PFNGLGETSTRINGPROC,                         glGetString);
 GL_IMPORT______(false, PFNGLGETUNIFORMLOCATIONPROC,                glGetUniformLocation);
-
 #if BGFX_CONFIG_RENDERER_OPENGL || !(BGFX_CONFIG_RENDERER_OPENGLES < 30)
 GL_IMPORT______(true,  PFNGLGETSTRINGIPROC,                        glGetStringi);
 GL_IMPORT______(true,  PFNGLINVALIDATEFRAMEBUFFERPROC,             glInvalidateFramebuffer);
@@ -449,6 +450,7 @@ GL_IMPORT_EXT__(true,  PFNGLDELETEFRAMEBUFFERSPROC,                glDeleteFrame
 GL_IMPORT_EXT__(true,  PFNGLCHECKFRAMEBUFFERSTATUSPROC,            glCheckFramebufferStatus);
 GL_IMPORT_EXT__(true,  PFNGLFRAMEBUFFERRENDERBUFFERPROC,           glFramebufferRenderbuffer);
 GL_IMPORT_EXT__(true,  PFNGLFRAMEBUFFERTEXTURE2DPROC,              glFramebufferTexture2D);
+GL_IMPORT_EXT__(true,  PFNGLFRAMEBUFFERTEXTURELAYERPROC,           glFramebufferTextureLayer);
 GL_IMPORT_EXT__(true,  PFNGLBINDRENDERBUFFERPROC,                  glBindRenderbuffer);
 GL_IMPORT_EXT__(true,  PFNGLGENRENDERBUFFERSPROC,                  glGenRenderbuffers);
 GL_IMPORT_EXT__(true,  PFNGLDELETERENDERBUFFERSPROC,               glDeleteRenderbuffers);
@@ -503,6 +505,8 @@ GL_IMPORT_EXT__(true,  PFNGLTEXSTORAGE2DPROC,                      glTexStorage2
 GL_IMPORT_EXT__(true,  PFNGLTEXSTORAGE3DPROC,                      glTexStorage3D);
 GL_IMPORT______(true,  PFNGLTEXIMAGE2DMULTISAMPLEPROC,             glTexImage2DMultisample);
 GL_IMPORT______(true,  PFNGLTEXIMAGE3DMULTISAMPLEPROC,             glTexImage3DMultisample);
+
+GL_IMPORT_EXT__(true,  PFNGLFRAMEBUFFERTEXTURELAYERPROC,           glFramebufferTextureLayer);
 
 GL_IMPORT_EXT__(true,  PFNGLINSERTEVENTMARKEREXTPROC,              glInsertEventMarker);
 GL_IMPORT_EXT__(true,  PFNGLPUSHGROUPMARKEREXTPROC,                glPushGroupMarker);

--- a/src/glimports.h
+++ b/src/glimports.h
@@ -344,6 +344,7 @@ GL_IMPORT______(false, PFNGLGETSHADERIVPROC,                       glGetShaderiv
 GL_IMPORT______(false, PFNGLGETSHADERINFOLOGPROC,                  glGetShaderInfoLog);
 GL_IMPORT______(false, PFNGLGETSTRINGPROC,                         glGetString);
 GL_IMPORT______(false, PFNGLGETUNIFORMLOCATIONPROC,                glGetUniformLocation);
+
 #if BGFX_CONFIG_RENDERER_OPENGL || !(BGFX_CONFIG_RENDERER_OPENGLES < 30)
 GL_IMPORT______(true,  PFNGLGETSTRINGIPROC,                        glGetStringi);
 GL_IMPORT______(true,  PFNGLINVALIDATEFRAMEBUFFERPROC,             glInvalidateFramebuffer);

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4984,34 +4984,34 @@ namespace bgfx { namespace d3d11
 						default:
 						case TextureD3D11::Texture2D:
 							if(1 < msaa.Count)
-+                                                       {
-+                                                               if(1 < texture.m_depth)
-+                                                               {
-+                                                                       desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY;
-+                                                                       desc.Texture2DMSArray.FirstArraySlice = m_attachment[ii].layer;
-+                                                                       desc.Texture2DMSArray.ArraySize = 1;
-+                                                               }
-+                                                               else
-+                                                               {
-+                                                                       desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMS;
-+                                                               }
-+                                                       }
-+                                                       else
-+                                                       {
-+                                                               if(1 < texture.m_depth)
-+                                                               {
-+                                                                       desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
-+                                                                       desc.Texture2DArray.FirstArraySlice = m_attachment[ii].layer;
-+                                                                       desc.Texture2DArray.ArraySize = 1;
-+                                                                       desc.Texture2DArray.MipSlice = m_attachment[ii].mip;
-+                                                               }
-+                                                               else
-+                                                               {
-+                                                                       desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
-+                                                                       desc.Texture2D.MipSlice = m_attachment[ii].mip;
-+                                                               }
-+                                                       }
-
+							{
+								if(1 < texture.m_depth)
+								{
+									desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY;
+									desc.Texture2DMSArray.FirstArraySlice = m_attachment[ii].layer;
+									desc.Texture2DMSArray.ArraySize = 1;
+								}
+								else
+								{
+									desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMS;
+								}
+							}
+							else
+							{
+								if(1 < texture.m_depth)
+								{
+									desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+									desc.Texture2DArray.FirstArraySlice = m_attachment[ii].layer;
+									desc.Texture2DArray.ArraySize = 1;
+									desc.Texture2DArray.MipSlice = m_attachment[ii].mip;
+								}
+								else
+								{
+									desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+									desc.Texture2D.MipSlice = m_attachment[ii].mip;
+								}
+							}
+							
 							DX_CHECK(s_renderD3D11->m_device->CreateRenderTargetView(
 								  NULL == texture.m_rt ? texture.m_ptr : texture.m_rt
 								, &desc

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4983,9 +4983,9 @@ namespace bgfx { namespace d3d11
 						{
 						default:
 						case TextureD3D11::Texture2D:
-							if(1 < msaa.Count)
+							if (1 < msaa.Count)
 							{
-								if(1 < texture.m_depth)
+								if (1 < texture.m_depth)
 								{
 									desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DMSARRAY;
 									desc.Texture2DMSArray.FirstArraySlice = m_attachment[ii].layer;
@@ -4998,7 +4998,7 @@ namespace bgfx { namespace d3d11
 							}
 							else
 							{
-								if(1 < texture.m_depth)
+								if (1 < texture.m_depth)
 								{
 									desc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
 									desc.Texture2DArray.FirstArraySlice = m_attachment[ii].layer;
@@ -5011,7 +5011,7 @@ namespace bgfx { namespace d3d11
 									desc.Texture2D.MipSlice = m_attachment[ii].mip;
 								}
 							}
-							
+
 							DX_CHECK(s_renderD3D11->m_device->CreateRenderTargetView(
 								  NULL == texture.m_rt ? texture.m_ptr : texture.m_rt
 								, &desc

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6212,17 +6212,29 @@ namespace bgfx { namespace gl
 					}
 					else
 					{
-						GLenum target = texture.isCubeMap()
-							? GL_TEXTURE_CUBE_MAP_POSITIVE_X + m_attachment[ii].layer
-							: texture.m_target
-							;
-
-						GL_CHECK(glFramebufferTexture2D(GL_FRAMEBUFFER
-							, attachment
-							, target
-							, texture.m_id
-							, m_attachment[ii].mip
+						if(texture.m_depth > 1 && !texture.isCubeMap())
+						{
+							GL_CHECK(glFramebufferTextureLayer(GL_FRAMEBUFFER
+								, attachment
+								, texture.m_id
+								, m_attachment[ii].mip
+								, m_attachment[ii].layer
 							) );
+						}
+						else
+						{
+							GLenum target = texture.isCubeMap()
+								? GL_TEXTURE_CUBE_MAP_POSITIVE_X + m_attachment[ii].layer
+								: texture.m_target
+								;
+
+							GL_CHECK(glFramebufferTexture2D(GL_FRAMEBUFFER
+								, attachment
+								, target
+								, texture.m_id
+								, m_attachment[ii].mip
+							) );
+						}
 					}
 
 					needResolve |= (0 != texture.m_rbo) && (0 != texture.m_id);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6212,7 +6212,8 @@ namespace bgfx { namespace gl
 					}
 					else
 					{
-						if(texture.m_depth > 1 && !texture.isCubeMap())
+						if (1 < texture.m_depth
+                        &&  !texture.isCubeMap())
 						{
 							GL_CHECK(glFramebufferTextureLayer(GL_FRAMEBUFFER
 								, attachment


### PR DESCRIPTION
This adds the ability to bind a FrameBuffer to a 2D Texture Array layer, which wasn't implemented so far.
I tested that it works in my own code, but none of the examples use that feature.
I checked that the examples still work.

Some notes :
- GL was already storing the number of layers in the `m_depth` member of the texture object, but D3D11 wasn't, so I opted to do the same for D3D11. 
- glFramebufferTextureLayer needed to be added to the GL imports. I'm not exactly sure I added them in the right way, but I think you will know how exactly it needs to be (glFramebufferTextureLayer exists in GL >= 30, GLES >= 30 and in an extension called ARB_geometry_shader4 ?)

EDIT : I have no idea why the CI build fails. This doesn't look related to the code ?