### PR TITLE
Fix issue with tab character in shaderc output

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -340,7 +340,7 @@ namespace bgfx
 					bx::snprintf(&hex[hexPos], sizeof(hex)-hexPos, "0x%02x, ", data[asciiPos]);
 					hexPos += 6;
 
-					ascii[asciiPos] = isprint(data[asciiPos]) && data[asciiPos] != '\\' ? data[asciiPos] : '.';
+					ascii[asciiPos] = isprint(data[asciiPos]) && data[asciiPos] != '\\'  && data[asciiPos] != '\t' ? data[asciiPos] : '.';
 					asciiPos++;
 
 					if (HEX_DUMP_WIDTH == asciiPos)


### PR DESCRIPTION
When printing the binary representation of the converted shader, shaderc
also prints a comment with the ascii readable characters for each line.
For unprintable characters, it relies on isprint() to replace them with
the '.' character.

Under MSVC 2017, isprint() may incorrectly return true for the tab
character. This patch adds a WAR to explicitly test for tabs, to make
sure they get replaced with '.'.

See here for discussion of isprint() bug on stackoverflow:

https://stackoverflow.com/questions/51435249/isprint-t-evaluates-to-true-64-with-md-compiler-option
