### PR TITLE
AddInputCharacter can handle Unicode

### DIFF
--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -9,7 +9,6 @@
 #include <bx/math.h>
 #include <bx/timer.h>
 #include <dear-imgui/imgui.h>
-#include <dear-imgui/imgui_internal.h>
 
 #include "imgui.h"
 #include "../bgfx_utils.h"
@@ -348,15 +347,9 @@ struct OcornutImguiContext
 		m_viewId = _viewId;
 
 		ImGuiIO& io = ImGui::GetIO();
-		if (_inputChar < 0x7f)
+		if (_inputChar >= 0)
 		{
-			io.AddInputCharacter(_inputChar); // ASCII or GTFO! :(
-		} else
-		{
-			char tmpstr[6];
-			ImWchar unicode[2] = { (ImWchar)_inputChar, 0 };
-			ImTextStrToUtf8(tmpstr, sizeof(tmpstr), unicode, unicode+1);
-			io.AddInputCharactersUTF8(tmpstr);
+			io.AddInputCharacter(_inputChar);
 		}
 
 		io.DisplaySize = ImVec2( (float)_width, (float)_height);

--- a/examples/common/imgui/imgui.h
+++ b/examples/common/imgui/imgui.h
@@ -30,7 +30,7 @@ namespace bx { struct AllocatorI; }
 void imguiCreate(float _fontSize = 18.0f, bx::AllocatorI* _allocator = NULL);
 void imguiDestroy();
 
-void imguiBeginFrame(int32_t _mx, int32_t _my, uint8_t _button, int32_t _scroll, uint16_t _width, uint16_t _height, int _inputChar = 0, bgfx::ViewId _view = 255);
+void imguiBeginFrame(int32_t _mx, int32_t _my, uint8_t _button, int32_t _scroll, uint16_t _width, uint16_t _height, int _inputChar = -1, bgfx::ViewId _view = 255);
 void imguiEndFrame();
 
 namespace entry { class AppI; }


### PR DESCRIPTION
1. I found io.AddInputCharacter can handle unicode code point, so we don't need  `AddInputCharactersUTF8` .

2.  We should not call  `AddInputCharacter` where no char message, because  it will push a message to a internal queue of imgui, and 0 is a valid char. So I change the default value of `_inputChar` to -1.

3. Actually, bgfx haven't handle input char now (Always use the default value), but my binding use this API `imguiBeginFrame` .

