### PR TITLE
Fix warning -Wgnu-zero-variadic-macro-arguments

### DIFF
--- a/3rdparty/dear-imgui/imconfig.h
+++ b/3rdparty/dear-imgui/imconfig.h
@@ -15,7 +15,7 @@
 
 //---- Define assertion handler. Defaults to calling assert().
 #include <assert.h>
-#define IM_ASSERT(_EXPR, ...) assert(_EXPR)
+#define IM_ASSERT(_EXPR) assert(_EXPR)
 
 //---- Define attributes of all API symbols declarations, e.g. for DLL under Windows.
 //#define IMGUI_API __declspec( dllexport )


### PR DESCRIPTION
Having the ellipsis triggers the warning, and upstream doesn't have those : https://github.com/ocornut/imgui/blob/master/imconfig.h#L17

It seems safe to remove.