### PR TITLE
Fix uninitialized Vulkan sampler hash.

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3275,6 +3275,7 @@ VK_IMPORT_DEVICE
 		VkSampler getSampler(uint32_t _samplerFlags, uint32_t _mipLevels)
 		{
 			bx::HashMurmur2A hash;
+			hash.begin();
 			hash.add(_samplerFlags);
 			hash.add(_mipLevels);
 			uint32_t hashKey = hash.end();


### PR DESCRIPTION
This was manifesting as occasionally wrong texture wrap mode.