### PR TITLE
Create HTML5/Esmscripten glcontext

### DIFF
--- a/examples/common/entry/entry_asmjs.cpp
+++ b/examples/common/entry/entry_asmjs.cpp
@@ -303,7 +303,6 @@ namespace entry
 
 	EM_BOOL Context::focusCb(int eventType, const EmscriptenFocusEvent* event, void* userData)
 	{
-		printf("focusCb %d", eventType);
 		BX_UNUSED(event, userData);
 
 		if (event)

--- a/makefile
+++ b/makefile
@@ -49,7 +49,7 @@ projgen: ## Generate project files for all configurations.
 	$(GENIE)              --with-combined-examples --with-shared-lib --gcc=freebsd         gmake
 	$(GENIE)              --with-combined-examples                   --gcc=android-arm     gmake
 	$(GENIE)              --with-combined-examples                   --gcc=android-x86     gmake
-	$(GENIE)              --with-combined-examples                   --gcc=asmjs           gmake
+	$(GENIE)              --with-examples                            --gcc=asmjs           gmake
 	$(GENIE)              --with-combined-examples                   --gcc=ios-arm         gmake
 	$(GENIE)              --with-combined-examples                   --gcc=ios-arm64       gmake
 	$(GENIE)              --with-combined-examples                   --gcc=ios-simulator   gmake

--- a/src/amalgamated.cpp
+++ b/src/amalgamated.cpp
@@ -9,6 +9,7 @@
 #include "glcontext_egl.cpp"
 #include "glcontext_glx.cpp"
 #include "glcontext_wgl.cpp"
+#include "glcontext_html5.cpp"
 #include "nvapi.cpp"
 #include "renderer_d3d11.cpp"
 #include "renderer_d3d12.cpp"

--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -16,6 +16,8 @@
 // from emscripten gl.c, because we're not going to go
 // through egl
 extern "C" void* emscripten_GetProcAddress(const char *name_);
+extern "C" void* emscripten_webgl1_get_proc_address(const char *name_);
+extern "C" void* emscripten_webgl2_get_proc_address(const char *name_);
 
 namespace bgfx { namespace gl
 {
@@ -130,7 +132,7 @@ namespace bgfx { namespace gl
 
 		SwapChainGL* swapChain = BX_NEW(g_allocator, SwapChainGL)(context, canvas);
 
-		import();
+		import(1);
 
 		return swapChain;
 	}
@@ -169,14 +171,16 @@ namespace bgfx { namespace gl
 		}
 	}
 
-	void GlContext::import()
+	void GlContext::import(int webGLVersion)
 	{
 		BX_TRACE("Import:");
 #		define GL_EXTENSION(_optional, _proto, _func, _import)                                                                                                   \
 			{                                                                                                                                                    \
 				if (NULL == _func)                                                                                                                               \
 				{                                                                                                                                                \
-					_func = (_proto)emscripten_GetProcAddress(#_import);                                                                                                 \
+					_func = (_proto)emscripten_webgl1_get_proc_address(#_import);                                                                                \
+					if (!_func && webGLVersion >= 2)                                                                                                             \
+					    _func = (_proto)emscripten_webgl2_get_proc_address(#_import);                                                                            \
 					BX_TRACE("\t%p " #_func " (" #_import ")", _func);                                                                                           \
 					BGFX_FATAL(_optional || NULL != _func, Fatal::UnableToInitialize, "Failed to create WebGL/OpenGLES context. GetProcAddress(\"%s\")", #_import); \
 				}                                                                                                                                                \

--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -32,7 +32,7 @@ namespace bgfx { namespace gl
 		SwapChainGL(int _context, const char* _canvas)
 			: m_context(_context)
 		{
-			BX_ALLOC(g_allocator, strlen(_canvas) + 1);
+			m_canvas = (char*)BX_ALLOC(g_allocator, strlen(_canvas) + 1);
 			strcpy(m_canvas, _canvas);
 
 			makeCurrent();

--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2011-2019 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#include "bgfx_p.h"
+
+#if BGFX_CONFIG_RENDERER_OPENGLES
+#	include "renderer_gl.h"
+
+#	if BGFX_USE_HTML5
+
+#include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
+
+// from emscripten gl.c, because we're not going to go
+// through egl
+extern "C" void* emscripten_GetProcAddress(const char *name_);
+
+namespace bgfx { namespace gl
+{
+
+#	define GL_IMPORT(_optional, _proto, _func, _import) _proto _func = NULL
+#	include "glimports.h"
+
+	static EmscriptenWebGLContextAttributes s_attrs;
+
+	struct SwapChainGL
+	{
+		SwapChainGL(int _context, const char* _canvas)
+			: m_context(_context)
+		{
+			BX_ALLOC(g_allocator, strlen(_canvas) + 1);
+			strcpy(m_canvas, _canvas);
+
+			makeCurrent();
+			GL_CHECK(glClearColor(0.0f, 0.0f, 0.0f, 0.0f) );
+			GL_CHECK(glClear(GL_COLOR_BUFFER_BIT) );
+			swapBuffers();
+			GL_CHECK(glClear(GL_COLOR_BUFFER_BIT) );
+			swapBuffers();
+		}
+
+		~SwapChainGL()
+		{
+			emscripten_webgl_destroy_context(m_context);
+			BX_FREE(g_allocator, m_canvas);
+		}
+
+		void makeCurrent()
+		{
+			emscripten_webgl_make_context_current(m_context);
+		}
+
+		void swapBuffers()
+		{
+			// There is no swapBuffers equivalent.  A swap happens whenever control is returned back
+			// to the browser.
+		}
+
+		int m_context;
+		char* m_canvas;
+	};
+
+	void GlContext::create(uint32_t _width, uint32_t _height)
+	{
+		// assert?
+		if (m_primary != NULL)
+			return;
+
+		const char* canvas = (const char*) g_platformData.nwh; // if 0, Module.canvas is used
+
+		m_primary = createSwapChain((void*)canvas);
+
+		if (_width && _height)
+			emscripten_set_canvas_element_size(canvas, (int)_width, (int)_height);
+
+		makeCurrent(m_primary);
+	}
+
+	void GlContext::destroy()
+	{
+		if (m_primary)
+		{
+			if (m_current == m_primary)
+				m_current = NULL;
+			BX_DELETE(g_allocator, m_primary);
+			m_primary = NULL;
+		}
+	}
+
+	void GlContext::resize(uint32_t _width, uint32_t _height, uint32_t /* _flags */)
+    {
+		if (m_primary == NULL)
+			return;
+
+		emscripten_set_canvas_element_size(m_primary->m_canvas, (int) _width, (int) _height);
+    }
+
+	SwapChainGL* GlContext::createSwapChain(void* _nwh)
+	{
+		emscripten_webgl_init_context_attributes(&s_attrs);
+
+		s_attrs.alpha = false;
+		s_attrs.depth = true;
+		s_attrs.stencil = true;
+		s_attrs.enableExtensionsByDefault = true;
+
+        // let emscripten figure out the best WebGL context to create
+		// TODO this isn't necessarily the right thing, I don't think the code actually does the fallback like it should
+		s_attrs.majorVersion = 0;
+		s_attrs.majorVersion = 0;
+
+		const char* canvas = (const char*) _nwh;
+
+		int context = emscripten_webgl_create_context(canvas, &s_attrs);
+
+		if (context <= 0)
+		{
+			BX_TRACE("Failed to create WebGL context.  (Canvas handle: '%s', error %d)", canvas, (int)context);
+			return NULL;
+		}
+
+		int result = emscripten_webgl_make_context_current(context);
+		if (EMSCRIPTEN_RESULT_SUCCESS != result)
+		{
+			BX_TRACE("emscripten_webgl_make_context_current failed (%d)", result);
+			return NULL;
+		}
+
+		SwapChainGL* swapChain = BX_NEW(g_allocator, SwapChainGL)(context, canvas);
+
+		import();
+
+		return swapChain;
+	}
+
+	uint64_t GlContext::getCaps() const
+	{
+		return BGFX_CAPS_SWAP_CHAIN;
+	}
+
+	void GlContext::destroySwapChain(SwapChainGL* _swapChain)
+	{
+		BX_DELETE(g_allocator, _swapChain);
+	}
+
+	void GlContext::swap(SwapChainGL* /* _swapChain */)
+	{
+	}
+
+	void GlContext::makeCurrent(SwapChainGL* _swapChain)
+	{
+		if (m_current != _swapChain)
+		{
+			m_current = _swapChain;
+
+			if (NULL == _swapChain)
+			{
+				if (NULL != m_primary)
+				{
+					m_primary->makeCurrent();
+				}
+			}
+			else
+			{
+				_swapChain->makeCurrent();
+			}
+		}
+	}
+
+	void GlContext::import()
+	{
+		BX_TRACE("Import:");
+#		define GL_EXTENSION(_optional, _proto, _func, _import)                                                                                                   \
+			{                                                                                                                                                    \
+				if (NULL == _func)                                                                                                                               \
+				{                                                                                                                                                \
+					_func = (_proto)emscripten_GetProcAddress(#_import);                                                                                                 \
+					BX_TRACE("\t%p " #_func " (" #_import ")", _func);                                                                                           \
+					BGFX_FATAL(_optional || NULL != _func, Fatal::UnableToInitialize, "Failed to create WebGL/OpenGLES context. GetProcAddress(\"%s\")", #_import); \
+				}                                                                                                                                                \
+			}
+
+#	include "glimports.h"
+	}
+
+} /* namespace gl */ } // namespace bgfx
+
+#	endif // BGFX_USE_EGL
+#endif // (BGFX_CONFIG_RENDERER_OPENGLES || BGFX_CONFIG_RENDERER_OPENGL)

--- a/src/glcontext_html5.h
+++ b/src/glcontext_html5.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2011-2019 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#ifndef BGFX_GLCONTEXT_HTML5_H_HEADER_GUARD
+#define BGFX_GLCONTEXT_HTML5_H_HEADER_GUARD
+
+#if BGFX_USE_HTML5
+
+namespace bgfx { namespace gl
+{
+	struct SwapChainGL;
+
+	struct GlContext
+	{
+		GlContext()
+			: m_current(NULL)
+			, m_primary(NULL)
+		{
+		}
+
+		void create(uint32_t _width, uint32_t _height);
+		void destroy();
+		void resize(uint32_t _width, uint32_t _height, uint32_t _flags);
+
+		uint64_t getCaps() const;
+		SwapChainGL* createSwapChain(void* _nwh);
+		void destroySwapChain(SwapChainGL*  _swapChain);
+		void swap(SwapChainGL* _swapChain = NULL);
+		void makeCurrent(SwapChainGL* _swapChain = NULL);
+
+		void import();
+
+		bool isValid() const
+		{
+			return NULL != m_primary;
+		}
+
+        SwapChainGL* m_current;
+		SwapChainGL* m_primary;
+	};
+} /* namespace gl */ } // namespace bgfx
+
+#endif // BGFX_USE_HTML5
+
+#endif // BGFX_GLCONTEXT_HTML5_H_HEADER_GUARD

--- a/src/glcontext_html5.h
+++ b/src/glcontext_html5.h
@@ -30,7 +30,7 @@ namespace bgfx { namespace gl
 		void swap(SwapChainGL* _swapChain = NULL);
 		void makeCurrent(SwapChainGL* _swapChain = NULL);
 
-		void import();
+		void import(int webGLVersion);
 
 		bool isValid() const
 		{

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1055,10 +1055,22 @@ namespace bgfx { namespace gl
 
 	typedef void (*PostSwapBuffersFn)(uint32_t _width, uint32_t _height);
 
+	void flushGlError()
+	{
+		for (GLenum err = glGetError(); err != 0; err = glGetError() );
+	}
+
+	GLenum getGlError()
+	{
+		GLenum err = glGetError();
+		flushGlError();
+		return err;
+	}
+
 	static const char* getGLString(GLenum _name)
 	{
 		const char* str = (const char*)glGetString(_name);
-		glGetError(); // ignore error if glGetString returns NULL.
+		getGlError(); // ignore error if glGetString returns NULL.
 		if (NULL != str)
 		{
 			return str;
@@ -1070,7 +1082,7 @@ namespace bgfx { namespace gl
 	static uint32_t getGLStringHash(GLenum _name)
 	{
 		const char* str = (const char*)glGetString(_name);
-		glGetError(); // ignore error if glGetString returns NULL.
+		getGlError(); // ignore error if glGetString returns NULL.
 		if (NULL != str)
 		{
 			return bx::hash<bx::HashMurmur2A>(str, (uint32_t)bx::strLen(str) );
@@ -1155,7 +1167,7 @@ namespace bgfx { namespace gl
 	{
 		GLint result = 0;
 		glGetIntegerv(_pname, &result);
-		GLenum err = glGetError();
+		GLenum err = getGlError();
 		BX_WARN(0 == err, "glGetIntegerv(0x%04x, ...) failed with GL error: 0x%04x.", _pname, err);
 		return 0 == err ? result : 0;
 	}
@@ -1166,11 +1178,6 @@ namespace bgfx { namespace gl
 		tfi.m_internalFmt = _internalFmt;
 		tfi.m_fmt         = _fmt;
 		tfi.m_type        = _type;
-	}
-
-	void flushGlError()
-	{
-		for (GLenum err = glGetError(); err != 0; err = glGetError() );
 	}
 
 	static void texSubImage(
@@ -1457,7 +1464,7 @@ namespace bgfx { namespace gl
 				uint32_t block = bx::uint32_max(4, dim);
 				size = (block*block*bpp)/8;
 				compressedTexImage(target, ii, internalFmt, dim, dim, 0, 0, size, data);
-				err |= glGetError();
+				err |= getGlError();
 			}
 		}
 		else
@@ -1467,7 +1474,7 @@ namespace bgfx { namespace gl
 				dim = bx::uint32_max(1, dim);
 				size = (dim*dim*bpp)/8;
 				texImage(target, 0, ii, internalFmt, dim, dim, 0, 0, tfi.m_fmt, tfi.m_type, data);
-				err |= glGetError();
+				err |= getGlError();
 			}
 		}
 
@@ -1513,7 +1520,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 				, _dim
 				, _dim
 				);
-			err = glGetError();
+			err = getGlError();
 		}
 
 		if (0 == err)
@@ -1532,7 +1539,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			&&  _mipAutogen)
 			{
 				glGenerateMipmap(target);
-				err = glGetError();
+				err = getGlError();
 			}
 		}
 
@@ -1556,7 +1563,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 		GLenum err = 0;
 
 		glTexStorage2D(GL_TEXTURE_2D, 1, s_imageFormat[_format], _dim, _dim);
-		err |= glGetError();
+		err |= getGlError();
 		if (0 == err)
 		{
 			glBindImageTexture(0
@@ -1567,7 +1574,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 				, GL_READ_WRITE
 				, s_imageFormat[_format]
 				);
-			err |= glGetError();
+			err |= getGlError();
 		}
 
 		GL_CHECK(glDeleteTextures(1, &id) );
@@ -1606,7 +1613,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			glBindRenderbuffer(GL_RENDERBUFFER, 0);
 			glDeleteRenderbuffers(1, &rbo);
 
-			GLenum err = glGetError();
+			GLenum err = getGlError();
 			return 0 == err;
 		}
 
@@ -1648,7 +1655,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 				, id
 				, 0
 				);
-		err = glGetError();
+		err = getGlError();
 
 		if (0 == err)
 		{
@@ -1892,7 +1899,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 			if (BX_ENABLED(BGFX_CONFIG_RENDERER_USE_EXTENSIONS) )
 			{
 				const char* extensions = (const char*)glGetString(GL_EXTENSIONS);
-				glGetError(); // ignore error if glGetString returns NULL.
+				getGlError(); // ignore error if glGetString returns NULL.
 				if (NULL != extensions)
 				{
 					bx::StringView ext(extensions);
@@ -1912,7 +1919,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 				{
 					GLint numExtensions = 0;
 					glGetIntegerv(GL_NUM_EXTENSIONS, &numExtensions);
-					glGetError(); // ignore error if glGetIntegerv returns NULL.
+					getGlError(); // ignore error if glGetIntegerv returns NULL.
 
 					for (GLint index = 0; index < numExtensions; ++index)
 					{
@@ -2205,7 +2212,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 							, 1
 							, &maxSamples
 							);
-						GLenum err = glGetError();
+						GLenum err = getGlError();
 						supported |= 0 == err && maxSamples > 0
 							? BGFX_CAPS_FORMAT_TEXTURE_FRAMEBUFFER_MSAA
 							: BGFX_CAPS_FORMAT_TEXTURE_NONE
@@ -2217,7 +2224,7 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 							, 1
 							, &maxSamples
 							);
-						err = glGetError();
+						err = getGlError();
 						supported |= 0 == err && maxSamples > 0
 							? BGFX_CAPS_FORMAT_TEXTURE_MSAA
 							: BGFX_CAPS_FORMAT_TEXTURE_NONE

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -9,12 +9,15 @@
 #define BGFX_USE_EGL (BGFX_CONFIG_RENDERER_OPENGLES && (0 \
 			|| BX_PLATFORM_ANDROID                        \
 			|| BX_PLATFORM_BSD                            \
-			|| BX_PLATFORM_EMSCRIPTEN                     \
 			|| BX_PLATFORM_LINUX                          \
 			|| BX_PLATFORM_NX                             \
 			|| BX_PLATFORM_RPI                            \
 			|| BX_PLATFORM_STEAMLINK                      \
 			|| BX_PLATFORM_WINDOWS                        \
+			) )
+
+#define BGFX_USE_HTML5 (BGFX_CONFIG_RENDERER_OPENGLES && (0 \
+			|| BX_PLATFORM_EMSCRIPTEN                     \
 			) )
 
 #define BGFX_USE_WGL (BGFX_CONFIG_RENDERER_OPENGL && BX_PLATFORM_WINDOWS)
@@ -123,6 +126,10 @@ typedef uint64_t GLuint64;
 
 #	if BGFX_USE_EGL
 #		include "glcontext_egl.h"
+#	endif // BGFX_USE_EGL
+
+#	if BGFX_USE_HTML5
+#		include "glcontext_html5.h"
 #	endif // BGFX_USE_EGL
 
 #	if BX_PLATFORM_EMSCRIPTEN


### PR DESCRIPTION
This uses the emscripten API to directly create a canvas webgl context, instead of going through the EGL compat layer.  It also does some annoying work around GL errors to work around an emscripten bug; this is being fixed on the emscripten side, but it would only be present in the very latest emscripten.

(The double-error bug was present even before; I doubt bgfx debug builds worked fully with emscripten without some hacking.  Or at least, they may have "worked" because debugBreak did nothing on emscripten before...)