### PR TITLE
Add C99 api(macro) BGFX_HANDLE_ID_VALID

### DIFF
--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -463,6 +463,8 @@ typedef struct bgfx_vertex_buffer_handle_s { uint16_t idx; } bgfx_vertex_buffer_
 typedef struct bgfx_vertex_decl_handle_s { uint16_t idx; } bgfx_vertex_decl_handle_t;
 
 
+#define BGFX_HANDLE_IS_VALID(h) ((h).idx != UINT16_MAX)
+
 /**
  * Memory release callback.
  *

--- a/scripts/temp.bgfx.h
+++ b/scripts/temp.bgfx.h
@@ -106,6 +106,8 @@ typedef struct bgfx_callback_vtbl_s
 
 $chandles
 
+#define BGFX_HANDLE_IS_VALID(h) ((h).idx != UINT16_MAX)
+
 $cfuncptrs
 
 $cstructs


### PR DESCRIPTION
There are C++ APIs  `xxxHandle::IsValid`  https://github.com/bkaradzic/bgfx/blob/master/include/bgfx/bgfx.h#L18

But there is no C99 equivalent , this macro `bgfx_handle_is_valid` can check whether a handle is valid.