### PR TITLE
Use correct texture mip dimensions in Vulkan renderer.

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -5145,8 +5145,8 @@ VK_DESTROY
 			VkBufferImageCopy* bufferCopyInfo = (VkBufferImageCopy*)BX_ALLOC(g_allocator, sizeof(VkBufferImageCopy) * numSrd);
 			for (uint32_t ii = 0; ii < numSrd; ++ii)
 			{
-				uint32_t idealWidth  = m_width  >> imageInfos[ii].mipLevel;
-				uint32_t idealHeight = m_height >> imageInfos[ii].mipLevel;
+				uint32_t idealWidth  = bx::max<uint32_t>(1, m_width  >> imageInfos[ii].mipLevel);
+				uint32_t idealHeight = bx::max<uint32_t>(1, m_height >> imageInfos[ii].mipLevel);
 				bufferCopyInfo[ii].bufferOffset      = totalMemSize;
 				bufferCopyInfo[ii].bufferRowLength   = 0; // assume that image data are tightly aligned
 				bufferCopyInfo[ii].bufferImageHeight = 0; // assume that image data are tightly aligned


### PR DESCRIPTION
This was hitting debug validation:

`CommandBuffer, Validation, 0:  [ UNASSIGNED-CoreValidation-Image-ZeroAreaSubregion ] Object: VK_NULL_HANDLE (Type = 6) | vkCmdCopyBufferToImage(): pRegion[3] imageExtent of {1, 0, 1} has zero area`

Should have been `uint32_t idealWidth  = bx::max<uint32_t>(1, m_width  >> imageInfos[ii].mipLevel);` etc. but that's redundant since the dimensions are already in `ImageInfo`.