### PR TITLE
Added GL_HALF_FLOAT_OES token

### DIFF
--- a/3rdparty/khronos/gl/glext.h
+++ b/3rdparty/khronos/gl/glext.h
@@ -1117,6 +1117,7 @@ typedef khronos_uint16_t GLhalf;
 #define GL_VERTEX_ARRAY_BINDING           0x85B5
 #define GL_CLAMP_VERTEX_COLOR             0x891A
 #define GL_CLAMP_FRAGMENT_COLOR           0x891B
+#define GL_HALF_FLOAT_OES                 0x8D61
 #define GL_ALPHA_INTEGER                  0x8D97
 typedef void (APIENTRYP PFNGLCOLORMASKIPROC) (GLuint index, GLboolean r, GLboolean g, GLboolean b, GLboolean a);
 typedef void (APIENTRYP PFNGLGETBOOLEANI_VPROC) (GLenum target, GLuint index, GLboolean *data);


### PR DESCRIPTION
Added the missing `GL_HALF_FLOAT_OES` token for the `GL_OES_vertex_half_float` extension. in GLES2 where `GL_HALF_FLOAT` is not available (only available in GLES3+) , this token needs to be used instead when the `GL_OES_vertex_half_float` extension is available.

References:
https://www.khronos.org/registry/OpenGL/extensions/OES/OES_vertex_half_float.txt
https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glVertexAttribPointer.xml
https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glVertexAttribPointer.xhtml