### PR TITLE
Swapchain fixes

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -85,7 +85,7 @@ namespace bgfx
 				BX_MACRO_BLOCK_BEGIN                              \
 					if (!BX_IGNORE_C4127(_condition) )            \
 					{                                             \
-						BX_TRACE("WARN " _format, ##__VA_ARGS__); \
+						_BX_TRACE("WARN " _format, ##__VA_ARGS__); \
 					}                                             \
 				BX_MACRO_BLOCK_END
 
@@ -93,7 +93,7 @@ namespace bgfx
 				BX_MACRO_BLOCK_BEGIN                                                                                \
 					if (!BX_IGNORE_C4127(_condition) )                                                              \
 					{                                                                                               \
-						BX_TRACE("CHECK " _format, ##__VA_ARGS__);                                                  \
+						_BX_TRACE("CHECK " _format, ##__VA_ARGS__);                                                  \
 						bgfx::fatal(__FILE__, uint16_t(__LINE__), bgfx::Fatal::DebugCheck, _format, ##__VA_ARGS__); \
 					}                                                                                               \
 				BX_MACRO_BLOCK_END

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -17,6 +17,9 @@
 #	define BX_WARN  _BX_WARN
 #	define BX_CHECK _BX_CHECK
 #	define BX_CONFIG_ALLOCATOR_DEBUG 1
+#elif !defined(NDEBUG)
+#    define BX_WARN  _BX_WARN
+#    define BX_CHECK _BX_CHECK
 #endif // BGFX_CONFIG_DEBUG
 
 #include <bgfx/bgfx.h>

--- a/src/glcontext_eagl.h
+++ b/src/glcontext_eagl.h
@@ -35,7 +35,10 @@ namespace bgfx { namespace gl
 
 		void import();
 
-		GLuint getFbo();
+		GLuint getFbo()
+		{
+			return m_fbo;
+		}
 
 		bool isValid() const
 		{

--- a/src/glcontext_eagl.h
+++ b/src/glcontext_eagl.h
@@ -35,10 +35,7 @@ namespace bgfx { namespace gl
 
 		void import();
 
-		GLuint getFbo()
-		{
-			return m_fbo;
-		}
+		GLuint getFbo();
 
 		bool isValid() const
 		{

--- a/src/glcontext_eagl.mm
+++ b/src/glcontext_eagl.mm
@@ -368,18 +368,6 @@ namespace bgfx { namespace gl
 #	include "glimports.h"
 	}
 
-	GLuint GlContext::getFbo()
-	{
-		if(NULL == m_current)
-		{
-			return m_fbo;
-		}
-		else
-		{
-			return m_current->m_fbo;
-		}
-	}
-
 } /* namespace gl */ } // namespace bgfx
 
 #endif // BX_PLATFORM_IOS && (BGFX_CONFIG_RENDERER_OPENGLES|BGFX_CONFIG_RENDERER_OPENGL)

--- a/src/glcontext_eagl.mm
+++ b/src/glcontext_eagl.mm
@@ -368,6 +368,18 @@ namespace bgfx { namespace gl
 #	include "glimports.h"
 	}
 
+	GLuint GlContext::getFbo()
+	{
+		if(NULL == m_current)
+		{
+			return m_fbo;
+		}
+		else
+		{
+			return m_current->m_fbo;
+		}
+	}
+
 } /* namespace gl */ } // namespace bgfx
 
 #endif // BX_PLATFORM_IOS && (BGFX_CONFIG_RENDERER_OPENGLES|BGFX_CONFIG_RENDERER_OPENGL)

--- a/src/glcontext_eagl.mm
+++ b/src/glcontext_eagl.mm
@@ -41,27 +41,10 @@ namespace bgfx { namespace gl
 				];
 
 			[EAGLContext setCurrentContext:_context];
+			[CATransaction flush];
 
-			GL_CHECK(glGenFramebuffers(1, &m_fbo) );
-			GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_fbo) );
-
-			GL_CHECK(glGenRenderbuffers(1, &m_colorRbo) );
-			GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, m_colorRbo) );
-
-			[_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:_layer];
-			GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorRbo) );
-
-			GLint width;
-			GLint height;
-			GL_CHECK(glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &width) );
-			GL_CHECK(glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &height) );
-			BX_TRACE("Screen size: %d x %d", width, height);
-
-			m_width = width;
-			m_height = height;
 			m_layer = _layer;
-
-			createFrameBuffers(m_width, m_height);
+			createFrameBuffers();
 		}
 
 		~SwapChainGL()
@@ -93,17 +76,35 @@ namespace bgfx { namespace gl
 			}
 		}
 
-		void createFrameBuffers(GLint _width, GLint _height)
+		void createFrameBuffers()
 		{
+			GL_CHECK(glGenFramebuffers(1, &m_fbo) );
+			GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_fbo) );
+
+			GL_CHECK(glGenRenderbuffers(1, &m_colorRbo) );
+			GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, m_colorRbo) );
+
+			[m_context renderbufferStorage:GL_RENDERBUFFER fromDrawable:m_layer];
+			GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorRbo) );
+
+			GLint width;
+			GLint height;
+			GL_CHECK(glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &width) );
+			GL_CHECK(glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &height) );
+			BX_TRACE("Screen size: %d x %d", width, height);
+
 			GL_CHECK(glGenRenderbuffers(1, &m_depthStencilRbo) );
 			GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, m_depthStencilRbo) );
-			GL_CHECK(glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, _width, _height) );
+			GL_CHECK(glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, width, height) ); // from OES_packed_depth_stencil
 			GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilRbo) );
 			GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilRbo) );
 
 			GLenum err = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 			BX_CHECK(GL_FRAMEBUFFER_COMPLETE == err, "glCheckFramebufferStatus failed 0x%08x", err);
 			BX_UNUSED(err);
+
+			m_width = width;
+			m_height = height;
 
 			makeCurrent();
 
@@ -136,11 +137,7 @@ namespace bgfx { namespace gl
 			}
 
 			destroyFrameBuffers();
-
-			m_width = _width;
-			m_height = _height;
-
-			createFrameBuffers(m_width, m_height);
+			createFrameBuffers();
 		}
 
 		void swapBuffers()
@@ -332,7 +329,7 @@ namespace bgfx { namespace gl
 		}
 		else
 		{
-		    _swapChain->swapBuffers();
+			_swapChain->swapBuffers();
 		}
 	}
 

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3127,9 +3127,9 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 					m_frameBuffers[ii].postReset();
 				}
 
-				m_currentFbo = 0;
+				//m_currentFbo = 0;
 
-				GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_currentFbo) );
+				//GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_currentFbo) );
 			}
 		}
 
@@ -3171,7 +3171,8 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			{
 				m_needPresent |= true;
 
-				m_currentFbo = m_msaaBackBufferFbo;
+				//m_currentFbo = m_msaaBackBufferFbo;
+				GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_msaaBackBufferFbo) );
 
 				if (m_srgbWriteControlSupport)
 				{
@@ -3193,16 +3194,16 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 				{
 					m_glctx.makeCurrent(frameBuffer.m_swapChain);
 					frameBuffer.m_needPresent = true;
-					m_currentFbo = 0;
+					//m_currentFbo = 0;
 				}
 				else
 				{
 					m_glctx.makeCurrent(NULL);
-					m_currentFbo = frameBuffer.m_fbo[0];
+					//m_currentFbo = frameBuffer.m_fbo[0];
+					GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer.m_fbo[0]) );
 				}
 			}
 
-			GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_currentFbo) );
 
 			m_fbh       = _fbh;
 			m_fbDiscard = _discard;
@@ -3882,7 +3883,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 
 		Workaround m_workaround;
 
-		GLuint m_currentFbo;
+		//GLuint m_currentFbo;
 	};
 
 	RendererContextGL* s_renderGL;

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3193,7 +3193,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 				{
 					m_glctx.makeCurrent(frameBuffer.m_swapChain);
 					frameBuffer.m_needPresent = true;
-					m_currentFbo = 0;
+					m_currentFbo = m_glctx.getFbo();
 				}
 				else
 				{

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3193,7 +3193,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 				{
 					m_glctx.makeCurrent(frameBuffer.m_swapChain);
 					frameBuffer.m_needPresent = true;
-					m_currentFbo = m_glctx.getFbo();
+					m_currentFbo = 0;
 				}
 				else
 				{

--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -888,6 +888,35 @@ namespace bgfx { namespace mtl
 		uint8_t m_numMips;
 	};
 
+	struct FrameBufferMtl;
+
+	struct SwapChainMtl
+	{
+		SwapChainMtl()
+			: m_metalLayer(nil)
+			, m_drawable(nil)
+			, m_backBufferColorMSAA()
+			, m_backBufferDepth()
+			, m_backBufferStencil()
+			, m_maxAnisotropy(0)
+		{
+		}
+
+		~SwapChainMtl();
+
+		void init(void* _nwh);
+		void resize(FrameBufferMtl &_frameBuffer, uint32_t _width, uint32_t _height, uint32_t _flags);
+
+		id<CAMetalDrawable> currentDrawable();
+
+		CAMetalLayer* m_metalLayer;
+		id <CAMetalDrawable> m_drawable;
+		Texture m_backBufferColorMSAA;
+		Texture m_backBufferDepth;
+		Texture m_backBufferStencil;
+		uint32_t m_maxAnisotropy;
+	};
+
 	struct FrameBufferMtl
 	{
 		FrameBufferMtl()
@@ -910,6 +939,7 @@ namespace bgfx { namespace mtl
 		void postReset();
 		uint16_t destroy();
 
+		SwapChainMtl* m_swapChain;
 		uint32_t m_width;
 		uint32_t m_height;
 		uint16_t m_denseIdx;


### PR DESCRIPTION
These are fixes we need to be able to use multiple windows in out app (https://pacemaker.net/) (currently only used when running on iPad).
We have these changes live so they are tested on iOS both on GLES and Metal.

We have also added support for multiple windows in OS X for the window example so that at least the Metal functionality can be tested outside of our app.

Unfortunately the 'Use a single render target for VR rendering' commit broke swapchain support.
We don't now if our or Joseph Austin's fix to this breaks something else.

The last two commits are somewhat unrelated and reflect our changes to bx.
