### PR TITLE
Add C99 api : bgfx_vertex_decl_decode and bgfx_vertex_decl_has

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -1675,6 +1675,9 @@ namespace bgfx
 		VertexDecl& skip(uint8_t _num);
 
 		/// Decode attribute.
+		///
+		/// @attention C99 equivalent is `bgfx_vertex_decl_decode`.
+		///
 		void decode(
 			  Attrib::Enum _attrib
 			, uint8_t& _num
@@ -1684,6 +1687,9 @@ namespace bgfx
 			) const;
 
 		/// Returns true if VertexDecl contains attribute.
+		///
+		/// @attention C99 equivalent is `bgfx_vertex_decl_has`.
+		///
 		bool has(Attrib::Enum _attrib) const { return UINT16_MAX != m_attributes[_attrib]; }
 
 		/// Returns relative attribute offset from the vertex.

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -657,6 +657,12 @@ BGFX_C_API void bgfx_vertex_decl_begin(bgfx_vertex_decl_t* _decl, bgfx_renderer_
 BGFX_C_API void bgfx_vertex_decl_add(bgfx_vertex_decl_t* _decl, bgfx_attrib_t _attrib, uint8_t _num, bgfx_attrib_type_t _type, bool _normalized, bool _asInt);
 
 /**/
+BGFX_C_API void bgfx_vertex_decl_decode(const bgfx_vertex_decl_t* _decl, bgfx_attrib_t _attrib, uint8_t *_num, bgfx_attrib_type_t *_type, bool *_normalized, bool *_asInt);
+
+/**/
+BGFX_C_API bool bgfx_vertex_decl_has(const bgfx_vertex_decl_t* _decl, bgfx_attrib_t _attrib);
+
+/**/
 BGFX_C_API void bgfx_vertex_decl_skip(bgfx_vertex_decl_t* _decl, uint8_t _num);
 
 /**/

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4741,6 +4741,25 @@ BGFX_C_API void bgfx_vertex_decl_add(bgfx_vertex_decl_t* _decl, bgfx_attrib_t _a
 		);
 }
 
+BGFX_C_API void bgfx_vertex_decl_decode(const bgfx_vertex_decl_t* _decl, bgfx_attrib_t _attrib, uint8_t *_num, bgfx_attrib_type_t *_type, bool *_normalized, bool *_asInt)
+{
+	bgfx::AttribType::Enum type;
+	const bgfx::VertexDecl* decl = (const bgfx::VertexDecl*)_decl;
+	decl->decode(bgfx::Attrib::Enum(_attrib)
+		, *_num
+		, type
+		, *_normalized
+		, *_asInt
+		);
+	*_type = (bgfx_attrib_type_t)type;
+}
+
+BGFX_C_API bool bgfx_vertex_decl_has(const bgfx_vertex_decl_t* _decl, bgfx_attrib_t _attrib)
+{
+	const bgfx::VertexDecl* decl = (const bgfx::VertexDecl*)_decl;
+	return decl->has(bgfx::Attrib::Enum(_attrib));
+}
+
 BGFX_C_API void bgfx_vertex_decl_skip(bgfx_vertex_decl_t* _decl, uint8_t _num)
 {
 	bgfx::VertexDecl* decl = (bgfx::VertexDecl*)_decl;


### PR DESCRIPTION
I found some c99 api are missing when I do lua binding. I need these two api to convert struct bgfx_vertex_decl back to a lua table.
