### PR TITLE
Fixed shader errors abort process

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5861,7 +5861,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 
 				GL_CHECK(glDeleteShader(m_id) );
 				m_id = 0;
-				BGFX_FATAL(false, bgfx::Fatal::InvalidShader, "Failed to compile shader.");
+				bx::debugPrintf("Failed to compile shader. %d: %s",compiled,log);
 			}
 			else if (BX_ENABLED(BGFX_CONFIG_DEBUG)
 				 &&  s_extension[Extension::ANGLE_translated_shader_source].m_supported


### PR DESCRIPTION
This fix is to let the process continue working even without some incompatible or broken shaders. 
Instead of aborting program with: 
../../../src/renderer_gl.cpp (5867): BGFX 0x00000001: Failed to compile shader.
Aborted (core dumped)

This fix will output this (for example) and keep the process working:
Failed to compile shader. 0: 0:1(10): error: GLSL 4.30 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.00 ES, 3.00 ES, 3.10 ES, and 3.20 ES
Failed to compile shader. 0: 0:1(10): error: GLSL 4.30 is not supported. Supported versions are: 1.10, 1.20, 1.30, 1.00 ES, 3.00 ES, 3.10 ES, and 3.20 ES

And even without some incompatible shaders its still working
proof: https://imgur.com/xWfzUxA