### PR TITLE
fixes #1559 - Support opening X display on GLX

### DIFF
--- a/src/glcontext_glx.cpp
+++ b/src/glcontext_glx.cpp
@@ -61,8 +61,8 @@ namespace bgfx { namespace gl
 	{
 		BX_UNUSED(_width, _height);
 
-		m_context = (GLXContext)g_platformData.context;
-		m_display = (::Display*)g_platformData.ndt;
+		m_context = static_cast<GLXContext>(g_platformData.context);
+		m_display = static_cast<::Display*>(g_platformData.ndt);
 
 		// It's possible the user has provided the window handle, but not
 		// the display handle. If this is the case, try opening the default

--- a/src/glcontext_glx.h
+++ b/src/glcontext_glx.h
@@ -21,6 +21,7 @@ namespace bgfx { namespace gl
 			: m_current(NULL)
 			, m_context(0)
 			, m_visualInfo(NULL)
+			, m_display(NULL)
 		{
 		}
 
@@ -44,6 +45,7 @@ namespace bgfx { namespace gl
 		SwapChainGL* m_current;
 		GLXContext m_context;
 		XVisualInfo* m_visualInfo;
+		::Display* m_display;
 	};
 } /* namespace gl */ } // namespace bgfx
 


### PR DESCRIPTION
This change makes bgfx open the default X display in case the user specified a custom window handle, but didn't specify the display. The display pointer is stored in a new ```m_display``` attribute, which is necessary to know if bgfx has to call ```XCloseDisplay()``` or not. I replaced all occurrences of ```(::Display*)g_platformData.ndt``` with ```m_display```.

glcontext_vk.cpp might still have this problem, I didn't look into it though.

I tested this on linux with all of the possible scenarios and it works.