### PR TITLE
Implement aliasing vertex buffer with different vertex declaration.

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -5896,7 +5896,9 @@ namespace bgfx { namespace d3d11
 
 							const uint16_t handle = draw.m_stream[idx].m_handle.idx;
 							const VertexBufferD3D11& vb = m_vertexBuffers[handle];
-							const uint16_t decl = !isValid(vb.m_decl) ? draw.m_stream[idx].m_decl.idx : vb.m_decl.idx;
+							const uint16_t decl = isValid(draw.m_stream[idx].m_decl)
+								? draw.m_stream[idx].m_decl.idx
+								: vb.m_decl.idx;
 							const VertexDecl& vertexDecl = m_vertexDecls[decl];
 							const uint32_t stride = vertexDecl.m_stride;
 

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -6271,7 +6271,9 @@ namespace bgfx { namespace d3d12
 
 							uint16_t handle = draw.m_stream[idx].m_handle.idx;
 							const VertexBufferD3D12& vb = m_vertexBuffers[handle];
-							uint16_t decl = !isValid(vb.m_decl) ? draw.m_stream[idx].m_decl.idx : vb.m_decl.idx;
+							const uint16_t decl = isValid(draw.m_stream[idx].m_decl)
+								? draw.m_stream[idx].m_decl.idx
+								: vb.m_decl.idx;
 							const VertexDecl& vertexDecl = m_vertexDecls[decl];
 
 							decls[numStreams] = &vertexDecl;

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -4243,7 +4243,9 @@ namespace bgfx { namespace d3d9
 
 						const uint16_t handle = draw.m_stream[idx].m_handle.idx;
 						const VertexBufferD3D9& vb = m_vertexBuffers[handle];
-						const uint16_t decl = !isValid(vb.m_decl) ? draw.m_stream[idx].m_decl.idx : vb.m_decl.idx;
+						const uint16_t decl = isValid(draw.m_stream[idx].m_decl)
+							? draw.m_stream[idx].m_decl.idx
+							: vb.m_decl.idx;
 						const VertexDecl& vertexDecl = m_vertexDecls[decl];
 						const uint32_t stride = vertexDecl.m_stride;
 

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -7217,7 +7217,9 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 										currentState.m_stream[idx].m_startVertex = draw.m_stream[idx].m_startVertex;
 
 										const VertexBufferGL& vb = m_vertexBuffers[draw.m_stream[idx].m_handle.idx];
-										uint16_t decl = !isValid(vb.m_decl) ? draw.m_stream[idx].m_decl.idx : vb.m_decl.idx;
+										const uint16_t decl = isValid(draw.m_stream[idx].m_decl)
+											? draw.m_stream[idx].m_decl.idx
+											: vb.m_decl.idx;
 										GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, vb.m_id) );
 										program.bindAttributes(m_vertexDecls[decl], draw.m_stream[idx].m_startVertex);
 									}

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -4278,7 +4278,9 @@ namespace bgfx { namespace mtl
 
 						const uint16_t handle = draw.m_stream[idx].m_handle.idx;
 						const VertexBufferMtl& vb = m_vertexBuffers[handle];
-						const uint16_t decl = !isValid(vb.m_decl) ? draw.m_stream[idx].m_decl.idx : vb.m_decl.idx;
+						const uint16_t decl = isValid(draw.m_stream[idx].m_decl)
+							? draw.m_stream[idx].m_decl.idx
+							: vb.m_decl.idx;
 						const VertexDecl& vertexDecl = m_vertexDecls[decl];
 						const uint32_t stride = vertexDecl.m_stride;
 


### PR DESCRIPTION
The logic is now that vertex decl in the draw call always overrides/aliases the one in the vertex buffer, if present.
Examples still look correct on my machine.