### PR TITLE
Error line searching for HLSL compiled with debug info

### DIFF
--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -624,8 +624,17 @@ namespace bgfx { namespace hlsl
 			int32_t start  = 0;
 			int32_t end    = INT32_MAX;
 
+			if (!hlslfp.empty())
+			{
+				const char* logfp = bx::strFind(log, hlslfp.c_str());
+				if (NULL != logfp)
+				{
+					log = logfp + hlslfp.length();
+				}
+			}
+
 			bool found = false
-				|| 2 == sscanf(log, "(%u,%u):",  &line, &column)
+				|| 2 == sscanf(log, "(%u,%u",  &line, &column)
 				|| 2 == sscanf(log, " :%u:%u: ", &line, &column)
 				;
 


### PR DESCRIPTION
Hello, when the DirectX11 HLSL shader compiler is used with debug (for example: `--debug --profile vs_4_0`), errors have the format:
`<path to hlsl>(<row>,<column>): <error text>`
or:
`<path to hlsl>(<row>,<start column>-<end column>): <error text>`
for example:
`E:\tmp\vs_cubes.bin.hlsl(9,1-2): error X3000: unrecognized identifier 'xx'`
This will search and skip the hlsl path in the error message.