### PR TITLE
Small performance fix for large vertex buffers

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6590,7 +6590,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 		if (0 < _render->m_vboffset)
 		{
 			TransientVertexBuffer* vb = _render->m_transientVb;
-			m_vertexBuffers[vb->handle.idx].update(0, _render->m_vboffset, vb->data, true);
+			m_vertexBuffers[vb->handle.idx].update(0, _render->m_vboffset, vb->data, false);
 		}
 
 		_render->sort();


### PR DESCRIPTION
Feedback wanted:

Part of some changes we had in place. Separate from the other (unrelated) PR as we're not sure if it's safe.

Apparently this doubled the framerate of our game on a single PC that we know of.

CC-ing @xMyran since it was originally his change, he will have more insight on this.