### PR TITLE
added spirv legalization

### DIFF
--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -606,6 +606,8 @@ project "shaderc"
 		path.join(GLSL_OPTIMIZER, "src/glsl"),
 
 		SPIRV_CROSS,
+
+		path.join(SPIRV_TOOLS, "include"),
 	}
 
 	links {


### PR DESCRIPTION
I have added legalization. It fixed the texture write access problem for MSL. I have added it for spirv output too, because as far as I can understand glslang can generate invalid spirv output when using hlsl input.

see warning here:
https://github.com/bkaradzic/bgfx/blob/master/3rdparty/glslang/hlsl/hlslParseHelper.cpp#L9969

Diff is terrible this time too. I have just added an extra indent for success path.