### PR TITLE
OpenGL format detection and wider framebuffer-creation support

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -3941,11 +3941,19 @@ namespace bgfx
 			return;
 		}
 
-		bool formatSupported = 0 != (g_caps.formats[_format] & (0
+		bool formatSupported;
+		if (0 != (_flags & (BGFX_TEXTURE_RT | BGFX_TEXTURE_RT_WRITE_ONLY)) )
+		{
+			formatSupported = 0 != (g_caps.formats[_format] & BGFX_CAPS_FORMAT_TEXTURE_FRAMEBUFFER);
+		}
+		else
+		{
+			formatSupported = 0 != (g_caps.formats[_format] & (0
 				| BGFX_CAPS_FORMAT_TEXTURE_2D
 				| BGFX_CAPS_FORMAT_TEXTURE_2D_EMULATED
 				| BGFX_CAPS_FORMAT_TEXTURE_2D_SRGB
 				) );
+		}
 		uint16_t srgbCaps = BGFX_CAPS_FORMAT_TEXTURE_2D_SRGB;
 
 		if (_cubeMap)

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1571,8 +1571,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			? tfi.m_internalFmtSrgb
 			: tfi.m_internalFmt
 			;
-		if (GL_ZERO == internalFmt
-		||  !tfi.m_supported)
+		if (GL_ZERO == internalFmt)
 		{
 			return false;
 		}
@@ -5911,11 +5910,27 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 
 					if (0 != texture.m_rbo)
 					{
-						GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER
-							, attachment
-							, GL_RENDERBUFFER
-							, texture.m_rbo
-							) );
+#if !(BGFX_CONFIG_RENDERER_OPENGL >= 30 || BGFX_CONFIG_RENDERER_OPENGLES >= 30)
+						if (GL_DEPTH_STENCIL_ATTACHMENT == attachment)
+						{
+							GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER
+								, GL_DEPTH_ATTACHMENT
+								, GL_RENDERBUFFER
+								, texture.m_rbo
+								) );
+							GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER
+								, GL_STENCIL_ATTACHMENT
+								, GL_RENDERBUFFER
+								, texture.m_rbo
+								) );
+						}
+						else
+#endif
+							GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER
+								, attachment
+								, GL_RENDERBUFFER
+								, texture.m_rbo
+								) );
 					}
 					else
 					{


### PR DESCRIPTION
Made an attempt at creating a pull request which deals with the things mentioned in #1528.
I feel that it should be ok that `isFramebufferFormatValid` only checks that it has an `internalFmt` just like `isImageFormatValid`.

Also, for devices that support `D24S8`-format but not `GL_DEPTH_STENCIL_ATTACHMENT` I made a proposed fix for that.

Finally I changed `isTextureFormatValid` to allow for creating framebuffers of formats that are only supported as that.