### PR TITLE
Added automatic mipmap generation for GL, Metal Textures

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5098,6 +5098,11 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			GL_CHECK(glPixelStorei(GL_UNPACK_ROW_LENGTH, 0) );
 		}
 
+		if (m_numMips > 1)
+		{
+			GL_CHECK(glGenerateMipmap(m_target));
+		}
+
 		if (NULL != temp)
 		{
 			BX_FREE(g_allocator, temp);

--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -143,6 +143,13 @@ namespace bgfx { namespace mtl
 		{
 			[m_obj endEncoding];
 		}
+
+		void generateMipmapsForTexture(
+			  id<MTLTexture> _texture
+			)
+		{
+			[m_obj generateMipmapsForTexture:_texture];
+		}
 	MTL_CLASS_END
 
 	MTL_CLASS(Buffer)
@@ -951,6 +958,7 @@ namespace bgfx { namespace mtl
 
 		TextureMtl()
 			: m_ptr(NULL)
+			, m_nativePtr(NULL)
 			, m_ptrMsaa(NULL)
 			, m_ptrStencil(NULL)
 			, m_sampler(NULL)
@@ -970,7 +978,8 @@ namespace bgfx { namespace mtl
 
 		void destroy()
 		{
-			MTL_RELEASE(m_ptr);
+			MTL_RELEASE(m_nativePtr);
+			m_ptr = 0;
 			MTL_RELEASE(m_ptrStencil);
 			for (uint32_t ii = 0; ii < m_numMips; ++ii)
 			{
@@ -998,6 +1007,7 @@ namespace bgfx { namespace mtl
 		Texture getTextureMipLevel(int _mip);
 
 		Texture m_ptr;
+		id<MTLTexture> m_nativePtr;
 		Texture m_ptrMsaa;
 		Texture m_ptrStencil; // for emulating packed depth/stencil formats - only for iOS8...
 		Texture m_ptrMips[14];

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -2709,7 +2709,8 @@ namespace bgfx { namespace mtl
 				}
 			}
 
-			m_ptr = s_renderMtl->m_device.newTextureWithDescriptor(desc);
+			m_nativePtr = s_renderMtl->m_device.newTextureWithDescriptor(desc);
+			m_ptr = m_nativePtr;
 
 			if (sampleCount > 1)
 			{
@@ -2844,6 +2845,8 @@ namespace bgfx { namespace mtl
 			data = temp;
 		}
 
+		BlitCommandEncoder bce = s_renderMtl->getBlitCommandEncoder();
+
 		if (NULL != s_renderMtl->m_renderCommandEncoder)
 		{
 			s_renderMtl->m_cmd.finish(true);
@@ -2858,8 +2861,6 @@ namespace bgfx { namespace mtl
 		}
 		else
 		{
-			BlitCommandEncoder bce = s_renderMtl->getBlitCommandEncoder();
-
 			const uint32_t dstpitch = bx::strideAlign(rectpitch, 64);
 
 			Buffer tempBuffer = s_renderMtl->m_device.newBufferWithLength(dstpitch*_rect.m_height, 0);
@@ -2884,6 +2885,11 @@ namespace bgfx { namespace mtl
 				, MTLOriginMake(_rect.m_x, _rect.m_y, zz)
 				);
 			release(tempBuffer);
+		}
+
+		if ([m_nativePtr mipmapLevelCount] > 1)
+		{
+			bce.generateMipmapsForTexture(m_nativePtr);
 		}
 
 		if (NULL != temp)


### PR DESCRIPTION
Added OpenGL glGenerateMipmap and Metal generateMipmapForTexture to automatically generate mipmaps for textures with multiple mipmap levels.