### PR TITLE
Fixed gather usage after cleanup commit in bx.

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -370,7 +370,11 @@ namespace
 		uint32_t pitch = tex->width * bytesPerPixel;
 
 		const bgfx::Memory* mem = bgfx::alloc(w * h * bytesPerPixel);
-		bx::gather(mem->data, data + y * pitch + x * bytesPerPixel, w * bytesPerPixel, h, pitch);
+		bx::gather(mem->data,                            // dst
+		           data + y * pitch + x * bytesPerPixel, // src
+		           pitch,                                // srcStride
+		           w * bytesPerPixel,                    // stride
+		           h);                                   // num
 
 		bgfx::updateTexture2D(
 			  tex->id


### PR DESCRIPTION
Your cleanup commit (https://github.com/bkaradzic/bx/commit/49bd00e4461f27baecc42195943d81a624bc2f29) reordered the arguments of `bx::cleanup`, but the usage of it in bgfx wasn't updated accordingly. There was only one usage, being nanovg_bgfx.cpp. I fixed the order of the arguments in the calling code.

Too validate the bug, run the nanovg example. This crashes with a heap-buffer-overflow error.

Cheers!