### PR TITLE
Add support for using NSView for platform window handle

### DIFF
--- a/src/glcontext_nsgl.mm
+++ b/src/glcontext_nsgl.mm
@@ -67,8 +67,20 @@ namespace bgfx { namespace gl
 		BX_CHECK(NULL != s_opengl, "OpenGL dynamic library is not found!");
 
 		const AutoreleasePoolHolder pool;
-		NSWindow* nsWindow = (NSWindow*)g_platformData.nwh;
+		NSObject* nwh = (NSObject*)g_platformData.nwh;
 		m_context = g_platformData.context;
+
+		NSWindow* nsWindow = nil;
+		NSView* contentView = nil;
+		if ([nwh isKindOfClass:[NSView class]])
+		{
+			contentView = (NSView*)nwh;
+		}
+		else if ([nwh isKindOfClass:[NSWindow class]])
+		{
+			nsWindow = (NSWindow*)nwh;
+			contentView = [nsWindow contentView];
+		}
 
 		if (NULL == g_platformData.context)
 		{
@@ -99,14 +111,13 @@ namespace bgfx { namespace gl
 			NSOpenGLPixelFormat* pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:pixelFormatAttributes];
 			BGFX_FATAL(NULL != pixelFormat, Fatal::UnableToInitialize, "Failed to initialize pixel format.");
 
-			NSRect glViewRect = [[nsWindow contentView] bounds];
+			NSRect glViewRect = [contentView bounds];
 			NSOpenGLView* glView = [[NSOpenGLView alloc] initWithFrame:glViewRect pixelFormat:pixelFormat];
 
 			[pixelFormat release];
 			// GLFW creates a helper contentView that handles things like keyboard and drag and
 			// drop events. We don't want to clobber that view if it exists. Instead we just
 			// add ourselves as a subview and make the view resize automatically.
-			NSView *contentView = [nsWindow contentView];
 			if (nil != contentView)
 			{
 				[glView setAutoresizingMask:( NSViewHeightSizable |
@@ -119,7 +130,8 @@ namespace bgfx { namespace gl
 			}
 			else
 			{
-				[nsWindow setContentView:glView];
+				if (nil != nsWindow)
+					[nsWindow setContentView:glView];
 			}
 
 			NSOpenGLContext* glContext = [glView openGLContext];
@@ -179,8 +191,8 @@ namespace bgfx { namespace gl
 	{
 		uint64_t caps = 0;
 #if defined(MAC_OS_X_VERSION_MAX_ALLOWED) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
-		NSWindow* nsWindow = (NSWindow*)g_platformData.nwh;
-		if ([nsWindow respondsToSelector:@selector(backingScaleFactor)] && (1.0f < [nsWindow backingScaleFactor]))
+		NSObject* nwh = (NSObject*)g_platformData.nwh;
+		if ([nwh respondsToSelector:@selector(backingScaleFactor)] && (1.0f < [nwh backingScaleFactor]))
 			caps |= BGFX_CAPS_HIDPI;
 #endif // defined(MAC_OS_X_VERSION_MAX_ALLOWED) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
 		return caps;

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -2991,17 +2991,34 @@ namespace bgfx { namespace mtl
 				}
 				else
 				{
+					NSView *contentView;
+
+					if ([nvh isKindOfClass:[NSView class]])
+					{
+						contentView = (NSView*)nvh;
+					}
+					else if ([nvh isKindOfClass:[NSWindow class]])
+					{
+						NSWindow* nsWindow = (NSWindow*)nvh;
+						contentView = [nsWindow contentView];
+					}
+					else
+					{
+						BX_WARN(0, "Unable to create Metal device. Please set platform data window to an NSWindow, NSView, or CAMetalLayer");
+						return;
+					}
+
 					NSWindow* nsWindow = (NSWindow*)_nwh;
-					CALayer* layer = nsWindow.contentView.layer;
+					CALayer* layer = contentView.layer;
 					if(NULL != layer && [layer isKindOfClass:NSClassFromString(@"CAMetalLayer")])
 					{
 						m_metalLayer = (CAMetalLayer*)layer;
 					}
 					else
 					{
-						[nsWindow.contentView setWantsLayer:YES];
+						[contentView setWantsLayer:YES];
 						m_metalLayer = [CAMetalLayer layer];
-						[nsWindow.contentView setLayer:m_metalLayer];
+						[contentView setLayer:m_metalLayer];
 					}
 				}
 			}


### PR DESCRIPTION
I'm using bgfx in my application, along side Qt.

This is needed for interop between bgfx and Qt.

Qt has an API to get the native handle from a UI widget, called QWidget::winId(). However on mac, this returns a NSView and not an NSWindow. My patch updates the bgfx backend, so that it can accept both NSView and NSWindow in bgfx::PlatformData.nwh.