### PR TITLE
Metal fb attachment

### DIFF
--- a/examples/08-update/update.cpp
+++ b/examples/08-update/update.cpp
@@ -313,7 +313,7 @@ public:
 			for (uint32_t ii = 0; ii < BX_COUNTOF(m_textureCubeFaceFb); ++ii)
 			{
 				bgfx::Attachment at;
-				at.init(m_textureCube[3], bgfx::Access::Write, ii);
+				at.init(m_textureCube[3], bgfx::Access::Write, uint16_t(ii));
 				m_textureCubeFaceFb[ii] = bgfx::createFrameBuffer(1, &at);
 			}
 		}
@@ -540,7 +540,7 @@ public:
 			
 			for (uint32_t ii = 0; ii < BX_COUNTOF(m_textureCubeFaceFb); ++ii)
 			{
-				bgfx::ViewId viewId = ii+2;
+				bgfx::ViewId viewId = bgfx::ViewId(ii+2);
 				bgfx::setViewFrameBuffer(viewId, m_textureCubeFaceFb[ii]);
 
 				bx::Vec3 color = bx::add(s_faceColors[ii], bx::sin(time*4.0f)*0.25f);

--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -1062,6 +1062,8 @@ namespace bgfx { namespace mtl
 
 		TextureHandle m_colorHandle[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS-1];
 		TextureHandle m_depthHandle;
+		Attachment m_colorAttachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS-1];
+		Attachment m_depthAttachment;
 		uint8_t m_num; // number of color handles
 	};
 


### PR DESCRIPTION
Fixed issue: https://github.com/bkaradzic/bgfx/issues/1618
08-update: added a cube that has a texturecube that is rendered using framebuffer attachment. It looks the same as the one whose texture is updated with compute shader.