### PR TITLE
Fix linux-clang warning flags

### DIFF
--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -207,7 +207,7 @@ project "glslang"
 			"-Wno-deprecated-register",
 		}
 
-	configuration { "linux-*" }
+	configuration { "linux-gcc-*" }
 		buildoptions {
 			"-Wno-unused-but-set-variable",
 		}
@@ -308,7 +308,7 @@ project "glsl-optimizer"
 			"-Wno-deprecated-register",
 		}
 
-	configuration { "mingw* or linux" }
+	configuration { "mingw* or linux-gcc-*" }
 		buildoptions {
 			"-Wno-misleading-indentation",
 		}


### PR DESCRIPTION
`-Wno-unused-but-set-variable` and `-Wno-misleading-indentation` do not exist when building using `linux-clang`. If treat all warnings as errors has been enabled, the build will fail due to thousands of unknown argument errors.

See: https://clang.llvm.org/docs/DiagnosticsReference.html
And: https://github.com/bkaradzic/bx/pull/188