### PR TITLE
Add option to force bgfx::begin() to return an encoder for a worker thread

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -1907,7 +1907,9 @@ namespace bgfx
 
 	/// Begin submitting draw calls from thread.
 	///
-	Encoder* begin();
+	/// @param[in] _forThread Explicitly request an encoder for a worker thread.
+	///
+	Encoder* begin(bool _forThread = false);
 
 	/// End submitting draw calls from thread.
 	///

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -6,7 +6,7 @@
 #ifndef BGFX_DEFINES_H_HEADER_GUARD
 #define BGFX_DEFINES_H_HEADER_GUARD
 
-#define BGFX_API_VERSION UINT32_C(83)
+#define BGFX_API_VERSION UINT32_C(84)
 
 /// Color RGB/alpha/depth write. When it's not specified write will be disabled.
 #define BGFX_STATE_WRITE_R                 UINT64_C(0x0000000000000001) //!< Enable R write.

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1749,12 +1749,12 @@ namespace bgfx
 		}
 	}
 
-	Encoder* Context::begin()
+	Encoder* Context::begin(bool _forThread)
 	{
 		EncoderImpl* encoder = &m_encoder[0];
 
 #if BGFX_CONFIG_MULTITHREADED
-		if (BGFX_API_THREAD_MAGIC != s_threadIndex)
+		if (_forThread || BGFX_API_THREAD_MAGIC != s_threadIndex)
 		{
 			bx::MutexScope scopeLock(m_encoderApiLock);
 
@@ -3015,9 +3015,9 @@ namespace bgfx
 		s_ctx->reset(_width, _height, _flags, _format);
 	}
 
-	Encoder* begin()
+	Encoder* begin(bool _forThread)
 	{
-		return s_ctx->begin();
+		return s_ctx->begin(_forThread);
 	}
 
 #define BGFX_ENCODER(_func) reinterpret_cast<EncoderImpl*>(this)->_func

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -4507,7 +4507,7 @@ namespace bgfx
 			}
 		}
 
-		BGFX_API_FUNC(Encoder* begin() );
+		BGFX_API_FUNC(Encoder* begin(bool _forThread) );
 
 		BGFX_API_FUNC(void end(Encoder* _encoder) );
 


### PR DESCRIPTION
For now the only way to get an encoder usable from a worker thread is to call `bgfx::begin()` from a thread that is not the main thread.

This adds the ability to explicitly get an encoder for a worker thread from the main thread when calling `bgfx::begin()`.