### PR TITLE
Add option to turn off mipmap autogen

### DIFF
--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -6,7 +6,7 @@
 #ifndef BGFX_DEFINES_H_HEADER_GUARD
 #define BGFX_DEFINES_H_HEADER_GUARD
 
-#define BGFX_API_VERSION UINT32_C(83)
+#define BGFX_API_VERSION UINT32_C(84)
 
 /// Color RGB/alpha/depth write. When it's not specified write will be disabled.
 #define BGFX_STATE_WRITE_R                 UINT64_C(0x0000000000000001) //!< Enable R write.
@@ -350,6 +350,7 @@
 #define BGFX_TEXTURE_SRGB                UINT64_C(0x0000200000000000) //!< Sample texture as sRGB.
 #define BGFX_TEXTURE_BLIT_DST            UINT64_C(0x0000400000000000) //!< Texture will be used as blit destination.
 #define BGFX_TEXTURE_READ_BACK           UINT64_C(0x0000800000000000) //!< Texture will be used for read back from GPU.
+#define BGFX_TEXTURE_NO_MIP_AUTOGEN      UINT64_C(0x0000f00000000000) //!< Texture will not have mipmaps auto generated.
 
 /// Sampler flags.
 #define BGFX_SAMPLER_NONE                UINT32_C(0x00000000) //!<

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4515,7 +4515,9 @@ namespace bgfx { namespace d3d11
 		}
 
 		const bool renderTarget = 0 != (m_flags&BGFX_TEXTURE_RT_MASK);
+		const bool mipAutoGen   = 0 == (m_flags&BGFX_TEXTURE_NO_MIP_AUTOGEN);
 		if (renderTarget
+		&&  mipAutoGen
 		&&  1 < m_numMips)
 		{
 			deviceCtx->GenerateMips(m_srv);

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -3140,7 +3140,9 @@ namespace bgfx { namespace d3d9
 				) );
 			DX_RELEASE(surface, 1);
 
-			if (1 < m_numMips)
+			const bool mipAutoGen = 0 == (m_flags&BGFX_TEXTURE_NO_MIP_AUTOGEN);
+			if (1 < m_numMips
+			&&	mipAutoGen)
 			{
 				m_ptr->GenerateMipSubLevels();
 			}

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5191,7 +5191,9 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 	void TextureGL::resolve() const
 	{
 		const bool renderTarget = 0 != (m_flags&BGFX_TEXTURE_RT_MASK);
+		const bool mipAutoGen   = 0 == (m_flags&BGFX_TEXTURE_NO_MIP_AUTOGEN);
 		if (renderTarget
+		&&  mipAutoGen
 		&&  1 < m_numMips)
 		{
 			GL_CHECK(glBindTexture(m_target, m_id) );


### PR DESCRIPTION
This adds a Texture flag option to disable mipmap autogen.

I added it to all D3D/GL backends, so I added it to the D3D9 backend too, in the same location for consistency, but I wasn't sure about this one.