### PR TITLE
unicode inputChar support for imguiBeginFrame

### DIFF
--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -9,6 +9,7 @@
 #include <bx/math.h>
 #include <bx/timer.h>
 #include <dear-imgui/imgui.h>
+#include <dear-imgui/imgui_internal.h>
 
 #include "imgui.h"
 #include "../bgfx_utils.h"
@@ -340,7 +341,7 @@ struct OcornutImguiContext
 		, int32_t _scroll
 		, int _width
 		, int _height
-		, char _inputChar
+		, int _inputChar
 		, bgfx::ViewId _viewId
 		)
 	{
@@ -350,6 +351,12 @@ struct OcornutImguiContext
 		if (_inputChar < 0x7f)
 		{
 			io.AddInputCharacter(_inputChar); // ASCII or GTFO! :(
+		} else
+		{
+			char tmpstr[6];
+			ImWchar unicode[2] = { (ImWchar)_inputChar, 0 };
+			ImTextStrToUtf8(tmpstr, sizeof(tmpstr), unicode, unicode+1);
+			io.AddInputCharactersUTF8(tmpstr);
 		}
 
 		io.DisplaySize = ImVec2( (float)_width, (float)_height);
@@ -427,7 +434,7 @@ void imguiDestroy()
 	s_ctx.destroy();
 }
 
-void imguiBeginFrame(int32_t _mx, int32_t _my, uint8_t _button, int32_t _scroll, uint16_t _width, uint16_t _height, char _inputChar, bgfx::ViewId _viewId)
+void imguiBeginFrame(int32_t _mx, int32_t _my, uint8_t _button, int32_t _scroll, uint16_t _width, uint16_t _height, int _inputChar, bgfx::ViewId _viewId)
 {
 	s_ctx.beginFrame(_mx, _my, _button, _scroll, _width, _height, _inputChar, _viewId);
 }

--- a/examples/common/imgui/imgui.h
+++ b/examples/common/imgui/imgui.h
@@ -30,7 +30,7 @@ namespace bx { struct AllocatorI; }
 void imguiCreate(float _fontSize = 18.0f, bx::AllocatorI* _allocator = NULL);
 void imguiDestroy();
 
-void imguiBeginFrame(int32_t _mx, int32_t _my, uint8_t _button, int32_t _scroll, uint16_t _width, uint16_t _height, char _inputChar = 0, bgfx::ViewId _view = 255);
+void imguiBeginFrame(int32_t _mx, int32_t _my, uint8_t _button, int32_t _scroll, uint16_t _width, uint16_t _height, int _inputChar = 0, bgfx::ViewId _view = 255);
 void imguiEndFrame();
 
 namespace entry { class AppI; }


### PR DESCRIPTION
I'm writing a bgfx imgui lua bindings, and I found `imguiBeginFrame` only support ascii char now.

This PR add a unicode inputChar support by `io.AddInputCharactersUTF8`.

btw, I include  `<dear-imgui/imgui_internal.h>` because I use the internal function `ImTextStrToUtf8`. I'm not sure is there any equivalent function in `bx`. (Converting a unicode code point to utf-8 string)