### PR TITLE
Reset s_renderFrameCalled back to false when calling bgfx::shutdown.

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -3467,6 +3467,7 @@ namespace bgfx
 		s_threadIndex = 0;
 		g_callback    = NULL;
 		g_allocator   = NULL;
+		s_renderFrameCalled = false;
 	}
 
 	void reset(uint32_t _width, uint32_t _height, uint32_t _flags, TextureFormat::Enum _format)


### PR DESCRIPTION
The documentation says that renderFrame should be called before bgfx::init in order the prevent the render thread from being created.

If I call the renderFrame in the following sequence:

bgfx::renderFrame
bgfx::init
bgfx::shutdown
bgfx::renderFrame <= abort() triggered

I'll get an abort with the following message:
bgfx/src/bgfx.cpp(1386): BGFX 0x00000000: Must be called from render thread.

