### PR TITLE
Revert 42b1104

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -4487,7 +4487,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 					GL_CHECK(glVertexAttribDivisor(loc, 0) );
 
 					uint32_t baseVertex = _baseVertex*_vertexDecl.m_stride + _vertexDecl.m_offset[attr];
-					if ( (BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL >= 30) ||  BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGLES >= 31) )
+					if (NULL != glVertexAttribIPointer
 					&& (AttribType::Uint8 == type || AttribType::Int16 == type)
 					&&  !normalized)
 					{


### PR DESCRIPTION
This reverts commit https://github.com/bkaradzic/bgfx/commit/42b1104b741c05a633cd0b4e4057edf2a8251e96 which was intended as a fix to https://github.com/bkaradzic/bgfx/issues/1395

The argument here is that the problem in https://github.com/bkaradzic/bgfx/issues/1395 could perfectly have been worked around by the user by using a `ivec4` attribute instead of an `uvec4`, which works just as well, while the current situation can only be worked around by compiling bgfx with a custom `BGFX_CONFIG_RENDERER_OPENGL` compiler define.

AFAIU the more functionality of bgfx is not tied to `BGFX_CONFIG_RENDERER_OPENGL`, and just works out of the box, the better.