### PR TITLE
vulkan backend implementation 3: blit, debug draw, and instancing

### DIFF
--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -169,6 +169,7 @@
 			VK_IMPORT_DEVICE_FUNC(false, vkCmdResolveImage);               \
 			VK_IMPORT_DEVICE_FUNC(false, vkCmdCopyBuffer);                 \
 			VK_IMPORT_DEVICE_FUNC(false, vkCmdCopyBufferToImage);          \
+			VK_IMPORT_DEVICE_FUNC(false, vkCmdBlitImage);                  \
 			VK_IMPORT_DEVICE_FUNC(false, vkMapMemory);                     \
 			VK_IMPORT_DEVICE_FUNC(false, vkUnmapMemory);                   \
 			VK_IMPORT_DEVICE_FUNC(false, vkFlushMappedMemoryRanges);       \
@@ -390,6 +391,7 @@ VK_DESTROY
 			, m_hash(0)
 			, m_numUniforms(0)
 			, m_numPredefined(0)
+			, m_uniformBinding(0)
 			, m_numBindings(0)
 		{
 		}
@@ -418,6 +420,7 @@ VK_DESTROY
 			uint32_t imageBinding;
 		};
 		SamplerInfo m_sampler[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
+		uint32_t m_uniformBinding;
 		uint16_t m_numBindings;
 		VkDescriptorSetLayoutBinding m_bindings[32];
 	};


### PR DESCRIPTION
Hello again! This is the 3rd PR for my vulkan backend implementation.

### Changes

- implement blit operation
- implement debug draw
- implement instancing (roughly)

### Status

- 00-helloworld and 05-instancing start to work!
- In 08-update, the second cube (which represents the usage of blit function) can be drawn.

### Question

- Currently, I've just bound the instance data with the sequential order. I think that method this cannot work if the instance data attributes are not sequential order.
```glsl
// this works
$input a_position, a_color0, i_data0, i_data1, i_data2, i_data3, i_data4
...
// this may not work
$input a_position, a_color0, i_data1, i_data0
```
- So, should I consider the disordered instance attributes? If so, I should modify the shader compiler to store the information about instance attributes.

Thank you for reading!