### PR TITLE
Fixed objc_msgSend in strict checking mode

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2260,12 +2260,14 @@ namespace bgfx
 		NSAutoreleasePoolScope()
 		{
 			id obj = class_createInstance(objc_getClass("NSAutoreleasePool"), 0);
-			pool = objc_msgSend(obj, sel_getUid("init") );
+			typedef id(*objc_msgSend_init)(void*, SEL);
+			pool = ((objc_msgSend_init)objc_msgSend)(obj, sel_getUid("init") );
 		}
 
 		~NSAutoreleasePoolScope()
 		{
-			objc_msgSend(pool, sel_getUid("release") );
+			typedef void(*objc_msgSend_release)(void*, SEL);
+			((objc_msgSend_release)objc_msgSend)(pool, sel_getUid("release") );
 		}
 
 		id pool;


### PR DESCRIPTION
Issue was reported by @PyryM 
bgfx.cpp has compile error on XCode 11 beta. I was able to reproduce this in latest (non-beta) XCode with renaming bgfx.cpp to bgfx.mm, that triggered strict objc_msgSend checking. It seems XCode 11 will check this rule in cpp files too. 

Info about strict checking and how to fix it:
https://stackoverflow.com/questions/27771345/what-exactly-does-enable-strict-checking-of-objc-msgsend-calls-mean

Issue:
../../../src/bgfx.cpp:2265:11: fatal error: no matching function for call to
      'objc_msgSend'
                        pool = objc_msgSend(obj, sel_getUid("init") );
                               ^~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/objc/message.h:63:1: note: 
      candidate function not viable: requires 0 arguments, but 2 were provided
objc_msgSend(void /* id self, SEL op, ... */ )

Apple clang version 11.0.0 (clang-1100.0.20.17)
Target: x86_64-apple-darwin18.7.0