### PR TITLE
Correct pitch usage for D3D9 updateTexture calls.

### DIFF
--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -373,6 +373,34 @@ namespace bgfx { namespace d3d9
 			;
 	}
 
+	static inline bool useD3D9Pitch(bimg::TextureFormat::Enum _format)
+	{
+		// For BC4 and B5 in DX9 LockRect returns wrong number of
+		// bytes. If actual mip size is used it causes memory corruption.
+		// http://www.aras-p.info/texts/D3D9GPUHacks.html#3dc
+		return true
+			&& _format != bimg::TextureFormat::BC4
+			&& _format != bimg::TextureFormat::BC5
+			;
+	}
+
+	static inline uint32_t calcRowPitch(const bimg::ImageBlockInfo& _blockInfo, uint8_t _lod, uint32_t _width)
+	{
+		const uint8_t blockWidth   = _blockInfo.blockWidth;
+		const uint8_t blockHeight  = _blockInfo.blockHeight;
+		const uint8_t minBlockX    = _blockInfo.minBlockX;
+		const uint8_t bitsPerPixel = _blockInfo.bitsPerPixel;
+
+		// Calculate the row pitch
+		const uint32_t minBlkWidth = minBlockX;
+		const uint32_t lodBlkWidth = (((_width >> _lod) + blockWidth - 1) / blockWidth);
+		const uint32_t rowBlkWidth = bx::max<uint32_t>(minBlkWidth, lodBlkWidth);
+		const uint32_t pixBlkWidth = rowBlkWidth * blockWidth * blockHeight;
+		const uint32_t rowPitch    = pixBlkWidth * bitsPerPixel / 8u;
+
+		return rowPitch;
+	}
+
 	struct RendererContextD3D9 : public RendererContextI
 	{
 		RendererContextD3D9()
@@ -2961,14 +2989,7 @@ namespace bgfx { namespace d3d9
 				return;
 			}
 
-			// For BC4 and B5 in DX9 LockRect returns wrong number of
-			// bytes. If actual mip size is used it causes memory corruption.
-			// http://www.aras-p.info/texts/D3D9GPUHacks.html#3dc
-			const bool useMipSize = true
-				&& imageContainer.m_format != bimg::TextureFormat::BC4
-				&& imageContainer.m_format != bimg::TextureFormat::BC5
-				;
-
+			const bool useMipSize = useD3D9Pitch(imageContainer.m_format);
 			for (uint8_t side = 0, numSides = imageContainer.m_cubeMap ? 6 : 1; side < numSides; ++side)
 			{
 				uint32_t width     = ti.width;
@@ -3062,11 +3083,14 @@ namespace bgfx { namespace d3d9
 
 	void TextureD3D9::update(uint8_t _side, uint8_t _mip, const Rect& _rect, uint16_t _z, uint16_t _depth, uint16_t _pitch, const Memory* _mem)
 	{
-		const uint32_t bpp = bimg::getBitsPerPixel(bimg::TextureFormat::Enum(m_textureFormat) );
-		const uint32_t rectpitch = _rect.m_width*bpp/8;
-		const uint32_t srcpitch  = UINT16_MAX == _pitch ? rectpitch : _pitch;
-		const uint32_t dstpitch  = s_renderD3D9->m_updateTexturePitch;
-		uint8_t* bits = s_renderD3D9->m_updateTextureBits + _rect.m_y*dstpitch + _rect.m_x*bpp/8;
+		const bimg::ImageBlockInfo & blockInfo = bimg::getBlockInfo(bimg::TextureFormat::Enum(m_textureFormat) );
+		const uint16_t blockHeight = blockInfo.blockHeight;
+		const uint16_t bpp         = blockInfo.bitsPerPixel;
+		const bool useLockedPitch  = useD3D9Pitch(bimg::TextureFormat::Enum(m_textureFormat) );
+		const uint32_t rectpitch   = calcRowPitch(blockInfo, 0, _rect.m_width);
+		const uint32_t srcpitch    = UINT16_MAX == _pitch ? rectpitch : _pitch;
+		const uint32_t dstpitch    = (useLockedPitch) ? s_renderD3D9->m_updateTexturePitch : calcRowPitch(blockInfo, _mip, m_width);
+		uint8_t* bits = s_renderD3D9->m_updateTextureBits + _rect.m_y*dstpitch/blockHeight + _rect.m_x*blockHeight*bpp/8;
 
 		const bool convert = m_textureFormat != m_requestedFormat;
 
@@ -3083,7 +3107,7 @@ namespace bgfx { namespace d3d9
 		{
 			uint8_t* src = data;
 			uint8_t* dst = bits;
-			for (uint32_t yy = 0, height = _rect.m_height; yy < height; ++yy)
+			for (uint32_t yy = 0, height = _rect.m_height; yy < height; yy += blockHeight)
 			{
 				switch (m_textureFormat)
 				{


### PR DESCRIPTION
Summary
=======

Adding support to `bgfx::updateTexture` for D3D9 to properly handle BCn texture formats.

Description
===========

In testing I found that compressed texture formats (BCn) aren't supported well in D3D9. Namely, I ran into corruption issues when trying to upload data. I deduced that this is because of three reasons:
1. The pitch is not calculated correctly for a block compression format.
2. The number of "lines" (y) to loop over to memcpy to the locked rectangle doesn't take block height into consideration.
3. For BC4/BC5 formats, the locked pitch returned doesn't accurately represent the actual pitch of the data.

To solve this, I have added a helper function `useD3D9Pitch` to encapsulate the check for BC4/BC5 (so that we can reference it in multiple places). And I created a `calcRowPitch` function which calculates the pitch for a given format using the bimg `ImageBlockInfo` data. Then, in `TextureD3D9::update` I refactored rectpitch, dstpitch, and bits to represent the proper values. I also increment yy (the y-axis loop for updating the rectangle of a texture) to now increment by blockHeight instead of 1.

Notes
=====

I believe that `bgfx::readTexture` is also busted, I don't see it asking for block size or anything, so I imagine it would cause corruption to attempt to read back a BCn texture format. I decided not to fix this because I was running into other issues with `bgfx::readTexture` that stopped me from properly testing my fix, so I will come back with another PR later for that issue.

I think fixing `bgfx::updateTexture` is important enough, and `bgfx::readTexture` can wait a little longer while we suss out all the details.

How Tested
==========

I tested this in a custom project by creating several sample BCn texture formats and attempting to load and display them on screen (ensuring that they made sense and matched what I expected). The test textures were hand-authored using custom code to be very specific looking (checkerboard patterns with alternating colours - if alpha is present, I mark every other line as 50% alpha to test all features of the BCn format in question).

I think these textures could be helpful in the future, so I have attached them for reference.
[bcn-textures.zip](https://github.com/bkaradzic/bgfx/files/2823851/bcn-textures.zip)

I also built the example projects with BGFX_CONFIG_RENDERER_DIRECT3D9 set to 1. I ran all of the examples that looked like they had anything to do with textures. All of them ran except for 3 of them - I then reverted my change locally to ensure that my change did not cause these problems. Even without my changes on D3D9 the issues still occur, so I am guessing these are other issues.

### Here are the examples that failed:

**example-21-deferred**
+ Nothing renders in the end.

**example-39-assao**
+ src\bgfx.cpp(3979): BGFX CHECK _mem can't be NULL

**example-40-svt**
+ Unhandled exception at 0x01392DB1 in example-40-svtRelease.exe: 0xC0000094: Integer division by zero. (in VirtualTexture::VirtualTexture, m_atlasCount = _atlassize / m_info->GetPageSize()) 