### PR TITLE
VertexBufferGL unbinds correct target if destroyed

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -4554,7 +4554,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 
 	void VertexBufferGL::destroy()
 	{
-		GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, 0) );
+		GL_CHECK(glBindBuffer(m_target, 0) );
 		GL_CHECK(glDeleteBuffers(1, &m_id) );
 	}
 


### PR DESCRIPTION
it was only unbinding `GL_DRAW_BUFFER` when the vbo target could be either `GL_DRAW_BUFFER` or `GL_DRAW_INDIRECT_BUFFER`.

see https://github.com/bkaradzic/bgfx/blob/6bff345637c981136e4694b6dd3cac493be63adc/src/renderer_gl.h#L1186 for detail