### PR TITLE
15-shadowmaps-simple: Fixed float depth packing mode

### DIFF
--- a/examples/15-shadowmaps-simple/shadowmaps_simple.cpp
+++ b/examples/15-shadowmaps-simple/shadowmaps_simple.cpp
@@ -106,6 +106,8 @@ public:
 		}
 		bgfx::setUniform(u_depthScaleOffset, depthScaleOffset);
 
+		bgfx::touch(0);
+
 		// Create vertex stream declaration.
 		PosNormalVertex::init();
 
@@ -129,67 +131,14 @@ public:
 		// Shadow samplers are supported at least partially supported if texture
 		// compare less equal feature is supported.
 		m_shadowSamplerSupported = 0 != (caps->supported & BGFX_CAPS_TEXTURE_COMPARE_LEQUAL);
+		m_useShadowSampler = m_shadowSamplerSupported;
 
-		bgfx::TextureHandle shadowMapTexture;
-
-		if (m_shadowSamplerSupported)
-		{
-			// Depth textures and shadow samplers are supported.
-			m_progShadow = loadProgram("vs_sms_shadow", "fs_sms_shadow");
-			m_progMesh   = loadProgram("vs_sms_mesh",   "fs_sms_mesh");
-
-			bgfx::TextureHandle fbtextures[] =
-			{
-				bgfx::createTexture2D(
-					  m_shadowMapSize
-					, m_shadowMapSize
-					, false
-					, 1
-					, bgfx::TextureFormat::D16
-					, BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LEQUAL
-					),
-			};
-			shadowMapTexture = fbtextures[0];
-			m_shadowMapFB = bgfx::createFrameBuffer(BX_COUNTOF(fbtextures), fbtextures, true);
-		}
-		else
-		{
-			// Depth textures and shadow samplers are not supported. Use float
-			// depth packing into color buffer instead.
-			m_progShadow = loadProgram("vs_sms_shadow_pd", "fs_sms_shadow_pd");
-			m_progMesh   = loadProgram("vs_sms_mesh",      "fs_sms_mesh_pd");
-
-			bgfx::TextureHandle fbtextures[] =
-			{
-				bgfx::createTexture2D(
-					  m_shadowMapSize
-					, m_shadowMapSize
-					, false
-					, 1
-					, bgfx::TextureFormat::BGRA8
-					, BGFX_TEXTURE_RT
-					),
-				bgfx::createTexture2D(
-					  m_shadowMapSize
-					, m_shadowMapSize
-					, false
-					, 1
-					, bgfx::TextureFormat::D16
-					, BGFX_TEXTURE_RT_WRITE_ONLY
-					),
-			};
-			shadowMapTexture = fbtextures[0];
-			m_shadowMapFB = bgfx::createFrameBuffer(BX_COUNTOF(fbtextures), fbtextures, true);
-		}
+		m_shadowMapFB = BGFX_INVALID_HANDLE;
+		m_progShadow = BGFX_INVALID_HANDLE;
+		m_progMesh = BGFX_INVALID_HANDLE;
 
 		m_state[0] = meshStateCreate();
-		m_state[0]->m_state = 0
-			| (m_shadowSamplerSupported ? 0 : BGFX_STATE_WRITE_RGB|BGFX_STATE_WRITE_A)
-			| BGFX_STATE_WRITE_Z
-			| BGFX_STATE_DEPTH_TEST_LESS
-			| BGFX_STATE_CULL_CCW
-			| BGFX_STATE_MSAA
-			;
+		m_state[0]->m_state = 0;
 		m_state[0]->m_program = m_progShadow;
 		m_state[0]->m_viewId  = RENDER_SHADOW_PASS_ID;
 		m_state[0]->m_numTextures = 0;
@@ -209,7 +158,7 @@ public:
 		m_state[1]->m_textures[0].m_flags = UINT32_MAX;
 		m_state[1]->m_textures[0].m_stage = 0;
 		m_state[1]->m_textures[0].m_sampler = s_shadowMap;
-		m_state[1]->m_textures[0].m_texture = shadowMapTexture;
+		m_state[1]->m_textures[0].m_texture = BGFX_INVALID_HANDLE;
 
 		// Set view and projection matrices.
 
@@ -271,11 +220,111 @@ public:
 
 			showExampleDialog(this);
 
+			ImGui::SetNextWindowPos(
+				ImVec2(m_width - m_width / 5.0f - 10.0f, 10.0f)
+				, ImGuiCond_FirstUseEver
+			);
+			ImGui::SetNextWindowSize(
+				ImVec2(m_width / 5.0f, m_height / 2.0f)
+				, ImGuiCond_FirstUseEver
+			);
+			ImGui::Begin("Settings"
+				, NULL
+				, 0
+			);
+
+			bool shadowSamplerModeChanged = false;
+			if (m_shadowSamplerSupported)
+			{
+				shadowSamplerModeChanged = ImGui::Checkbox("Use Shadow Sampler", &m_useShadowSampler);
+			}
+			else
+			{
+				ImGui::Text("Shadow sampler is not supported");
+			}
+
+			ImGui::End();
+
 			imguiEndFrame();
 
 			int64_t now = bx::getHPCounter();
 			const double freq = double(bx::getHPFrequency() );
 			float time = float( (now-m_timeOffset)/freq);
+
+			if (!bgfx::isValid(m_shadowMapFB) || shadowSamplerModeChanged)
+			{
+				bgfx::TextureHandle shadowMapTexture;
+
+				if (bgfx::isValid(m_progShadow))
+					bgfx::destroy(m_progShadow);
+				if (bgfx::isValid(m_progMesh))
+					bgfx::destroy(m_progMesh);
+
+				if (bgfx::isValid(m_shadowMapFB))
+					bgfx::destroy(m_shadowMapFB);
+
+				if (m_useShadowSampler)
+				{
+					// Depth textures and shadow samplers are supported.
+					m_progShadow = loadProgram("vs_sms_shadow", "fs_sms_shadow");
+					m_progMesh = loadProgram("vs_sms_mesh", "fs_sms_mesh");
+
+					bgfx::TextureHandle fbtextures[] =
+					{
+						bgfx::createTexture2D(
+							  m_shadowMapSize
+							, m_shadowMapSize
+							, false
+							, 1
+							, bgfx::TextureFormat::D16
+							, BGFX_TEXTURE_RT | BGFX_SAMPLER_COMPARE_LEQUAL
+							),
+					};
+					shadowMapTexture = fbtextures[0];
+					m_shadowMapFB = bgfx::createFrameBuffer(BX_COUNTOF(fbtextures), fbtextures, true);
+				}
+				else
+				{
+					// Depth textures and shadow samplers are not supported. Use float
+					// depth packing into color buffer instead.
+					m_progShadow = loadProgram("vs_sms_shadow_pd", "fs_sms_shadow_pd");
+					m_progMesh = loadProgram("vs_sms_mesh", "fs_sms_mesh_pd");
+
+					bgfx::TextureHandle fbtextures[] =
+					{
+						bgfx::createTexture2D(
+							  m_shadowMapSize
+							, m_shadowMapSize
+							, false
+							, 1
+							, bgfx::TextureFormat::BGRA8
+							, BGFX_TEXTURE_RT
+							),
+						bgfx::createTexture2D(
+							  m_shadowMapSize
+							, m_shadowMapSize
+							, false
+							, 1
+							, bgfx::TextureFormat::D16
+							, BGFX_TEXTURE_RT_WRITE_ONLY
+							),
+					};
+					shadowMapTexture = fbtextures[0];
+					m_shadowMapFB = bgfx::createFrameBuffer(BX_COUNTOF(fbtextures), fbtextures, true);
+				}
+
+				m_state[0]->m_program = m_progShadow;
+				m_state[0]->m_state = 0
+					| (m_useShadowSampler ? 0 : BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A)
+					| BGFX_STATE_WRITE_Z
+					| BGFX_STATE_DEPTH_TEST_LESS
+					| BGFX_STATE_CULL_CCW
+					| BGFX_STATE_MSAA
+					;
+
+				m_state[1]->m_program = m_progMesh;
+				m_state[1]->m_textures[0].m_texture = shadowMapTexture;
+			}
 
 			// Setup lights.
 			float lightPos[4];
@@ -444,6 +493,7 @@ public:
 	bgfx::FrameBufferHandle m_shadowMapFB;
 
 	bool m_shadowSamplerSupported;
+	bool m_useShadowSampler;
 
 	MeshState* m_state[2];
 


### PR DESCRIPTION
There was an issue with example-15 with vulkan renderer. I have found that it was not a renderer specific problem. Vulkan doesn't expose BGFX_CAPS_TEXTURE_COMPARE_LEQUAL caps so a different code path was used, other renderers had the same issue with disabling shadow sampler path.

Fix was only adding bgfx::touch(0) to force update u_depthScaleOffset uniform, it was skipped otherwise.

For better test coverage I have added an option to disable shadow sampler usage. 

