### PR TITLE
Crash fix for shaderc.cpp in release mode.

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -180,6 +180,7 @@ namespace bgfx
 		"i_data2",
 		"i_data3",
 		"i_data4",
+		NULL
 	};
 
 	Options::Options()


### PR DESCRIPTION
Fix for a crash I encountered when using shaderc in release mode when compiling a shader with incorrect input attributes. 
bx::findIdentifierMatch will run through the end of the list, as there is no closing NULL to stop the iteration, causing a crash in release mode, and resulting in shaderc exiting out without printing any errors.