### PR TITLE
Inline default values

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -158,10 +158,6 @@ namespace bgfx
 	{
 	public:
 		AllocatorStub()
-#if BGFX_CONFIG_MEMORY_TRACKING
-			: m_numBlocks(0)
-			, m_maxBlocks(0)
-#endif // BGFX_CONFIG_MEMORY_TRACKING
 		{
 		}
 
@@ -231,8 +227,8 @@ namespace bgfx
 	protected:
 #if BGFX_CONFIG_MEMORY_TRACKING
 		bx::Mutex m_mutex;
-		uint32_t m_numBlocks;
-		uint32_t m_maxBlocks;
+		uint32_t m_numBlocks = 0;
+		uint32_t m_maxBlocks = 0;
 #endif // BGFX_CONFIG_MEMORY_TRACKING
 	};
 

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -548,11 +548,6 @@ namespace bgfx
 	struct TextVideoMem
 	{
 		TextVideoMem()
-			: m_mem(NULL)
-			, m_size(0)
-			, m_width(0)
-			, m_height(0)
-			, m_small(false)
 		{
 			resize(false, 1, 1);
 			clear();
@@ -642,11 +637,11 @@ namespace bgfx
 			uint8_t character;
 		};
 
-		MemSlot* m_mem;
-		uint32_t m_size;
-		uint16_t m_width;
-		uint16_t m_height;
-		bool m_small;
+		MemSlot* m_mem = NULL;
+		uint32_t m_size = 0;
+		uint16_t m_width = 0;
+		uint16_t m_height = 0;
+		bool m_small = false;
 	};
 
 	struct TextVideoMemBlitter
@@ -674,7 +669,6 @@ namespace bgfx
 	struct UpdateBatchT
 	{
 		UpdateBatchT()
-			: m_num(0)
 		{
 		}
 
@@ -708,7 +702,7 @@ namespace bgfx
 			m_num = 0;
 		}
 
-		uint32_t m_num;
+		uint32_t m_num = 0;
 		uint32_t m_keys[maxKeys];
 		uint32_t m_values[maxKeys];
 	};
@@ -769,8 +763,6 @@ namespace bgfx
 
 	public:
 		CommandBuffer()
-			: m_pos(0)
-			, m_size(BGFX_CONFIG_MAX_COMMAND_BUFFER_SIZE)
 		{
 			finish();
 		}
@@ -882,8 +874,8 @@ namespace bgfx
 			m_pos = 0;
 		}
 
-		uint32_t m_pos;
-		uint32_t m_size;
+		uint32_t m_pos = 0;
+		uint32_t m_size = BGFX_CONFIG_MAX_COMMAND_BUFFER_SIZE;
 		uint8_t m_buffer[BGFX_CONFIG_MAX_COMMAND_BUFFER_SIZE];
 	};
 
@@ -1272,7 +1264,6 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 	struct RectCache
 	{
 		RectCache()
-			: m_num(0)
 		{
 		}
 
@@ -1297,7 +1288,7 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 		}
 
 		Rect m_cache[BGFX_CONFIG_MAX_RECT_CACHE];
-		uint32_t m_num;
+		uint32_t m_num = 0;
 	};
 
 #define CONSTANT_OPCODE_TYPE_SHIFT 27
@@ -1427,7 +1418,6 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 	private:
 		UniformBuffer(uint32_t _size)
 			: m_size(_size)
-			, m_pos(0)
 		{
 			finish();
 		}
@@ -1437,7 +1427,7 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 		}
 
 		uint32_t m_size;
-		uint32_t m_pos;
+		uint32_t m_pos = 0;
 		char m_buffer[256<<20];
 	};
 
@@ -1880,9 +1870,6 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 	BX_ALIGN_DECL_CACHE_LINE(struct) Frame
 	{
 		Frame()
-			: m_waitSubmit(0)
-			, m_waitRender(0)
-			, m_capture(false)
 		{
 			SortKey term;
 			term.reset();
@@ -2158,10 +2145,10 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 		Stats     m_perfStats;
 		ViewStats m_viewStats[BGFX_CONFIG_MAX_VIEWS];
 
-		int64_t m_waitSubmit;
-		int64_t m_waitRender;
+		int64_t m_waitSubmit = 0;
+		int64_t m_waitRender = 0;
 
-		bool m_capture;
+		bool m_capture = false;
 	};
 
 	BX_ALIGN_DECL_CACHE_LINE(struct) EncoderImpl
@@ -2813,21 +2800,6 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 		Context()
 			: m_render(&m_frame[0])
 			, m_submit(&m_frame[BGFX_CONFIG_MULTITHREADED ? 1 : 0])
-			, m_numFreeDynamicIndexBufferHandles(0)
-			, m_numFreeDynamicVertexBufferHandles(0)
-			, m_numFreeOcclusionQueryHandles(0)
-			, m_colorPaletteDirty(0)
-			, m_frames(0)
-			, m_debug(BGFX_DEBUG_NONE)
-			, m_rtMemoryUsed(0)
-			, m_textureMemoryUsed(0)
-			, m_renderCtx(NULL)
-			, m_renderMain(NULL)
-			, m_renderNoop(NULL)
-			, m_rendererInitialized(false)
-			, m_exit(false)
-			, m_flipAfterRender(false)
-			, m_singleThreaded(false)
 		{
 		}
 
@@ -4897,9 +4869,9 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 		DynamicIndexBuffer  m_dynamicIndexBuffers[BGFX_CONFIG_MAX_DYNAMIC_INDEX_BUFFERS];
 		DynamicVertexBuffer m_dynamicVertexBuffers[BGFX_CONFIG_MAX_DYNAMIC_VERTEX_BUFFERS];
 
-		uint16_t m_numFreeDynamicIndexBufferHandles;
-		uint16_t m_numFreeDynamicVertexBufferHandles;
-		uint16_t m_numFreeOcclusionQueryHandles;
+		uint16_t m_numFreeDynamicIndexBufferHandles = 0;
+		uint16_t m_numFreeDynamicVertexBufferHandles = 0;
+		uint16_t m_numFreeOcclusionQueryHandles = 0;
 		DynamicIndexBufferHandle  m_freeDynamicIndexBufferHandle[BGFX_CONFIG_MAX_DYNAMIC_INDEX_BUFFERS];
 		DynamicVertexBufferHandle m_freeDynamicVertexBufferHandle[BGFX_CONFIG_MAX_DYNAMIC_VERTEX_BUFFERS];
 		OcclusionQueryHandle      m_freeOcclusionQueryHandle[BGFX_CONFIG_MAX_OCCLUSION_QUERIES];
@@ -4942,27 +4914,27 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 
 		float m_clearColor[BGFX_CONFIG_MAX_COLOR_PALETTE][4];
 
-		uint8_t m_colorPaletteDirty;
+		uint8_t m_colorPaletteDirty = 0;
 
 		Init     m_init;
 		int64_t  m_frameTimeLast;
-		uint32_t m_frames;
-		uint32_t m_debug;
+		uint32_t m_frames = 0;
+		uint32_t m_debug = BGFX_DEBUG_NONE;
 
-		int64_t m_rtMemoryUsed;
-		int64_t m_textureMemoryUsed;
+		int64_t m_rtMemoryUsed = 0;
+		int64_t m_textureMemoryUsed = 0;
 
 		TextVideoMemBlitter m_textVideoMemBlitter;
 		ClearQuad m_clearQuad;
 
-		RendererContextI* m_renderCtx;
-		RendererContextI* m_renderMain;
-		RendererContextI* m_renderNoop;
+		RendererContextI* m_renderCtx = NULL;
+		RendererContextI* m_renderMain = NULL;
+		RendererContextI* m_renderNoop = NULL;
 
-		bool m_rendererInitialized;
-		bool m_exit;
-		bool m_flipAfterRender;
-		bool m_singleThreaded;
+		bool m_rendererInitialized = false;
+		bool m_exit = false;
+		bool m_flipAfterRender = false;
+		bool m_singleThreaded = false;
 		bool m_flipped;
 
 		typedef UpdateBatchT<256> TextureUpdateBatch;

--- a/src/dxgi.cpp
+++ b/src/dxgi.cpp
@@ -116,12 +116,6 @@ namespace bgfx
 	}
 
 	Dxgi::Dxgi()
-		: m_dxgiDll(NULL)
-		, m_dxgiDebugDll(NULL)
-		, m_driverType(D3D_DRIVER_TYPE_NULL)
-		, m_factory(NULL)
-		, m_adapter(NULL)
-		, m_output(NULL)
 	{
 	}
 

--- a/src/dxgi.h
+++ b/src/dxgi.h
@@ -95,14 +95,14 @@ namespace bgfx
 		void trim();
 
 		///
-		void* m_dxgiDll;
-		void* m_dxgiDebugDll;
+		void* m_dxgiDll = NULL;
+		void* m_dxgiDebugDll = NULL;
 
-		D3D_DRIVER_TYPE   m_driverType;
+		D3D_DRIVER_TYPE   m_driverType = D3D_DRIVER_TYPE_NULL;
 		DXGI_ADAPTER_DESC m_adapterDesc;
-		FactoryI* m_factory;
-		AdapterI* m_adapter;
-		OutputI*  m_output;
+		FactoryI* m_factory = NULL;
+		AdapterI* m_adapter = NULL;
+		OutputI*  m_output = NULL;
 	};
 
 } // namespace bgfx

--- a/src/glcontext_eagl.h
+++ b/src/glcontext_eagl.h
@@ -15,11 +15,6 @@ namespace bgfx { namespace gl
 	struct GlContext
 	{
 		GlContext()
-			: m_current(0)
-			, m_context(0)
-			, m_fbo(0)
-			, m_colorRbo(0)
-			, m_depthStencilRbo(0)
 		{
 		}
 
@@ -45,12 +40,12 @@ namespace bgfx { namespace gl
 			return 0 != m_context;
 		}
 
-		SwapChainGL* m_current;
-		void* m_context;
+		SwapChainGL* m_current = NULL;
+		void* m_context = NULL;
 
-		GLuint m_fbo;
-		GLuint m_colorRbo;
-		GLuint m_depthStencilRbo;
+		GLuint m_fbo = 0;
+		GLuint m_colorRbo = 0;
+		GLuint m_depthStencilRbo = 0;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_eagl.mm
+++ b/src/glcontext_eagl.mm
@@ -21,9 +21,6 @@ namespace bgfx { namespace gl
 	{
 		SwapChainGL(EAGLContext *_context, CAEAGLLayer *_layer)
 			: m_context(_context)
-			, m_fbo(0)
-			, m_colorRbo(0)
-			, m_depthStencilRbo(0)
 		{
 			_layer.contentsScale = [UIScreen mainScreen].scale;
 
@@ -152,9 +149,9 @@ namespace bgfx { namespace gl
 		EAGLContext* m_context;
 
 		CAEAGLLayer *m_layer;
-		GLuint m_fbo;
-		GLuint m_colorRbo;
-		GLuint m_depthStencilRbo;
+		GLuint m_fbo = 0;
+		GLuint m_colorRbo = 0;
+		GLuint m_depthStencilRbo = 0;
 		GLint m_width;
 		GLint m_height;
 	};

--- a/src/glcontext_egl.h
+++ b/src/glcontext_egl.h
@@ -22,10 +22,6 @@ namespace bgfx { namespace gl
 	struct GlContext
 	{
 		GlContext()
-			: m_current(NULL)
-			, m_context(NULL)
-			, m_display(NULL)
-			, m_surface(NULL)
 		{
 		}
 
@@ -47,11 +43,11 @@ namespace bgfx { namespace gl
 		}
 
 		void* m_eglLibrary;
-		SwapChainGL* m_current;
+		SwapChainGL* m_current = NULL;
 		EGLConfig  m_config;
-		EGLContext m_context;
-		EGLDisplay m_display;
-		EGLSurface m_surface;
+		EGLContext m_context = NULL;
+		EGLDisplay m_display = NULL;
+		EGLSurface m_surface = NULL;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_glx.h
+++ b/src/glcontext_glx.h
@@ -18,10 +18,6 @@ namespace bgfx { namespace gl
 	struct GlContext
 	{
 		GlContext()
-			: m_current(NULL)
-			, m_context(0)
-			, m_visualInfo(NULL)
-			, m_display(NULL)
 		{
 		}
 
@@ -42,10 +38,10 @@ namespace bgfx { namespace gl
 			return 0 != m_context;
 		}
 
-		SwapChainGL* m_current;
-		GLXContext m_context;
-		XVisualInfo* m_visualInfo;
-		::Display* m_display;
+		SwapChainGL* m_current = NULL;
+		GLXContext m_context = 0;
+		XVisualInfo* m_visualInfo = NULL;
+		::Display* m_display = NULL;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_nsgl.h
+++ b/src/glcontext_nsgl.h
@@ -15,8 +15,6 @@ namespace bgfx { namespace gl
 	struct GlContext
 	{
 		GlContext()
-			: m_context(NULL)
-			, m_view(NULL)
 		{
 		}
 
@@ -37,8 +35,8 @@ namespace bgfx { namespace gl
 			return NULL != m_context;
 		}
 
-		void* m_context;
-		void* m_view;
+		void* m_context = NULL;
+		void* m_view = NULL;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_wgl.h
+++ b/src/glcontext_wgl.h
@@ -61,10 +61,6 @@ typedef void (APIENTRYP PFNGLSTENCILOPPROC) (GLenum fail, GLenum zfail, GLenum z
 	struct GlContext
 	{
 		GlContext()
-			: m_current(NULL)
-			, m_opengl32dll(NULL)
-			, m_context(NULL)
-			, m_hdc(NULL)
 		{
 		}
 
@@ -88,10 +84,10 @@ typedef void (APIENTRYP PFNGLSTENCILOPPROC) (GLenum fail, GLenum zfail, GLenum z
 		int32_t m_contextAttrs[9];
 		int m_pixelFormat;
 		PIXELFORMATDESCRIPTOR m_pfd;
-		SwapChainGL* m_current;
-		void* m_opengl32dll;
-		HGLRC m_context;
-		HDC m_hdc;
+		SwapChainGL* m_current = NULL;
+		void* m_opengl32dll = NULL;
+		HGLRC m_context = NULL;
+		HDC m_hdc = NULL;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/nvapi.cpp
+++ b/src/nvapi.cpp
@@ -97,10 +97,6 @@ namespace bgfx
 	static PFN_NVAFTERMATH_GETPAGEFAULTINFORMATION  nvAftermathGetPageFaultInformation;
 
 	NvApi::NvApi()
-		: m_nvApiDll(NULL)
-		, m_nvGpu(NULL)
-		, m_nvAftermathDll(NULL)
-		, m_aftermathHandle(NULL)
 	{
 	}
 

--- a/src/nvapi.h
+++ b/src/nvapi.h
@@ -69,11 +69,11 @@ namespace bgfx
 		void setMarker(const bx::StringView& _marker);
 
 		///
-		void* m_nvApiDll;
-		NvPhysicalGpuHandle* m_nvGpu;
+		void* m_nvApiDll = NULL;
+		NvPhysicalGpuHandle* m_nvGpu = NULL;
 
-		void* m_nvAftermathDll;
-		NvAftermathContextHandle* m_aftermathHandle;
+		void* m_nvAftermathDll = NULL;
+		NvAftermathContextHandle* m_aftermathHandle = NULL;
 
 		PFN_NVAPI_MULTIDRAWINDIRECT nvApiD3D11MultiDrawInstancedIndirect;
 		PFN_NVAPI_MULTIDRAWINDIRECT nvApiD3D11MultiDrawIndexedInstancedIndirect;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -31,7 +31,6 @@ namespace bgfx
 	{
 		BlitState(const Frame* _frame)
 			: m_frame(_frame)
-			, m_item(0)
 		{
 			m_key.decode(_frame->m_blitKeys[0]);
 		}
@@ -55,7 +54,7 @@ namespace bgfx
 
 		const Frame* m_frame;
 		BlitKey  m_key;
-		uint16_t m_item;
+		uint16_t m_item = 0;
 	};
 
 	struct ViewState
@@ -483,8 +482,6 @@ namespace bgfx
 			: m_viewName(_viewName)
 			, m_frame(_frame)
 			, m_gpuTimer(_gpuTimer)
-			, m_queryIdx(UINT32_MAX)
-			, m_numViews(0)
 			, m_enabled(_enabled && 0 != (_frame->m_debug & BGFX_DEBUG_PROFILER) )
 		{
 		}
@@ -532,8 +529,8 @@ namespace bgfx
 		const char (*m_viewName)[BGFX_CONFIG_MAX_VIEW_NAME];
 		Frame*   m_frame;
 		Ty&      m_gpuTimer;
-		uint32_t m_queryIdx;
-		uint16_t m_numViews;
+		uint32_t m_queryIdx = UINT32_MAX;
+		uint16_t m_numViews = 0;
 		bool     m_enabled;
 	};
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -658,34 +658,6 @@ namespace bgfx { namespace d3d11
 	struct RendererContextD3D11 : public RendererContextI
 	{
 		RendererContextD3D11()
-			: m_d3d9Dll(NULL)
-			, m_d3d11Dll(NULL)
-			, m_renderDocDll(NULL)
-			, m_agsDll(NULL)
-			, m_ags(NULL)
-			, m_featureLevel(D3D_FEATURE_LEVEL(0) )
-			, m_swapChain(NULL)
-			, m_lost(false)
-			, m_numWindows(0)
-			, m_device(NULL)
-			, m_deviceCtx(NULL)
-			, m_annotation(NULL)
-			, m_infoQueue(NULL)
-			, m_backBufferColor(NULL)
-			, m_backBufferDepthStencil(NULL)
-			, m_currentColor(NULL)
-			, m_currentDepthStencil(NULL)
-			, m_captureTexture(NULL)
-			, m_captureResolve(NULL)
-			, m_maxAnisotropy(1)
-			, m_depthClamp(false)
-			, m_wireframe(false)
-			, m_currentProgram(NULL)
-			, m_vsChanges(0)
-			, m_fsChanges(0)
-			, m_rtMsaa(false)
-			, m_timerQuerySupport(false)
-			, m_directAccessSupport(false)
 		{
 			m_fbh.idx = kInvalidHandle;
 			bx::memSet(&m_scd, 0, sizeof(m_scd) );
@@ -3419,51 +3391,51 @@ namespace bgfx { namespace d3d11
 			}
 		}
 
-		void* m_d3d9Dll;
-		void* m_d3d11Dll;
-		void* m_renderDocDll;
-		void* m_agsDll;
+		void* m_d3d9Dll = NULL;
+		void* m_d3d11Dll = NULL;
+		void* m_renderDocDll = NULL;
+		void* m_agsDll = NULL;
 
 		Dxgi m_dxgi;
-		AGSContext* m_ags;
+		AGSContext* m_ags = NULL;
 		NvApi m_nvapi;
 
-		D3D_FEATURE_LEVEL m_featureLevel;
+		D3D_FEATURE_LEVEL m_featureLevel = D3D_FEATURE_LEVEL(0);
 
-		Dxgi::SwapChainI* m_swapChain;
+		Dxgi::SwapChainI* m_swapChain = NULL;
 		ID3D11Texture2D*  m_msaaRt;
 
 		bool m_needPresent;
-		bool m_lost;
-		uint16_t m_numWindows;
+		bool m_lost = false;
+		uint16_t m_numWindows = 0;
 		FrameBufferHandle m_windows[BGFX_CONFIG_MAX_FRAME_BUFFERS];
 
-		ID3D11Device*              m_device;
-		ID3D11DeviceContext*       m_deviceCtx;
-		ID3DUserDefinedAnnotation* m_annotation;
-		ID3D11InfoQueue*           m_infoQueue;
+		ID3D11Device*              m_device = NULL;
+		ID3D11DeviceContext*       m_deviceCtx = NULL;
+		ID3DUserDefinedAnnotation* m_annotation = NULL;
+		ID3D11InfoQueue*           m_infoQueue = NULL;
 
 		TimerQueryD3D11     m_gpuTimer;
 		OcclusionQueryD3D11 m_occlusionQuery;
 
 		uint32_t m_deviceInterfaceVersion;
 
-		ID3D11RenderTargetView* m_backBufferColor;
-		ID3D11DepthStencilView* m_backBufferDepthStencil;
-		ID3D11RenderTargetView* m_currentColor;
-		ID3D11DepthStencilView* m_currentDepthStencil;
+		ID3D11RenderTargetView* m_backBufferColor = NULL;
+		ID3D11DepthStencilView* m_backBufferDepthStencil = NULL;
+		ID3D11RenderTargetView* m_currentColor = NULL;
+		ID3D11DepthStencilView* m_currentDepthStencil = NULL;
 
-		ID3D11Texture2D* m_captureTexture;
-		ID3D11Texture2D* m_captureResolve;
+		ID3D11Texture2D* m_captureTexture = NULL;
+		ID3D11Texture2D* m_captureResolve = NULL;
 
 		Resolution m_resolution;
 
 		SwapChainDesc m_scd;
 		DXGI_SWAP_EFFECT m_swapEffect;
 		uint32_t m_swapBufferCount;
-		uint32_t m_maxAnisotropy;
-		bool m_depthClamp;
-		bool m_wireframe;
+		uint32_t m_maxAnisotropy = 1;
+		bool m_depthClamp = false;
+		bool m_wireframe = false;
 
 		IndexBufferD3D11 m_indexBuffers[BGFX_CONFIG_MAX_INDEX_BUFFERS];
 		VertexBufferD3D11 m_vertexBuffers[BGFX_CONFIG_MAX_VERTEX_BUFFERS];
@@ -3487,17 +3459,17 @@ namespace bgfx { namespace d3d11
 
 		TextureStage m_textureStage;
 
-		ProgramD3D11* m_currentProgram;
+		ProgramD3D11* m_currentProgram = NULL;
 
 		uint8_t m_vsScratch[64<<10];
 		uint8_t m_fsScratch[64<<10];
-		uint32_t m_vsChanges;
-		uint32_t m_fsChanges;
+		uint32_t m_vsChanges = 0;
+		uint32_t m_fsChanges = 0;
 
 		FrameBufferHandle m_fbh;
-		bool m_rtMsaa;
-		bool m_timerQuerySupport;
-		bool m_directAccessSupport;
+		bool m_rtMsaa = false;
+		bool m_timerQuerySupport = false;
+		bool m_directAccessSupport = false;
 	};
 
 	static RendererContextD3D11* s_renderD3D11;

--- a/src/renderer_d3d11.h
+++ b/src/renderer_d3d11.h
@@ -77,14 +77,6 @@ namespace bgfx { namespace d3d11
 	struct BufferD3D11
 	{
 		BufferD3D11()
-			: m_ptr(NULL)
-#if USE_D3D11_STAGING_BUFFER
-			, m_staging(NULL)
-#endif // USE_D3D11_STAGING_BUFFER
-			, m_srv(NULL)
-			, m_uav(NULL)
-			, m_flags(BGFX_BUFFER_NONE)
-			, m_dynamic(false)
 		{
 		}
 
@@ -107,15 +99,15 @@ namespace bgfx { namespace d3d11
 			DX_RELEASE(m_uav, 0);
 		}
 
-		ID3D11Buffer* m_ptr;
+		ID3D11Buffer* m_ptr = NULL;
 #if USE_D3D11_STAGING_BUFFER
-		ID3D11Buffer* m_staging;
+		ID3D11Buffer* m_staging = NULL;
 #endif // USE_D3D11_STAGING_BUFFER
-		ID3D11ShaderResourceView*  m_srv;
-		ID3D11UnorderedAccessView* m_uav;
+		ID3D11ShaderResourceView*  m_srv = NULL;
+		ID3D11UnorderedAccessView* m_uav = NULL;
 		uint32_t m_size;
-		uint16_t m_flags;
-		bool m_dynamic;
+		uint16_t m_flags = BGFX_BUFFER_NONE;
+		bool m_dynamic = false;
 	};
 
 	typedef BufferD3D11 IndexBufferD3D11;
@@ -135,14 +127,6 @@ namespace bgfx { namespace d3d11
 	struct ShaderD3D11
 	{
 		ShaderD3D11()
-			: m_ptr(NULL)
-			, m_code(NULL)
-			, m_buffer(NULL)
-			, m_constantBuffer(NULL)
-			, m_hash(0)
-			, m_numUniforms(0)
-			, m_numPredefined(0)
-			, m_hasDepthOp(false)
 		{
 		}
 
@@ -178,27 +162,25 @@ namespace bgfx { namespace d3d11
 			ID3D11ComputeShader* m_computeShader;
 			ID3D11PixelShader*   m_pixelShader;
 			ID3D11VertexShader*  m_vertexShader;
-			ID3D11DeviceChild*   m_ptr;
+			ID3D11DeviceChild*   m_ptr = NULL;
 		};
-		const Memory* m_code;
-		ID3D11Buffer* m_buffer;
-		UniformBuffer* m_constantBuffer;
+		const Memory* m_code = NULL;
+		ID3D11Buffer* m_buffer = NULL;
+		UniformBuffer* m_constantBuffer = NULL;
 
 		PredefinedUniform m_predefined[PredefinedUniform::Count];
 		uint16_t m_attrMask[Attrib::Count];
 
-		uint32_t m_hash;
+		uint32_t m_hash = 0;
 
-		uint16_t m_numUniforms;
-		uint8_t m_numPredefined;
-		bool m_hasDepthOp;
+		uint16_t m_numUniforms = 0;
+		uint8_t m_numPredefined = 0;
+		bool m_hasDepthOp = false;
 	};
 
 	struct ProgramD3D11
 	{
 		ProgramD3D11()
-			: m_vsh(NULL)
-			, m_fsh(NULL)
 		{
 		}
 
@@ -225,8 +207,8 @@ namespace bgfx { namespace d3d11
 			m_fsh = NULL;
 		}
 
-		const ShaderD3D11* m_vsh;
-		const ShaderD3D11* m_fsh;
+		const ShaderD3D11* m_vsh = NULL;
+		const ShaderD3D11* m_fsh = NULL;
 
 		PredefinedUniform m_predefined[PredefinedUniform::Count*2];
 		uint8_t m_numPredefined;
@@ -245,8 +227,6 @@ namespace bgfx { namespace d3d11
 	struct DirectAccessResourceD3D11
 	{
 		DirectAccessResourceD3D11()
-			: m_ptr(NULL)
-			, m_descriptor(NULL)
 		{
 		}
 
@@ -256,12 +236,12 @@ namespace bgfx { namespace d3d11
 
 		union
 		{
-			ID3D11Resource*  m_ptr;
+			ID3D11Resource*  m_ptr = NULL;
 			ID3D11Texture2D* m_texture2d;
 			ID3D11Texture3D* m_texture3d;
 		};
 
-		IntelDirectAccessResourceDescriptor* m_descriptor;
+		IntelDirectAccessResourceDescriptor* m_descriptor = NULL;
 	};
 
 	struct TextureD3D11
@@ -274,11 +254,6 @@ namespace bgfx { namespace d3d11
 		};
 
 		TextureD3D11()
-			: m_ptr(NULL)
-			, m_rt(NULL)
-			, m_srv(NULL)
-			, m_uav(NULL)
-			, m_numMips(0)
 		{
 		}
 
@@ -293,7 +268,7 @@ namespace bgfx { namespace d3d11
 
 		union
 		{
-			ID3D11Resource*  m_ptr;
+			ID3D11Resource*  m_ptr = NULL;
 			ID3D11Texture2D* m_texture2d;
 			ID3D11Texture3D* m_texture3d;
 		};
@@ -302,12 +277,12 @@ namespace bgfx { namespace d3d11
 
 		union
 		{
-			ID3D11Resource* m_rt;
+			ID3D11Resource* m_rt = NULL;
 			ID3D11Texture2D* m_rt2d;
 		};
 
-		ID3D11ShaderResourceView*  m_srv;
-		ID3D11UnorderedAccessView* m_uav;
+		ID3D11ShaderResourceView*  m_srv = NULL;
+		ID3D11UnorderedAccessView* m_uav = NULL;
 		uint64_t m_flags;
 		uint32_t m_width;
 		uint32_t m_height;
@@ -316,22 +291,12 @@ namespace bgfx { namespace d3d11
 		uint8_t  m_type;
 		uint8_t  m_requestedFormat;
 		uint8_t  m_textureFormat;
-		uint8_t  m_numMips;
+		uint8_t  m_numMips = 0;
 	};
 
 	struct FrameBufferD3D11
 	{
 		FrameBufferD3D11()
-			: m_dsv(NULL)
-			, m_swapChain(NULL)
-			, m_nwh(NULL)
-			, m_width(0)
-			, m_height(0)
-			, m_denseIdx(UINT16_MAX)
-			, m_num(0)
-			, m_numTh(0)
-			, m_numUav(0)
-			, m_needPresent(false)
 		{
 		}
 
@@ -348,18 +313,18 @@ namespace bgfx { namespace d3d11
 		ID3D11RenderTargetView*    m_rtv[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS-1];
 		ID3D11UnorderedAccessView* m_uav[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS-1];
 		ID3D11ShaderResourceView*  m_srv[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS-1];
-		ID3D11DepthStencilView*    m_dsv;
-		Dxgi::SwapChainI* m_swapChain;
-		void* m_nwh;
-		uint32_t m_width;
-		uint32_t m_height;
+		ID3D11DepthStencilView*    m_dsv = NULL;
+		Dxgi::SwapChainI* m_swapChain = NULL;
+		void* m_nwh = NULL;
+		uint32_t m_width = 0;
+		uint32_t m_height = 0;
 
 		Attachment m_attachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
-		uint16_t m_denseIdx;
-		uint8_t m_num;
-		uint8_t m_numTh;
-		uint8_t m_numUav;
-		bool m_needPresent;
+		uint16_t m_denseIdx = UINT16_MAX;
+		uint8_t m_num = 0;
+		uint8_t m_numTh = 0;
+		uint8_t m_numUav = 0;
+		bool m_needPresent = false;
 	};
 
 	struct TimerQueryD3D11

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -649,20 +649,6 @@ namespace bgfx { namespace d3d12
 	struct RendererContextD3D12 : public RendererContextI
 	{
 		RendererContextD3D12()
-			: m_d3d12Dll(NULL)
-			, m_renderDocDll(NULL)
-			, m_winPixEvent(NULL)
-			, m_featureLevel(D3D_FEATURE_LEVEL(0) )
-			, m_swapChain(NULL)
-			, m_wireframe(false)
-			, m_lost(false)
-			, m_maxAnisotropy(1)
-			, m_depthClamp(false)
-			, m_fsChanges(0)
-			, m_vsChanges(0)
-			, m_backBufferColorIdx(0)
-			, m_rtMsaa(false)
-			, m_directAccessSupport(false)
 		{
 		}
 
@@ -3293,17 +3279,17 @@ namespace bgfx { namespace d3d12
 		NvApi m_nvapi;
 
 		void* m_kernel32Dll;
-		void* m_d3d12Dll;
-		void* m_renderDocDll;
-		void* m_winPixEvent;
+		void* m_d3d12Dll = NULL;
+		void* m_renderDocDll = NULL;
+		void* m_winPixEvent = NULL;
 
-		D3D_FEATURE_LEVEL m_featureLevel;
+		D3D_FEATURE_LEVEL m_featureLevel = D3D_FEATURE_LEVEL(0);
 
 		D3D_DRIVER_TYPE m_driverType;
 		D3D12_FEATURE_DATA_ARCHITECTURE m_architecture;
 		D3D12_FEATURE_DATA_D3D12_OPTIONS m_options;
 
-		Dxgi::SwapChainI* m_swapChain;
+		Dxgi::SwapChainI* m_swapChain = NULL;
 		ID3D12Resource*   m_msaaRt;
 
 #if BX_PLATFORM_WINDOWS
@@ -3341,12 +3327,12 @@ namespace bgfx { namespace d3d12
 		ID3D12GraphicsCommandList* m_commandList;
 
 		Resolution m_resolution;
-		bool m_wireframe;
-		bool m_lost;
+		bool m_wireframe = false;
+		bool m_lost = false;
 
 		SwapChainDesc m_scd;
-		uint32_t m_maxAnisotropy;
-		bool m_depthClamp;
+		uint32_t m_maxAnisotropy = 1;
+		bool m_depthClamp = false;
 
 		BufferD3D12 m_indexBuffers[BGFX_CONFIG_MAX_INDEX_BUFFERS];
 		VertexBufferD3D12 m_vertexBuffers[BGFX_CONFIG_MAX_VERTEX_BUFFERS];
@@ -3366,13 +3352,13 @@ namespace bgfx { namespace d3d12
 
 		uint8_t m_fsScratch[64<<10];
 		uint8_t m_vsScratch[64<<10];
-		uint32_t m_fsChanges;
-		uint32_t m_vsChanges;
+		uint32_t m_fsChanges = 0;
+		uint32_t m_vsChanges = 0;
 
 		FrameBufferHandle m_fbh;
-		uint32_t m_backBufferColorIdx;
-		bool m_rtMsaa;
-		bool m_directAccessSupport;
+		uint32_t m_backBufferColorIdx = 0;
+		bool m_rtMsaa = false;
+		bool m_directAccessSupport = false;
 	};
 
 	static RendererContextD3D12* s_renderD3D12;

--- a/src/renderer_d3d12.h
+++ b/src/renderer_d3d12.h
@@ -198,11 +198,6 @@ namespace bgfx { namespace d3d12
 	struct BufferD3D12
 	{
 		BufferD3D12()
-			: m_ptr(NULL)
-			, m_state(D3D12_RESOURCE_STATE_COMMON)
-			, m_size(0)
-			, m_flags(BGFX_BUFFER_NONE)
-			, m_dynamic(false)
 		{
 		}
 
@@ -214,12 +209,12 @@ namespace bgfx { namespace d3d12
 
 		D3D12_SHADER_RESOURCE_VIEW_DESC  m_srvd;
 		D3D12_UNORDERED_ACCESS_VIEW_DESC m_uavd;
-		ID3D12Resource* m_ptr;
+		ID3D12Resource* m_ptr = NULL;
 		D3D12_GPU_VIRTUAL_ADDRESS m_gpuVA;
-		D3D12_RESOURCE_STATES m_state;
-		uint32_t m_size;
-		uint16_t m_flags;
-		bool m_dynamic;
+		D3D12_RESOURCE_STATES m_state = D3D12_RESOURCE_STATE_COMMON;
+		uint32_t m_size = 0;
+		uint16_t m_flags = BGFX_BUFFER_NONE;
+		bool m_dynamic = false;
 	};
 
 	struct VertexBufferD3D12 : public BufferD3D12
@@ -232,11 +227,6 @@ namespace bgfx { namespace d3d12
 	struct ShaderD3D12
 	{
 		ShaderD3D12()
-			: m_code(NULL)
-			, m_constantBuffer(NULL)
-			, m_hash(0)
-			, m_numUniforms(0)
-			, m_numPredefined(0)
 		{
 		}
 
@@ -260,23 +250,21 @@ namespace bgfx { namespace d3d12
 			}
 		}
 
-		const Memory* m_code;
-		UniformBuffer* m_constantBuffer;
+		const Memory* m_code = NULL;
+		UniformBuffer* m_constantBuffer = NULL;
 
 		PredefinedUniform m_predefined[PredefinedUniform::Count];
 		uint16_t m_attrMask[Attrib::Count];
 
-		uint32_t m_hash;
-		uint16_t m_numUniforms;
+		uint32_t m_hash = 0;
+		uint16_t m_numUniforms = 0;
 		uint16_t m_size;
-		uint8_t m_numPredefined;
+		uint8_t m_numPredefined = 0;
 	};
 
 	struct ProgramD3D12
 	{
 		ProgramD3D12()
-			: m_vsh(NULL)
-			, m_fsh(NULL)
 		{
 		}
 
@@ -303,8 +291,8 @@ namespace bgfx { namespace d3d12
 			m_fsh = NULL;
 		}
 
-		const ShaderD3D12* m_vsh;
-		const ShaderD3D12* m_fsh;
+		const ShaderD3D12* m_vsh = NULL;
+		const ShaderD3D12* m_fsh = NULL;
 
 		PredefinedUniform m_predefined[PredefinedUniform::Count * 2];
 		uint8_t m_numPredefined;
@@ -320,13 +308,7 @@ namespace bgfx { namespace d3d12
 		};
 
 		TextureD3D12()
-			: m_ptr(NULL)
-			, m_directAccessPtr(NULL)
-			, m_state(D3D12_RESOURCE_STATE_COMMON)
-			, m_numMips(0)
 		{
-			bx::memSet(&m_srvd, 0, sizeof(m_srvd) );
-			bx::memSet(&m_uavd, 0, sizeof(m_uavd) );
 		}
 
 		void* create(const Memory* _mem, uint64_t _flags, uint8_t _skip);
@@ -335,11 +317,11 @@ namespace bgfx { namespace d3d12
 		void resolve(uint8_t _resolve) const;
 		D3D12_RESOURCE_STATES setState(ID3D12GraphicsCommandList* _commandList, D3D12_RESOURCE_STATES _state);
 
-		D3D12_SHADER_RESOURCE_VIEW_DESC  m_srvd;
-		D3D12_UNORDERED_ACCESS_VIEW_DESC m_uavd;
-		ID3D12Resource* m_ptr;
-		void* m_directAccessPtr;
-		D3D12_RESOURCE_STATES m_state;
+		D3D12_SHADER_RESOURCE_VIEW_DESC  m_srvd = {};
+		D3D12_UNORDERED_ACCESS_VIEW_DESC m_uavd = {};
+		ID3D12Resource* m_ptr = NULL;
+		void* m_directAccessPtr = NULL;
+		D3D12_RESOURCE_STATES m_state = D3D12_RESOURCE_STATE_COMMON;
 		uint64_t m_flags;
 		uint32_t m_width;
 		uint32_t m_height;
@@ -349,21 +331,12 @@ namespace bgfx { namespace d3d12
 		uint8_t m_type;
 		uint8_t m_requestedFormat;
 		uint8_t m_textureFormat;
-		uint8_t m_numMips;
+		uint8_t m_numMips = 0;
 	};
 
 	struct FrameBufferD3D12
 	{
 		FrameBufferD3D12()
-			: m_swapChain(NULL)
-			, m_nwh(NULL)
-			, m_width(0)
-			, m_height(0)
-			, m_denseIdx(UINT16_MAX)
-			, m_num(0)
-			, m_numTh(0)
-			, m_state(D3D12_RESOURCE_STATE_PRESENT)
-			, m_needPresent(false)
 		{
 			m_depth.idx = bgfx::kInvalidHandle;
 		}
@@ -380,24 +353,22 @@ namespace bgfx { namespace d3d12
 
 		TextureHandle m_texture[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 		TextureHandle m_depth;
-		Dxgi::SwapChainI* m_swapChain;
-		void* m_nwh;
-		uint32_t m_width;
-		uint32_t m_height;
-		uint16_t m_denseIdx;
-		uint8_t m_num;
-		uint8_t m_numTh;
+		Dxgi::SwapChainI* m_swapChain = NULL;
+		void* m_nwh = NULL;
+		uint32_t m_width = 0;
+		uint32_t m_height = 0;
+		uint16_t m_denseIdx = UINT16_MAX;
+		uint8_t m_num = 0;
+		uint8_t m_numTh = 0;
 		Attachment m_attachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
-		D3D12_RESOURCE_STATES m_state;
-		bool m_needPresent;
+		D3D12_RESOURCE_STATES m_state = D3D12_RESOURCE_STATE_PRESENT;
+		bool m_needPresent = false;
 	};
 
 	struct CommandQueueD3D12
 	{
 		CommandQueueD3D12()
-			: m_currentFence(0)
-			, m_completedFence(0)
-			, m_control(BX_COUNTOF(m_commandList) )
+			: m_control(BX_COUNTOF(m_commandList))
 		{
 			BX_STATIC_ASSERT(BX_COUNTOF(m_commandList) == BX_COUNTOF(m_release) );
 		}
@@ -419,8 +390,8 @@ namespace bgfx { namespace d3d12
 		};
 
 		ID3D12CommandQueue* m_commandQueue;
-		uint64_t m_currentFence;
-		uint64_t m_completedFence;
+		uint64_t m_currentFence = 0;
+		uint64_t m_completedFence = 0;
 		ID3D12Fence* m_fence;
 		CommandList m_commandList[256];
 		typedef stl::vector<ID3D12Resource*> ResourceArray;
@@ -439,12 +410,7 @@ namespace bgfx { namespace d3d12
 		};
 
 		BatchD3D12()
-			: m_currIndirect(0)
-			, m_maxDrawPerBatch(0)
-			, m_minIndirect(0)
-			, m_flushPerBatch(0)
 		{
-			bx::memSet(m_num, 0, sizeof(m_num) );
 		}
 
 		~BatchD3D12()
@@ -476,7 +442,7 @@ namespace bgfx { namespace d3d12
 		}
 
 		ID3D12CommandSignature* m_commandSignature[Count];
-		uint32_t m_num[Count];
+		uint32_t m_num[Count] = {};
 		void* m_cmds[Count];
 
 		struct DrawIndirectCommand
@@ -501,13 +467,13 @@ namespace bgfx { namespace d3d12
 		};
 
 		BufferD3D12 m_indirect[32];
-		uint32_t m_currIndirect;
+		uint32_t m_currIndirect = 0;
 		DrawIndexedIndirectCommand m_current;
 
 		Stats m_stats;
-		uint32_t m_maxDrawPerBatch;
-		uint32_t m_minIndirect;
-		uint32_t m_flushPerBatch;
+		uint32_t m_maxDrawPerBatch = 0;
+		uint32_t m_minIndirect = 0;
+		uint32_t m_flushPerBatch = 0;
 	};
 
 	struct TimerQueryD3D12

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -405,22 +405,6 @@ namespace bgfx { namespace d3d9
 	struct RendererContextD3D9 : public RendererContextI
 	{
 		RendererContextD3D9()
-			: m_d3d9(NULL)
-			, m_device(NULL)
-			, m_flushQuery(NULL)
-			, m_swapChain(NULL)
-			, m_captureTexture(NULL)
-			, m_captureSurface(NULL)
-			, m_captureResolve(NULL)
-			, m_maxAnisotropy(1)
-			, m_initialized(false)
-			, m_amd(false)
-			, m_nvidia(false)
-			, m_atocSupport(false)
-			, m_instancingSupport(false)
-			, m_occlusionQuerySupport(false)
-			, m_timerQuerySupport(false)
-			, m_rtMsaa(false)
 		{
 		}
 
@@ -2191,14 +2175,14 @@ namespace bgfx { namespace d3d9
 		IDirect3D9Ex* m_d3d9ex;
 		IDirect3DDevice9Ex* m_deviceEx;
 
-		IDirect3D9*        m_d3d9;
-		IDirect3DDevice9*  m_device;
-		IDirect3DQuery9*   m_flushQuery;
+		IDirect3D9*        m_d3d9 = NULL;
+		IDirect3DDevice9*  m_device = NULL;
+		IDirect3DQuery9*   m_flushQuery = NULL;
 		TimerQueryD3D9     m_gpuTimer;
 		OcclusionQueryD3D9 m_occlusionQuery;
 		D3DPOOL m_pool;
 
-		IDirect3DSwapChain9* m_swapChain;
+		IDirect3DSwapChain9* m_swapChain = NULL;
 
 		bool m_needPresent;
 		uint16_t m_numWindows;
@@ -2207,9 +2191,9 @@ namespace bgfx { namespace d3d9
 		IDirect3DSurface9* m_backBufferColor;
 		IDirect3DSurface9* m_backBufferDepthStencil;
 
-		IDirect3DTexture9* m_captureTexture;
-		IDirect3DSurface9* m_captureSurface;
-		IDirect3DSurface9* m_captureResolve;
+		IDirect3DTexture9* m_captureTexture = NULL;
+		IDirect3DSurface9* m_captureSurface = NULL;
+		IDirect3DSurface9* m_captureResolve = NULL;
 
 		IDirect3DVertexDeclaration9* m_instanceDataDecls[BGFX_CONFIG_MAX_INSTANCE_DATA_COUNT];
 
@@ -2218,17 +2202,17 @@ namespace bgfx { namespace d3d9
 		uint32_t m_adapter;
 		D3DDEVTYPE m_deviceType;
 		D3DPRESENT_PARAMETERS m_params;
-		uint32_t m_maxAnisotropy;
+		uint32_t m_maxAnisotropy = 1;
 		D3DADAPTER_IDENTIFIER9 m_identifier;
 		Resolution m_resolution;
 
-		bool m_initialized;
-		bool m_amd;
-		bool m_nvidia;
-		bool m_atocSupport;
-		bool m_instancingSupport;
-		bool m_occlusionQuerySupport;
-		bool m_timerQuerySupport;
+		bool m_initialized = false;
+		bool m_amd = false;
+		bool m_nvidia = false;
+		bool m_atocSupport = false;
+		bool m_instancingSupport = false;
+		bool m_occlusionQuerySupport = false;
+		bool m_timerQuerySupport = false;
 
 		D3DFORMAT m_fmtDepth;
 
@@ -2255,7 +2239,7 @@ namespace bgfx { namespace d3d9
 		TextVideoMem m_textVideoMem;
 
 		FrameBufferHandle m_fbh;
-		bool m_rtMsaa;
+		bool m_rtMsaa = false;
 	};
 
 	static RendererContextD3D9* s_renderD3D9;

--- a/src/renderer_d3d9.h
+++ b/src/renderer_d3d9.h
@@ -131,10 +131,6 @@ namespace bgfx { namespace d3d9
 	struct IndexBufferD3D9
 	{
 		IndexBufferD3D9()
-			: m_ptr(NULL)
-			, m_dynamic(NULL)
-			, m_size(0)
-			, m_flags(BGFX_BUFFER_NONE)
 		{
 		}
 
@@ -176,18 +172,15 @@ namespace bgfx { namespace d3d9
 		void preReset();
 		void postReset();
 
-		IDirect3DIndexBuffer9* m_ptr;
-		uint8_t* m_dynamic;
-		uint32_t m_size;
-		uint16_t m_flags;
+		IDirect3DIndexBuffer9* m_ptr = NULL;
+		uint8_t* m_dynamic = NULL;
+		uint32_t m_size = 0;
+		uint16_t m_flags = BGFX_BUFFER_NONE;
 	};
 
 	struct VertexBufferD3D9
 	{
 		VertexBufferD3D9()
-			: m_ptr(NULL)
-			, m_dynamic(NULL)
-			, m_size(0)
 		{
 		}
 
@@ -229,19 +222,15 @@ namespace bgfx { namespace d3d9
 		void preReset();
 		void postReset();
 
-		IDirect3DVertexBuffer9* m_ptr;
-		uint8_t* m_dynamic;
-		uint32_t m_size;
+		IDirect3DVertexBuffer9* m_ptr = NULL;
+		uint8_t* m_dynamic = NULL;
+		uint32_t m_size = 0;
 		VertexDeclHandle m_decl;
 	};
 
 	struct ShaderD3D9
 	{
 		ShaderD3D9()
-			: m_vertexShader(NULL)
-			, m_constantBuffer(NULL)
-			, m_numPredefined(0)
-			, m_type(0)
 		{
 		}
 
@@ -266,13 +255,13 @@ namespace bgfx { namespace d3d9
 		union
 		{
 			// X360 doesn't have interface inheritance (can't use IUnknown*).
-			IDirect3DVertexShader9* m_vertexShader;
+			IDirect3DVertexShader9* m_vertexShader = NULL;
 			IDirect3DPixelShader9*  m_pixelShader;
 		};
-		UniformBuffer* m_constantBuffer;
+		UniformBuffer* m_constantBuffer = NULL;
 		PredefinedUniform m_predefined[PredefinedUniform::Count];
-		uint8_t m_numPredefined;
-		uint8_t m_type;
+		uint8_t m_numPredefined = 0;
+		uint8_t m_type = 0;
 	};
 
 	struct ProgramD3D9
@@ -316,10 +305,6 @@ namespace bgfx { namespace d3d9
 		};
 
 		TextureD3D9()
-			: m_ptr(NULL)
-			, m_surface(NULL)
-			, m_staging(NULL)
-			, m_textureFormat(TextureFormat::Unknown)
 		{
 		}
 
@@ -373,17 +358,17 @@ namespace bgfx { namespace d3d9
 
 		union
 		{
-			IDirect3DBaseTexture9*   m_ptr;
+			IDirect3DBaseTexture9*   m_ptr = NULL;
 			IDirect3DTexture9*       m_texture2d;
 			IDirect3DVolumeTexture9* m_texture3d;
 			IDirect3DCubeTexture9*   m_textureCube;
 		};
 
-		IDirect3DSurface9* m_surface;
+		IDirect3DSurface9* m_surface = NULL;
 
 		union
 		{
-			IDirect3DBaseTexture9*   m_staging;
+			IDirect3DBaseTexture9*   m_staging = NULL;
 			IDirect3DTexture9*       m_staging2d;
 			IDirect3DVolumeTexture9* m_staging3d;
 			IDirect3DCubeTexture9*   m_stagingCube;
@@ -396,19 +381,12 @@ namespace bgfx { namespace d3d9
 		uint8_t m_numMips;
 		uint8_t m_type;
 		uint8_t m_requestedFormat;
-		uint8_t m_textureFormat;
+		uint8_t m_textureFormat = TextureFormat::Unknown;
 	};
 
 	struct FrameBufferD3D9
 	{
 		FrameBufferD3D9()
-			: m_hwnd(NULL)
-			, m_denseIdx(UINT16_MAX)
-			, m_num(0)
-			, m_numTh(0)
-			, m_dsIdx(UINT8_MAX)
-			, m_needResolve(false)
-			, m_needPresent(false)
 		{
 		}
 
@@ -424,17 +402,17 @@ namespace bgfx { namespace d3d9
 
 		IDirect3DSurface9* m_surface[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS-1];
 		IDirect3DSwapChain9* m_swapChain;
-		HWND m_hwnd;
+		HWND m_hwnd = NULL;
 		uint32_t m_width;
 		uint32_t m_height;
 
 		Attachment m_attachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
-		uint16_t m_denseIdx;
-		uint8_t m_num;
-		uint8_t m_numTh;
-		uint8_t m_dsIdx;
-		bool m_needResolve;
-		bool m_needPresent;
+		uint16_t m_denseIdx = UINT16_MAX;
+		uint8_t m_num = 0;
+		uint8_t m_numTh = 0;
+		uint8_t m_dsIdx = UINT8_MAX;
+		bool m_needResolve = false;
+		bool m_needPresent = false;
 	};
 
 	struct TimerQueryD3D9

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1727,35 +1727,6 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 	struct RendererContextGL : public RendererContextI
 	{
 		RendererContextGL()
-			: m_numWindows(1)
-			, m_rtMsaa(false)
-			, m_fbDiscard(BGFX_CLEAR_NONE)
-			, m_capture(NULL)
-			, m_captureSize(0)
-			, m_maxAnisotropy(0.0f)
-			, m_maxAnisotropyDefault(0.0f)
-			, m_maxMsaa(0)
-			, m_vao(0)
-			, m_blitSupported(false)
-			, m_readBackSupported(BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL) )
-			, m_vaoSupport(false)
-			, m_samplerObjectSupport(false)
-			, m_shadowSamplersSupport(false)
-			, m_srgbWriteControlSupport(BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL) )
-			, m_borderColorSupport(BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL) )
-			, m_programBinarySupport(false)
-			, m_textureSwizzleSupport(false)
-			, m_depthTextureSupport(false)
-			, m_timerQuerySupport(false)
-			, m_occlusionQuerySupport(false)
-			, m_atocSupport(false)
-			, m_conservativeRasterSupport(false)
-			, m_flip(false)
-			, m_hash( (BX_PLATFORM_WINDOWS<<1) | BX_ARCH_64BIT)
-			, m_backBufferFbo(0)
-			, m_msaaBackBufferFbo(0)
-			, m_clearQuadColor(BGFX_INVALID_HANDLE)
-			, m_clearQuadDepth(BGFX_INVALID_HANDLE)
 		{
 			bx::memSet(m_msaaBackBufferRbos, 0, sizeof(m_msaaBackBufferRbos) );
 		}
@@ -3846,9 +3817,9 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			}
 		}
 
-		void* m_renderdocdll;
+		void* m_renderdocdll = NULL;
 
-		uint16_t m_numWindows;
+		uint16_t m_numWindows = 1;
 		FrameBufferHandle m_windows[BGFX_CONFIG_MAX_FRAME_BUFFERS];
 
 		IndexBufferGL m_indexBuffers[BGFX_CONFIG_MAX_INDEX_BUFFERS];
@@ -3867,47 +3838,47 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 		SamplerStateCache m_samplerStateCache;
 
 		TextVideoMem m_textVideoMem;
-		bool m_rtMsaa;
+		bool m_rtMsaa = false;
 
 		FrameBufferHandle m_fbh;
-		uint16_t m_fbDiscard;
+		uint16_t m_fbDiscard = BGFX_CLEAR_NONE;
 
 		Resolution m_resolution;
-		void* m_capture;
-		uint32_t m_captureSize;
-		float m_maxAnisotropy;
-		float m_maxAnisotropyDefault;
-		int32_t m_maxMsaa;
-		GLuint m_vao;
+		void* m_capture = NULL;
+		uint32_t m_captureSize = 0;
+		float m_maxAnisotropy = 0.0f;
+		float m_maxAnisotropyDefault = 0.0f;
+		int32_t m_maxMsaa = 0;
+		GLuint m_vao = 0;
 		uint16_t m_maxLabelLen;
-		bool m_blitSupported;
-		bool m_readBackSupported;
-		bool m_vaoSupport;
-		bool m_samplerObjectSupport;
-		bool m_shadowSamplersSupport;
-		bool m_srgbWriteControlSupport;
-		bool m_borderColorSupport;
-		bool m_programBinarySupport;
-		bool m_textureSwizzleSupport;
-		bool m_depthTextureSupport;
-		bool m_timerQuerySupport;
-		bool m_occlusionQuerySupport;
-		bool m_atocSupport;
-		bool m_conservativeRasterSupport;
-		bool m_imageLoadStoreSupport;
-		bool m_flip;
+		bool m_blitSupported = false;
+		bool m_readBackSupported = BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL);
+		bool m_vaoSupport = false;
+		bool m_samplerObjectSupport = false;
+		bool m_shadowSamplersSupport = false;
+		bool m_srgbWriteControlSupport = BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL);
+		bool m_borderColorSupport = BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL);
+		bool m_programBinarySupport = false;
+		bool m_textureSwizzleSupport = false;
+		bool m_depthTextureSupport = false;
+		bool m_timerQuerySupport = false;
+		bool m_occlusionQuerySupport = false;
+		bool m_atocSupport = false;
+		bool m_conservativeRasterSupport = false;
+		bool m_imageLoadStoreSupport = false;
+		bool m_flip = false;
 
-		uint64_t m_hash;
+		uint64_t m_hash = (BX_PLATFORM_WINDOWS << 1) | BX_ARCH_64BIT;
 
 		GLenum m_readPixelsFmt;
-		GLuint m_backBufferFbo;
-		GLuint m_msaaBackBufferFbo;
+		GLuint m_backBufferFbo = 0;
+		GLuint m_msaaBackBufferFbo = 0;
 		GLuint m_msaaBackBufferRbos[2];
 		GlContext m_glctx;
 		bool m_needPresent;
 
-		UniformHandle m_clearQuadColor;
-		UniformHandle m_clearQuadDepth;
+		UniformHandle m_clearQuadColor = BGFX_INVALID_HANDLE;
+		UniformHandle m_clearQuadDepth = BGFX_INVALID_HANDLE;
 
 		const char* m_vendor;
 		const char* m_renderer;

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -1253,14 +1253,6 @@ namespace bgfx { namespace gl
 	struct TextureGL
 	{
 		TextureGL()
-			: m_id(0)
-			, m_rbo(0)
-			, m_target(GL_TEXTURE_2D)
-			, m_fmt(GL_ZERO)
-			, m_type(GL_ZERO)
-			, m_flags(0)
-			, m_currentSamplerHash(UINT32_MAX)
-			, m_numMips(0)
 		{
 		}
 
@@ -1281,18 +1273,18 @@ namespace bgfx { namespace gl
 				;
 		}
 
-		GLuint m_id;
-		GLuint m_rbo;
-		GLenum m_target;
-		GLenum m_fmt;
-		GLenum m_type;
-		uint64_t m_flags;
-		uint32_t m_currentSamplerHash;
+		GLuint m_id = 0;
+		GLuint m_rbo = 0;
+		GLenum m_target = GL_TEXTURE_2D;
+		GLenum m_fmt = GL_ZERO;
+		GLenum m_type = GL_ZERO;
+		uint64_t m_flags = 0;
+		uint32_t m_currentSamplerHash = UINT32_MAX;
 		uint32_t m_width;
 		uint32_t m_height;
 		uint32_t m_depth;
 		uint32_t m_numLayers;
-		uint8_t m_numMips;
+		uint8_t m_numMips = 0;
 		uint8_t m_requestedFormat;
 		uint8_t m_textureFormat;
 	};
@@ -1300,27 +1292,20 @@ namespace bgfx { namespace gl
 	struct ShaderGL
 	{
 		ShaderGL()
-			: m_id(0)
-			, m_type(0)
-			, m_hash(0)
 		{
 		}
 
 		void create(const Memory* _mem);
 		void destroy();
 
-		GLuint m_id;
-		GLenum m_type;
-		uint32_t m_hash;
+		GLuint m_id = 0;
+		GLenum m_type = 0;
+		uint32_t m_hash = 0;
 	};
 
 	struct FrameBufferGL
 	{
 		FrameBufferGL()
-			: m_swapChain(NULL)
-			, m_denseIdx(UINT16_MAX)
-			, m_num(0)
-			, m_needPresent(false)
 		{
 			bx::memSet(m_fbo, 0, sizeof(m_fbo) );
 		}
@@ -1333,23 +1318,20 @@ namespace bgfx { namespace gl
 		void discard(uint16_t _flags);
 		void set();
 
-		SwapChainGL* m_swapChain;
+		SwapChainGL* m_swapChain = NULL;
 		GLuint m_fbo[2];
 		uint32_t m_width;
 		uint32_t m_height;
-		uint16_t m_denseIdx;
-		uint8_t  m_num;
+		uint16_t m_denseIdx = UINT16_MAX;
+		uint8_t  m_num = 0;
 		uint8_t  m_numTh;
-		bool     m_needPresent;
+		bool     m_needPresent = false;
 		Attachment m_attachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 	};
 
 	struct ProgramGL
 	{
 		ProgramGL()
-			: m_id(0)
-			, m_constantBuffer(NULL)
-			, m_numPredefined(0)
 		{
 		}
 
@@ -1381,7 +1363,7 @@ namespace bgfx { namespace gl
 
 		void unbindAttributes();
 
-		GLuint m_id;
+		GLuint m_id = 0;
 
 		uint8_t m_unboundUsedAttrib[Attrib::Count]; // For tracking unbound used attributes between begin()/end().
 		uint8_t m_usedCount;
@@ -1392,9 +1374,9 @@ namespace bgfx { namespace gl
 		GLint m_sampler[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
 		uint8_t m_numSamplers;
 
-		UniformBuffer* m_constantBuffer;
+		UniformBuffer* m_constantBuffer = NULL;
 		PredefinedUniform m_predefined[PredefinedUniform::Count];
-		uint8_t m_numPredefined;
+		uint8_t m_numPredefined = 0;
 	};
 
 	struct TimerQueryGL
@@ -1567,14 +1549,12 @@ namespace bgfx { namespace gl
 	public:
 		LineReader(const void* _str)
 			: m_str( (const char*)_str)
-			, m_pos(0)
 			, m_size(bx::strLen( (const char*)_str) )
 		{
 		}
 
 		LineReader(const bx::StringView& _str)
 			: m_str(_str.getPtr() )
-			, m_pos(0)
 			, m_size(_str.getLength() )
 		{
 		}
@@ -1604,7 +1584,7 @@ namespace bgfx { namespace gl
 		}
 
 		const char* m_str;
-		uint32_t m_pos;
+		uint32_t m_pos = 0;
 		uint32_t m_size;
 	};
 

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -804,12 +804,6 @@ VK_IMPORT_DEVICE
 	struct RendererContextVK : public RendererContextI
 	{
 		RendererContextVK()
-			: m_allocatorCb(NULL)
-			, m_renderDocDll(NULL)
-			, m_vulkan1Dll(NULL)
-			, m_maxAnisotropy(1)
-			, m_depthClamp(false)
-			, m_wireframe(false)
 		{
 		}
 
@@ -3189,7 +3183,7 @@ VK_IMPORT_DEVICE
 			return 0;
 		}
 
-		VkAllocationCallbacks*   m_allocatorCb;
+		VkAllocationCallbacks*   m_allocatorCb = NULL;
 		VkDebugReportCallbackEXT m_debugReportCallback;
 		VkInstance       m_instance;
 		VkPhysicalDevice m_physicalDevice;
@@ -3228,8 +3222,8 @@ VK_IMPORT_DEVICE
 		VkPipelineCache m_pipelineCache;
 		VkCommandPool m_commandPool;
 
-		void* m_renderDocDll;
-		void* m_vulkan1Dll;
+		void* m_renderDocDll = NULL;
+		void* m_vulkan1Dll = NULL;
 
 		IndexBufferVK m_indexBuffers[BGFX_CONFIG_MAX_INDEX_BUFFERS];
 		VertexBufferVK m_vertexBuffers[BGFX_CONFIG_MAX_VERTEX_BUFFERS];
@@ -3245,9 +3239,9 @@ VK_IMPORT_DEVICE
 		StateCacheT<VkPipeline> m_pipelineStateCache;
 
 		Resolution m_resolution;
-		uint32_t m_maxAnisotropy;
-		bool m_depthClamp;
-		bool m_wireframe;
+		uint32_t m_maxAnisotropy = 1;
+		bool m_depthClamp = false;
+		bool m_wireframe = false;
 
 		TextVideoMem m_textVideoMem;
 

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -376,38 +376,30 @@ VK_DESTROY
 	struct ShaderVK
 	{
 		ShaderVK()
-			: m_code(NULL)
-			, m_module(VK_NULL_HANDLE)
-			, m_constantBuffer(NULL)
-			, m_hash(0)
-			, m_numUniforms(0)
-			, m_numPredefined(0)
 		{
 		}
 
 		void create(const Memory* _mem);
 		void destroy();
 
-		const Memory* m_code;
-		VkShaderModule m_module;
-		UniformBuffer* m_constantBuffer;
+		const Memory* m_code = NULL;
+		VkShaderModule m_module = VK_NULL_HANDLE;
+		UniformBuffer* m_constantBuffer = NULL;
 
 		PredefinedUniform m_predefined[PredefinedUniform::Count];
 		uint16_t m_attrMask[Attrib::Count];
 		uint8_t m_attrRemap[Attrib::Count];
 
-		uint32_t m_hash;
-		uint16_t m_numUniforms;
+		uint32_t m_hash = 0;
+		uint16_t m_numUniforms = 0;
 		uint16_t m_size;
-		uint8_t m_numPredefined;
+		uint8_t m_numPredefined = 0;
 		uint8_t m_numAttrs;
 	};
 
 	struct ProgramVK
 	{
 		ProgramVK()
-			: m_vsh(NULL)
-			, m_fsh(NULL)
 		{
 		}
 
@@ -434,8 +426,8 @@ VK_DESTROY
 			m_fsh = NULL;
 		}
 
-		const ShaderVK* m_vsh;
-		const ShaderVK* m_fsh;
+		const ShaderVK* m_vsh = NULL;
+		const ShaderVK* m_fsh = NULL;
 
 		PredefinedUniform m_predefined[PredefinedUniform::Count * 2];
 		uint8_t m_numPredefined;

--- a/src/shader_dxbc.h
+++ b/src/shader_dxbc.h
@@ -479,50 +479,34 @@ namespace bgfx
 	struct DxbcSubOperand
 	{
 		DxbcSubOperand()
-			: type(DxbcOperandType::Temp)
-			, mode(0)
-			, modeBits(0)
-			, num(0)
-			, numAddrModes(0)
-			, addrMode(0)
-			, regIndex(0)
 		{
 		}
 
-		DxbcOperandType::Enum type;
-		uint8_t mode;
-		uint8_t modeBits;
-		uint8_t num;
-		uint8_t numAddrModes;
-		uint8_t addrMode;
-		uint32_t regIndex;
+		DxbcOperandType::Enum type = DxbcOperandType::Temp;
+		uint8_t mode = 0;
+		uint8_t modeBits = 0;
+		uint8_t num = 0;
+		uint8_t numAddrModes = 0;
+		uint8_t addrMode = 0;
+		uint32_t regIndex = 0;
 	};
 
 	struct DxbcOperand
 	{
 		DxbcOperand()
-			: type(DxbcOperandType::Temp)
-			, mode(DxbcOperandMode::Mask)
-			, modeBits(0)
-			, num(0)
-			, modifier(DxbcOperandModifier::None)
-			, numAddrModes(0)
 		{
-			bx::memSet(addrMode, 0, sizeof(addrMode) );
-			bx::memSet(regIndex, 0, sizeof(regIndex) );
-			bx::memSet(un.imm64, 0, sizeof(un.imm64) );
 		}
 
-		DxbcOperandType::Enum type;
-		DxbcOperandMode::Enum mode;
-		uint8_t modeBits;
-		uint8_t num;
-		DxbcOperandModifier::Enum modifier;
+		DxbcOperandType::Enum type = DxbcOperandType::Temp;
+		DxbcOperandMode::Enum mode = DxbcOperandMode::Mask;
+		uint8_t modeBits = 0;
+		uint8_t num = 0;
+		DxbcOperandModifier::Enum modifier = DxbcOperandModifier::None;
 
-		uint8_t numAddrModes;
-		uint8_t addrMode[3];
-		uint32_t regIndex[3];
-		DxbcSubOperand subOperand[3];
+		uint8_t numAddrModes = 0;
+		uint8_t addrMode[3] = {};
+		uint32_t regIndex[3] = {};
+		DxbcSubOperand subOperand[3] = {};
 
 		union
 		{


### PR DESCRIPTION
So this is a suggestion regarding default values, as bgfx is using a C++ standard > C++11
I find it can greatly enhance working on a big codebase to use the following rule of thumb for initializing values:
- If a value is always initialized to a given value when an object T is constructed, put the initializer in the class member definition

This has a few advantages:
- reduces the amount of lines of code overall (and need for scrolling)
- when looking up a definition of a member, you see right away what it was defaulted to (and if different)
- less error-prone, as when looking at the class outline you quickly see if an initializer is missing (e.g when it is next to similar data, which allowed me to see that initializer for `m_imageLoadStoreSupport` was missing)

I didn't touch the classes that were in public headers. (nor the Metal impl, as I don't know if that is valid Objective C)

This is a suggestion, I won't be offended if you disagree 😃 