### PR TITLE
Generalise genie xcode4 cases to apply to all xcode project versions.

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -75,7 +75,7 @@ solution "bgfx"
 		"Release",
 	}
 
-	if _ACTION == "xcode4" then
+	if _ACTION:match "xcode*" then
 		platforms {
 			"Universal",
 		}
@@ -343,13 +343,13 @@ function exampleProjectDefaults()
 			"-weak_framework Metal",
 		}
 
-	configuration { "xcode4", "ios" }
+	configuration { "xcode*", "ios" }
 		kind "WindowedApp"
 		files {
 			path.join(BGFX_DIR, "examples/runtime/iOS-Info.plist"),
 		}
 
-	configuration { "xcode4", "tvos" }
+	configuration { "xcode*", "tvos" }
 		kind "WindowedApp"
 		files {
 			path.join(BGFX_DIR, "examples/runtime/tvOS-Info.plist"),

--- a/scripts/texturev.lua
+++ b/scripts/texturev.lua
@@ -157,7 +157,7 @@ project ("texturev")
 			"-framework QuartzCore",
 		}
 
-	configuration { "xcode4", "ios" }
+	configuration { "xcode*", "ios" }
 		kind "WindowedApp"
 
 	configuration { "qnx*" }


### PR DESCRIPTION
This just fixes the bgfx genie scripts to work with any xcode project version, rather than just xcode4, particularly as the makefile is currently using xcode8 :)