### PR TITLE
fix GL include in renderer_gl.h

### DIFF
--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -56,7 +56,7 @@
 #			include <GL/gl.h>
 #		endif // BX_PLATFORM_
 
-#		include <gl/glext.h>
+#		include <GL/glext.h>
 #	endif // BGFX_CONFIG_RENDERER_OPENGL >= 31
 
 #elif BGFX_CONFIG_RENDERER_OPENGLES


### PR DESCRIPTION
On Debian only /usr/include/GL (upper-case) exists, this caused issues when porting to another build system.