### PR TITLE
fixed metal backbuffer issues

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -1566,7 +1566,7 @@ namespace bgfx { namespace mtl
 					: m_frameBuffers[_fbh.idx].m_swapChain
 					;
 
-				if (NULL != m_backBufferColorMsaa)
+				if (NULL != swapChain->m_backBufferColorMsaa)
 				{
 					renderPassDescriptor.colorAttachments[0].texture        = swapChain->m_backBufferColorMsaa;
 					renderPassDescriptor.colorAttachments[0].resolveTexture = NULL != m_screenshotTarget
@@ -1731,7 +1731,7 @@ namespace bgfx { namespace mtl
 
 			if (!isValid(_fbh) )
 			{
-				murmur.add(m_backBufferPixelFormatHash);
+				murmur.add(m_mainFrameBuffer.m_pixelFormatHash);
 			}
 			else
 			{
@@ -2164,10 +2164,6 @@ namespace bgfx { namespace mtl
 		CommandQueueMtl   m_cmd;
 
 		CAMetalLayer* m_metalLayer;
-		Texture       m_backBufferColorMsaa;
-		Texture       m_backBufferDepth;
-		Texture       m_backBufferStencil;
-		uint32_t      m_backBufferPixelFormatHash;
 		uint32_t      m_maxAnisotropy;
 
 		bool m_iOS9Runtime;


### PR DESCRIPTION
I have removed m_backBufferDepth and m_backBufferStencil, as they were not used anymore.

I have removed m_backBufferColorMsaa, it was used just here here(https://github.com/bkaradzic/bgfx/blob/master/src/renderer_mtl.mm#L1569), but inside the block swapChain->m_backBufferColorMsaa was used. 

I have removed m_backBufferPixelFormatHash. It was used just here (https://github.com/bkaradzic/bgfx/blob/master/src/renderer_mtl.mm#L1734). It wasn't even initialized. I think the hash for backbuffer is 'm_mainFrameBuffer.m_pixelFormatHash'.
