### PR TITLE
Don't set layouts when the stream not used

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -2066,9 +2066,12 @@ namespace bgfx { namespace mtl
 				for (; stream < _numStreams; ++stream)
 				{
 					const VertexDecl& vertexDecl = *_vertexDecls[stream];
+					bool streamUsed = false;
 					for (uint32_t ii = 0; Attrib::Count != program.m_used[ii]; ++ii)
 					{
 						Attrib::Enum attr = Attrib::Enum(program.m_used[ii]);
+						if (attrSet[attr])
+							continue;
 						const uint32_t loc = program.m_attributes[attr];
 
 						uint8_t num;
@@ -2087,11 +2090,13 @@ namespace bgfx { namespace mtl
 							BX_TRACE("attrib: %s format: %d offset: %d", s_attribName[attr], (int)vertexDesc.attributes[loc].format, (int)vertexDesc.attributes[loc].offset);
 
 							attrSet[attr] = true;
+							streamUsed = true;
 						}
 					}
-
-					vertexDesc.layouts[stream+1].stride       = vertexDecl.getStride();
-					vertexDesc.layouts[stream+1].stepFunction = MTLVertexStepFunctionPerVertex;
+					if (streamUsed) {
+						vertexDesc.layouts[stream+1].stride       = vertexDecl.getStride();
+						vertexDesc.layouts[stream+1].stepFunction = MTLVertexStepFunctionPerVertex;
+					}
 				}
 
 				for (uint32_t ii = 0; Attrib::Count != program.m_used[ii]; ++ii)


### PR DESCRIPTION
Our program raise an error :
```
-[MTLVertexDescriptorInternal newSerializedDescriptor], line 825: error 'None of the attributes set bufferIndex to 2, but MTLVertexDescriptor set buffer layout[2].stride(12).'
```

I found a similar issue https://github.com/hugoam/mud/issues/7 reported.

We use 2 streams, but 1 didn't use any `Attrib` for some program.  This patch can fix this issue.  

Btw, why `vertexDesc.attributes[loc].bufferIndex`  is base 1 ? Is `vertexDesc.layouts[0]` reserved for other use ? 
I saw `bufferIndex` can be 0 in a metal example https://github.com/metal-by-example/sample-code/blob/master/objc/07-Mipmapping/Mipmapping/MBERenderer.m#L59 .