### PR TITLE
Adds missing renderer_nvn.cpp to amalgamated.cpp

### DIFF
--- a/src/amalgamated.cpp
+++ b/src/amalgamated.cpp
@@ -17,6 +17,7 @@
 #include "renderer_gl.cpp"
 #include "renderer_vk.cpp"
 #include "renderer_gnm.cpp"
+#include "renderer_nvn.cpp"
 #include "shader_dxbc.cpp"
 #include "shader_dx9bc.cpp"
 #include "shader_spirv.cpp"


### PR DESCRIPTION
I was using amalgamated.cpp with my build system and the commit on https://github.com/bkaradzic/bgfx/commit/9f7c3281e1ae0e3074f171a74c8c91e655d92138 did not add the new renderer to the file, causing a build error. I've added the missing renderer to the file to fix it.