### PR TITLE
Fixes "BGFX_INVALID_HANDLE undeclared" error in C

### DIFF
--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -15,6 +15,8 @@
 
 #include <bx/platform.h>
 
+#define BGFX_INVALID_HANDLE { UINT16_MAX }
+
 #ifndef BGFX_SHARED_LIB_BUILD
 #    define BGFX_SHARED_LIB_BUILD 0
 #endif // BGFX_SHARED_LIB_BUILD


### PR DESCRIPTION
When trying to use `BGFX_INVALID_HANDLE` in C, I get an error that it's undeclared. This fix clears everything up and is functionally identical to its C++ equivalent.

Really enjoying what BGFX has to offer! Keep it up!