### PR TITLE
Fix build for non-English system encoding

### DIFF
--- a/3rdparty/dear-imgui/widgets/markdown.h
+++ b/3rdparty/dear-imgui/widgets/markdown.h
@@ -45,14 +45,14 @@ Headers:
 
 Indents: 
 On a new line, at the start of the line, add two spaces per indent.
-��Indent level 1
-����Indent level 2
+  Indent level 1
+    Indent level 2
 
 Unordered lists: 
 On a new line, at the start of the line, add two spaces, an asterisks and a space. 
 For nested lists, add two additional spaces in front of the asterisk per list level increment.
-��*�Unordered List level 1
-����*�Unordered List level 2
+  * Unordered List level 1
+    * Unordered List level 2
 
 Links:
 [link description](https://...)

--- a/examples/40-svt/svt.cpp
+++ b/examples/40-svt/svt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Aleö Mlakar. All rights reserved.
+ * Copyright 2018 Ale≈° Mlakar. All rights reserved.
  * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
  */
 

--- a/examples/40-svt/vt.cpp
+++ b/examples/40-svt/vt.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2018 Aleš Mlakar. All rights reserved.
  * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
  */

--- a/examples/40-svt/vt.h
+++ b/examples/40-svt/vt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Aleö Mlakar. All rights reserved.
+ * Copyright 2018 Ale≈° Mlakar. All rights reserved.
  * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
  */
 

--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -446,10 +446,10 @@ namespace ImGui
 } // namespace ImGui
 
 BX_PRAGMA_DIAGNOSTIC_IGNORED_MSVC(4505); // error C4505: '' : unreferenced local function has been removed
-BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wunused-function"); // warning: ‘int rect_width_compare(const void*, const void*)’ defined but not used
+BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wunused-function"); // warning: 'int rect_width_compare(const void*, const void*)' defined but not used
 BX_PRAGMA_DIAGNOSTIC_PUSH();
 BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG("-Wunknown-pragmas")
-//BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wunused-but-set-variable"); // warning: variable ‘L1’ set but not used
+//BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wunused-but-set-variable"); // warning: variable 'L1' set but not used
 BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG_GCC("-Wtype-limits"); // warning: comparison is always true due to limited range of data type
 #define STBTT_malloc(_size, _userData) memAlloc(_size, _userData)
 #define STBTT_free(_ptr, _userData) memFree(_ptr, _userData)


### PR DESCRIPTION
Some files had characters that were not compatible with some specific system encodings (e.g. Japanese Shift_JIS(932)). When building on VS2017, I got this warning about them:

> warning C4819: The file contains a character that cannot be represented in the current code page

The issues are from text in comments and example-40-svt was in ANSI encoding causing issues with the author's name in the copyright. The examples are configured to treat warnings as errors so the compilation fails. 
I fixed the characters and converted example 40-svt code to UTF-8.