### PR TITLE
shaderc: Add before hlsl validation option to spirv

### DIFF
--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -980,7 +980,10 @@ namespace bgfx { namespace spirv
 
 				opt.RegisterLegalizationPasses();
 
-				if (!opt.Run(spirv.data(), spirv.size(), &spirv) )
+				spvtools::ValidatorOptions validatorOptions;
+				validatorOptions.SetBeforeHlslLegalization(true);
+
+				if (!opt.Run(spirv.data(), spirv.size(), &spirv, validatorOptions, false) )
 				{
 					compiled = false;
 				}


### PR DESCRIPTION
Fixes  #1829 by disabling check.
```
Error: In Vulkan, OpTypeStruct must not contain an opaque type.
  %BgfxSampler2D = OpTypeStruct %6 %8
```