### PR TITLE
vulkan backend implementation 6: some optimization

### DIFF
--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -71,6 +71,7 @@
 			VK_IMPORT_INSTANCE_FUNC(false, vkEnumerateDeviceLayerProperties);          \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceProperties);             \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFormatProperties);       \
+			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFeatures);               \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceImageFormatProperties);  \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceMemoryProperties);       \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceMemoryProperties2KHR);   \
@@ -325,6 +326,11 @@ VK_DESTROY
 		void destroy();
 		void reset();
 
+		VkDescriptorSet& getCurrentDS()
+		{
+			return m_descriptorSet[m_currentDs - 1];
+		}
+
 		VkDescriptorSet* m_descriptorSet;
 		VkBuffer m_buffer;
 		VkDeviceMemory m_deviceMem;
@@ -469,6 +475,7 @@ VK_DESTROY
 			, m_textureImage(VK_NULL_HANDLE)
 			, m_textureDeviceMem(VK_NULL_HANDLE)
 			, m_textureImageView(VK_NULL_HANDLE)
+			, m_textureImageDepthView(VK_NULL_HANDLE)
 			, m_textureImageStorageView(VK_NULL_HANDLE)
 			, m_currentImageLayout(VK_IMAGE_LAYOUT_UNDEFINED)
 		{
@@ -498,6 +505,7 @@ VK_DESTROY
 		VkImage m_textureImage;
 		VkDeviceMemory m_textureDeviceMem;
 		VkImageView m_textureImageView;
+		VkImageView m_textureImageDepthView;
 		VkImageView m_textureImageStorageView;
 		VkImageLayout m_currentImageLayout;
 	};


### PR DESCRIPTION
Hello! This is the 6th PR of my Vulkan backend implementation (#274)

### Changes

#### Refactoring & optimizing descriptor set binding

- Uniform buffer objects which are set by setUniform() or predefined are now using dynamic uniform buffer.
- Thus descriptor set can be reused if renderBind information or pipeline layout is not changed.
- Allocating and writing descriptor sets is refactored into a function.
- I also tried to cache descriptor set like d3d12 implementation (using something like bindLru in the d3d12 backend), but failed. Maybe descriptor sets are already in a descriptor pool, so allocation and free is fast enough to be in a frame.
- After this optimization, example-17 now start to work, and active scissor rect drawing in example-21 also works. Perhaps the main reason that these examples don't work is the lack of descriptor sets (1024 for each frame)

#### Some minor change & bug fix

- Supports to indirect compute call (for enabling example-24 indirect call option)
- Image layout is reinitialized when texture is released. This fixes example-16 crash when switching a light source.
- Get / set device features when creating logical device, and check independent blending feature. This fixes example-19 crash when switching MRT-independent option.
- Create depth view for depth/stencil texture.

Thank you!