### PR TITLE
remove BX_FALLTHROUGH to avoid warning

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1508,7 +1508,6 @@ namespace bgfx { namespace d3d11
 				DX_RELEASE(m_swapChain, 0);
 				DX_RELEASE(m_deviceCtx, 0);
 				DX_RELEASE(m_device, 0);
-				BX_FALLTHROUGH;
 
 #if USE_D3D11_DYNAMIC_LIB
 				if (NULL != m_d3d9dll)


### PR DESCRIPTION
```
renderer_d3d11.cpp
In file included from ../../../../bx/include/bx/bx.h:17:0,
                 from ../../../src/config.h:9,
                 from ../../../src/bgfx_p.h:23,
                 from ../../../src/renderer_d3d11.cpp:6:
../../../src/renderer_d3d11.cpp: In member function 'bool bgfx::d3d11::RendererContextD3D11::init(const bgfx::Init&)':
../../../../bx/include/bx/macros.h:76:26: warning: attribute 'fallthrough' not preceding a case label or default label
 #  define BX_FALLTHROUGH __attribute__( (fallthrough) )
                          ^
../../../src/renderer_d3d11.cpp:1511:5: note: in expansion of macro 'BX_FALLTHROUGH'
     BX_FALLTHROUGH;
```

This warning is introduced by https://github.com/bkaradzic/bgfx/commit/480620751bcdc51dec9c71d917975c1de6a9723d  because of removing `case ErrorState::CreatedDXGIFactory` .