### PR TITLE
Disable d3d11 non-main window framebuffer multisampling

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4581,6 +4581,7 @@ namespace bgfx { namespace d3d11
 		scd.height = _height;
 		scd.nwh    = _nwh;
 		scd.ndt    = NULL;
+		scd.sampleDesc.Count = 1;
 
 		ID3D11Device* device = s_renderD3D11->m_device;
 


### PR DESCRIPTION
When multisampling is enabled the framebuffers on non-main windows don't display anything. Disabling the multisampling on them seems to solve the issue (but we render without multisampling obviously).