### PR TITLE
fix Solaris

### DIFF
--- a/3rdparty/dear-imgui/widgets/file_list.inl
+++ b/3rdparty/dear-imgui/widgets/file_list.inl
@@ -32,10 +32,15 @@ namespace ImGui
 				}
 				else if (0 != ImStricmp(item->d_name, ".") )
 				{
+#ifndef __sun
 					if (item->d_type & DT_DIR)
-					{
 						FileList.push_back(ImFileInfo(item->d_name, -1) );
-					}
+#else
+					struct stat st;
+					stat(item->d_name, &st);
+					if (S_ISDIR(st.st_mode))
+						FileList.push_back(ImFileInfo(item->d_name, -1) );
+#endif
 					else
 					{
 						struct stat statbuf;


### PR DESCRIPTION
this patch fixes building on Solaris 2.x, which does not have a BSD- or GNU-style `struct dirent` with the inode type encoded directly. 
Solaris (and possibly other System 5 UNIX) uses `struct stat` for this.