### PR TITLE
Fix mingw-gcc target system

### DIFF
--- a/makefile
+++ b/makefile
@@ -111,7 +111,7 @@ freebsd-release64: .build/projects/gmake-freebsd ## Build - FreeBSD x86 Release
 freebsd: freebsd-debug32 freebsd-release32 freebsd-debug64 freebsd-release64 ## Build - FreeBSD x86/x64 Debug and Release
 
 .build/projects/gmake-mingw-gcc:
-	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --gcc=mingw-gcc gmake
+	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --os=windows --gcc=mingw-gcc gmake
 mingw-gcc-debug32: .build/projects/gmake-mingw-gcc ## Build - MinGW GCC x86 Debug
 	$(MAKE) -R -C .build/projects/gmake-mingw-gcc config=debug32
 mingw-gcc-release32: .build/projects/gmake-mingw-gcc ## Build - MinGW GCC x86 Release


### PR DESCRIPTION
See: https://github.com/bkaradzic/bgfx/blob/master/scripts/shaderc.lua#L161

![Example error](https://cdn.jared.im/RoyalTS_2018-08-02_17-10-37.png)

Considering all `mingw-gcc` builds are targeting the same operating system, the appropriate flag should be set or this condition will fail during cross-compilation - as shown above.

For example: building for Windows on Unix using the `mingw-gcc-release64` action will implicitly define Unix as the target system. We are targeting Windows, not Unix, and therefore we want the condition to pass and avoid any Unix-only source files. Cygwin can fix this by providing all required files but also includes several unwanted runtime dependencies and is not always a viable solution.