### PR TITLE
Fixes shaderc texture array usage detection

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -124,6 +124,7 @@ namespace bgfx
 
 	static const char* s_textureArray[] =
 	{
+		"sampler2DArray",
 		"texture2DArray",
 		"texture2DArrayLod",
 		"shadow2DArray",


### PR DESCRIPTION
A glsl shader using only the SAMPLER2DARRAY() macro wasn't being detected as using the texture array extension.