### PR TITLE
Fix: Mouse up/down events from entry_sdl.cpp incorrectly have mouse_z=0

### DIFF
--- a/examples/common/entry/entry_sdl.cpp
+++ b/examples/common/entry/entry_sdl.cpp
@@ -561,7 +561,7 @@ namespace entry
 								m_eventQueue.postMouseEvent(handle
 									, mev.x
 									, mev.y
-									, 0
+									, m_mz
 									, button
 									, mev.type == SDL_MOUSEBUTTONDOWN
 									);


### PR DESCRIPTION
Results in this bug https://github.com/bkaradzic/bgfx/issues/1341