### PR TITLE
Use SRGB texture format on backbuffer when MSAA is enabled (DX11, DX12, OpenGL)

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1006,7 +1006,10 @@ namespace bgfx { namespace d3d11
 					bx::memSet(&m_scd, 0, sizeof(m_scd) );
 					m_scd.width  = _init.resolution.width;
 					m_scd.height = _init.resolution.height;
-					m_scd.format = s_textureFormat[_init.resolution.format].m_fmt;
+					m_scd.format = (_init.resolution.reset & BGFX_RESET_SRGB_BACKBUFFER)
+						? s_textureFormat[_init.resolution.format].m_fmtSrgb
+						: s_textureFormat[_init.resolution.format].m_fmt
+						;
 
 					updateMsaa(m_scd.format);
 					m_scd.sampleDesc  = s_msaa[(_init.resolution.reset&BGFX_RESET_MSAA_MASK)>>BGFX_RESET_MSAA_SHIFT];

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -934,7 +934,10 @@ namespace bgfx { namespace d3d12
 				bx::memSet(&m_scd, 0, sizeof(m_scd) );
 				m_scd.width  = _init.resolution.width;
 				m_scd.height = _init.resolution.height;
-				m_scd.format = s_textureFormat[_init.resolution.format].m_fmt;
+				m_scd.format = (_init.resolution.reset & BGFX_RESET_SRGB_BACKBUFFER)
+					? s_textureFormat[_init.resolution.format].m_fmtSrgb
+					: s_textureFormat[_init.resolution.format].m_fmt
+					;
 				m_scd.stereo  = false;
 
 				updateMsaa(m_scd.format);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3277,11 +3277,16 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			if (0 == m_msaaBackBufferFbo // iOS
 			&&  1 < _msaa)
 			{
+				GLenum storageFormat = (m_resolution.reset & BGFX_RESET_SRGB_BACKBUFFER)
+					? GL_SRGB8_ALPHA8
+					: GL_RGBA8
+					;
+
 				GL_CHECK(glGenFramebuffers(1, &m_msaaBackBufferFbo) );
 				GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_msaaBackBufferFbo) );
 				GL_CHECK(glGenRenderbuffers(BX_COUNTOF(m_msaaBackBufferRbos), m_msaaBackBufferRbos) );
 				GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, m_msaaBackBufferRbos[0]) );
-				GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, _msaa, GL_RGBA8, _width, _height) );
+				GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, _msaa, storageFormat, _width, _height) );
 				GL_CHECK(glBindRenderbuffer(GL_RENDERBUFFER, m_msaaBackBufferRbos[1]) );
 				GL_CHECK(glRenderbufferStorageMultisample(GL_RENDERBUFFER, _msaa, GL_DEPTH24_STENCIL8, _width, _height) );
 				GL_CHECK(glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_msaaBackBufferRbos[0]) );


### PR DESCRIPTION
When both SRGB and MSAA are enabled, DX11 & 12 fail to intialize, and OpenGL use a non-SRGB backbuffer.

This fix produce the expected behaviour on my computer, although I have no idea if this is the correct way to do it.
I haven't checked the other renderers.
