### PR TITLE
We should use numVertices here rather than draw.m_numVertices

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -4066,7 +4066,7 @@ namespace bgfx { namespace mtl
 							numInstances      = draw.m_numInstances;
 							numPrimsRendered  = numPrimsSubmitted*draw.m_numInstances;
 
-							rce.drawPrimitives(prim.m_type, 0, draw.m_numVertices, draw.m_numInstances);
+							rce.drawPrimitives(prim.m_type, 0, numVertices, draw.m_numInstances);
 						}
 					}
 


### PR DESCRIPTION
It doesn't work when submit without indexed buffer on ios/metal.

`draw.m_numVertices` may be `UINT32_MAX` here.