### PR TITLE
Set front face on gl context change

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3203,6 +3203,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			}
 
 			GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_currentFbo) );
+			GL_CHECK(glFrontFace(GL_CW) );
 
 			m_fbh       = _fbh;
 			m_fbDiscard = _discard;


### PR DESCRIPTION
When rendering on multiple windows, only the main window was rendering front-faces all the others were rendering backfaces. This commit sets the front faces on every context change (there could probably be a better implementation that does this only once for each context).