### PR TITLE
Fix webgl2 instancing bug

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -4528,6 +4528,15 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 		}
 	}
 
+	void ProgramGL::unbindInstanceData() const
+	{
+		for(uint32_t ii = 0; 0xffff != m_instanceData[ii]; ++ii)
+		{
+			GLint loc = m_instanceData[ii];
+			GL_CHECK(glDisableVertexAttribArray(loc));
+		}
+	}
+
 	void IndexBufferGL::destroy()
 	{
 		GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0) );
@@ -7309,6 +7318,11 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 						if (hasOcclusionQuery)
 						{
 							m_occlusionQuery.end();
+						}
+
+						if(isValid(draw.m_instanceDataBuffer))
+						{
+							program.unbindInstanceData();
 						}
 
 						statsNumPrimsSubmitted[primIndex] += numPrimsSubmitted;

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -1329,6 +1329,7 @@ namespace bgfx { namespace gl
 		void destroy();
 		void init();
 		void bindInstanceData(uint32_t _stride, uint32_t _baseVertex = 0) const;
+		void unbindInstanceData() const;
 
 		void bindAttributesBegin()
 		{


### PR DESCRIPTION
There is a bug which cause instancing to simply fail with WebGL 2
The cause is that the instancing attributes are never disabled after having been used. In WebGL 2, specifically, this will cause the next draw call to fail. This fixes the problem by disabling instancing attributes when they were used.
