### PR TITLE
37-gpudrivenrendering fix for OpenGL

### DIFF
--- a/examples/37-gpudrivenrendering/cs_gdr_copy_z.sc
+++ b/examples/37-gpudrivenrendering/cs_gdr_copy_z.sc
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Kostas Anagnostou. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#include "bgfx_compute.sh"
+
+SAMPLER2D(s_texOcclusionDepth, 0);
+IMAGE2D_WR(s_texOcclusionDepthOut, r32f, 1);
+
+uniform vec4 u_inputRTSize;
+
+NUM_THREADS(16, 16, 1)
+void main()
+{
+	// this shader can be used to both copy a mip over to the output and downscale it.
+
+	ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+
+	if (all(lessThan(coord.xy, u_inputRTSize.xy) ) )
+	{
+		float maxDepth = texelFetch(s_texOcclusionDepth, coord.xy, 0).x;
+
+		imageStore(s_texOcclusionDepthOut, coord, vec4(maxDepth,0,0,1) );
+	}
+}

--- a/examples/37-gpudrivenrendering/cs_gdr_downscale_hi_z.sc
+++ b/examples/37-gpudrivenrendering/cs_gdr_downscale_hi_z.sc
@@ -21,26 +21,18 @@ void main()
 	{
 		float maxDepth = 1.0;
 
-		if (u_inputRTSize.z > 1)
-		{
-			vec4 depths = vec4(
-				  imageLoad(s_texOcclusionDepthIn, ivec2(u_inputRTSize.zw * coord.xy                   ) ).x
-				, imageLoad(s_texOcclusionDepthIn, ivec2(u_inputRTSize.zw * coord.xy + ivec2(1.0, 0.0) ) ).x
-				, imageLoad(s_texOcclusionDepthIn, ivec2(u_inputRTSize.zw * coord.xy + ivec2(0.0, 1.0) ) ).x
-				, imageLoad(s_texOcclusionDepthIn, ivec2(u_inputRTSize.zw * coord.xy + ivec2(1.0, 1.0) ) ).x
-				);
+		vec4 depths = vec4(
+				imageLoad(s_texOcclusionDepthIn, ivec2(u_inputRTSize.zw * coord.xy                   ) ).x
+			, imageLoad(s_texOcclusionDepthIn, ivec2(u_inputRTSize.zw * coord.xy + ivec2(1.0, 0.0) ) ).x
+			, imageLoad(s_texOcclusionDepthIn, ivec2(u_inputRTSize.zw * coord.xy + ivec2(0.0, 1.0) ) ).x
+			, imageLoad(s_texOcclusionDepthIn, ivec2(u_inputRTSize.zw * coord.xy + ivec2(1.0, 1.0) ) ).x
+			);
 
-			// find and return max depth
-			maxDepth = max(
-				  max(depths.x, depths.y)
-				, max(depths.z, depths.w)
-				);
-		}
-		else
-		{
-			// do not downscale, just copy the value over to the output rendertarget
-			maxDepth = imageLoad(s_texOcclusionDepthIn, coord.xy).x;
-		}
+		// find and return max depth
+		maxDepth = max(
+				max(depths.x, depths.y)
+			, max(depths.z, depths.w)
+			);
 
 		imageStore(s_texOcclusionDepthOut, coord, vec4(maxDepth,0,0,1) );
 	}

--- a/examples/37-gpudrivenrendering/cs_gdr_occlude_props.sc
+++ b/examples/37-gpudrivenrendering/cs_gdr_occlude_props.sc
@@ -51,6 +51,9 @@ void main()
 			//transform World space aaBox to NDC
 			vec4 clipPos = mul( u_viewProj, vec4(boxCorners[i], 1) );
 
+#if BGFX_SHADER_LANGUAGE_GLSL 
+			clipPos.z = 0.5 * ( clipPos.z + clipPos.w );
+#endif
 			clipPos.z = max(clipPos.z, 0);
 
 			clipPos.xyz = clipPos.xyz / clipPos.w;
@@ -83,6 +86,10 @@ void main()
 		if (dims.x <= 2 && dims.y <= 2)
 			mip = level_lower;
 
+#if BGFX_SHADER_LANGUAGE_GLSL
+		boxUVs.y = 1.0 - boxUVs.y;
+		boxUVs.w = 1.0 - boxUVs.w;
+#endif
 		//load depths from high z buffer
 		vec4 depth =
 		{

--- a/examples/37-gpudrivenrendering/cs_gdr_stream_compaction.sc
+++ b/examples/37-gpudrivenrendering/cs_gdr_stream_compaction.sc
@@ -32,8 +32,8 @@ void main()
 	int NoofDrawcalls = int(u_cullingConfig.w);
 
 	int offset = 1;
-	temp[2 * tID    ] = uint(instancePredicates[2 * tID    ]); // load input into shared memory
-	temp[2 * tID + 1] = uint(instancePredicates[2 * tID + 1]);
+	temp[2 * tID    ] = uint(instancePredicates[2 * tID    ] ? 1 : 0); // load input into shared memory
+	temp[2 * tID + 1] = uint(instancePredicates[2 * tID + 1] ? 1 : 0);
 
 	int d;
 


### PR DESCRIPTION
This fixes the first pass ('copy') of Z Buffer downscale for OpenGL.
It was handled with cs_gdr_downscale_hi_z.sc now it is handled with cs_gdr_copy_z.sc using sampler texelfetch instead of imageLoad.

Also fixed coordinate differences.

NOTE: On OpenGL there are still has problem with flat varying. It seems shaderc only adds flat to vs or fs, not both which causes link error.
Needs shader recompile.