### PR TITLE
Fix blit to 2D texture layer on D3D11

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -5397,14 +5397,8 @@ namespace bgfx { namespace d3d11
 				box.bottom = blit.m_srcY + height;
 				box.back   = 1;
 
-				const uint32_t srcZ = TextureD3D11::TextureCube == src.m_type
-					? blit.m_srcZ
-					: 0
-					;
-				const uint32_t dstZ = TextureD3D11::TextureCube == dst.m_type
-					? blit.m_dstZ
-					: 0
-					;
+				const uint32_t srcZ = blit.m_srcZ;
+				const uint32_t dstZ = blit.m_dstZ;
 
 				deviceCtx->CopySubresourceRegion(dst.m_ptr
 					, dstZ*dst.m_numMips+blit.m_dstMip


### PR DESCRIPTION
Blitting to a 2D texture layer doesn't work on D3D11 : I pinned it down to these two lines, where the dest and source Z parameters are ignored if the texture is not a cubemap.
I simply removed the cubemap check, since it doesn't make much sense IIUC (2d textures can have layers too).