### PR TITLE
support user define macros

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,8 +23,12 @@ endif
 
 # $(info $(OS))
 
+ifneq ($(DEFINE),)
+GENIEDEFINE=--define="$(DEFINE)"
+endif
+
 BX_DIR?=../bx
-GENIE?=$(BX_DIR)/tools/bin/$(OS)/genie
+GENIE?=$(BX_DIR)/tools/bin/$(OS)/genie $(GENIEDEFINE)
 NINJA?=$(BX_DIR)/tools/bin/$(OS)/ninja
 
 .PHONY: help

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -48,6 +48,11 @@ newoption {
 	description = "Enable building examples.",
 }
 
+newoption {
+	trigger = "define",
+	description = "User defined macro.",
+}
+
 solution "bgfx"
 	configurations {
 		"Debug",
@@ -388,7 +393,20 @@ end
 dofile "bgfx.lua"
 
 group "libs"
-bgfxProject("", "StaticLib", {})
+
+local function split_define(str)
+	local ret = {}
+	if str then
+		for v in string.gmatch(str, "%S+") do
+			table.insert(ret, v)
+		end
+	end
+	return ret
+end
+
+local userdefines = split_define(_OPTIONS["define"])
+
+bgfxProject("", "StaticLib", userdefines)
 
 dofile(path.join(BX_DIR,   "scripts/bx.lua"))
 dofile(path.join(BIMG_DIR, "scripts/bimg.lua"))
@@ -458,7 +476,7 @@ end
 
 if _OPTIONS["with-shared-lib"] then
 	group "libs"
-	bgfxProject("-shared-lib", "SharedLib", {})
+	bgfxProject("-shared-lib", "SharedLib", userdefines)
 end
 
 if _OPTIONS["with-tools"] then


### PR DESCRIPTION
Sometimes we need define some bgfx config macros in projects, such as `BGFX_CONFIG_MAX_VERTEX_STREAMS=8` . 

This patch allows defining macros when generate projects by adding a new option "defines" to genie script. and we can define macros on command line like this:
```
make DEFINE=BGFX_CONFIG_MAX_VERTEX_STREAMS=8
```


