### PR TITLE
Added texture functions with bias parameter

### DIFF
--- a/scripts/shader.mk
+++ b/scripts/shader.mk
@@ -22,7 +22,7 @@ all:
 	@echo "  TARGET=4 (glsl)"
 	@echo "  TARGET=5 (metal)"
 	@echo "  TARGET=6 (pssl)"
-	@echo "  TARGET=7 (spriv)"
+	@echo "  TARGET=7 (spirv)"
 
 .PHONY: rebuild
 rebuild:

--- a/src/bgfx_shader.sh
+++ b/src/bgfx_shader.sh
@@ -176,6 +176,11 @@ vec4 bgfxTexture2D(BgfxSampler2D _sampler, vec2 _coord)
 	return _sampler.m_texture.Sample(_sampler.m_sampler, _coord);
 }
 
+vec4 bgfxTexture2DBias(BgfxSampler2D _sampler, vec2 _coord, float _bias)
+{
+	return _sampler.m_texture.SampleBias(_sampler.m_sampler, _coord, _bias);
+}
+
 vec4 bgfxTexture2DLod(BgfxSampler2D _sampler, vec2 _coord, float _level)
 {
 	return _sampler.m_texture.SampleLevel(_sampler.m_sampler, _coord, _level);
@@ -263,6 +268,11 @@ vec4 bgfxTextureCube(BgfxSamplerCube _sampler, vec3 _coord)
 	return _sampler.m_texture.Sample(_sampler.m_sampler, _coord);
 }
 
+vec4 bgfxTextureCubeBias(BgfxSamplerCube _sampler, vec3 _coord, float _bias)
+{
+	return _sampler.m_texture.SampleBias(_sampler.m_sampler, _coord, _bias);
+}
+
 vec4 bgfxTextureCubeLod(BgfxSamplerCube _sampler, vec3 _coord, float _level)
 {
 	return _sampler.m_texture.SampleLevel(_sampler.m_sampler, _coord, _level);
@@ -347,6 +357,7 @@ vec3 bgfxTextureSize(BgfxSampler3D _sampler, int _lod)
 			static BgfxUSampler2D _name = { _name ## Texture }
 #		define sampler2D BgfxSampler2D
 #		define texture2D(_sampler, _coord) bgfxTexture2D(_sampler, _coord)
+#		define texture2DBias(_sampler, _coord, _bias) bgfxTexture2DBias(_sampler, _coord, _bias)
 #		define texture2DLod(_sampler, _coord, _level) bgfxTexture2DLod(_sampler, _coord, _level)
 #		define texture2DLodOffset(_sampler, _coord, _level, _offset) bgfxTexture2DLodOffset(_sampler, _coord, _level, _offset)
 #		define texture2DProj(_sampler, _coord) bgfxTexture2DProj(_sampler, _coord)
@@ -401,6 +412,7 @@ vec3 bgfxTextureSize(BgfxSampler3D _sampler, int _lod)
 			static BgfxSamplerCube _name = { _name ## Sampler, _name ## Texture }
 #		define samplerCube BgfxSamplerCube
 #		define textureCube(_sampler, _coord) bgfxTextureCube(_sampler, _coord)
+#		define textureCubeBias(_sampler, _coord, _bias) bgfxTextureCubeBias(_sampler, _coord, _bias)
 #		define textureCubeLod(_sampler, _coord, _level) bgfxTextureCubeLod(_sampler, _coord, _level)
 
 #		define SAMPLERCUBESHADOW(_name, _reg) \
@@ -542,6 +554,9 @@ vec4  mod(vec4  _a, vec4  _b) { return _a - _b * floor(_a / _b); }
 #	define USAMPLER2D(_name, _reg) uniform usampler2D _name
 #	define ISAMPLER3D(_name, _reg) uniform isampler3D _name
 #	define USAMPLER3D(_name, _reg) uniform usampler3D _name
+
+#	define texture2DBias(_sampler, _coord, _bias)      texture2D(_sampler, _coord, _bias)
+#	define textureCubeBias(_sampler, _coord, _bias)    textureCube(_sampler, _coord, _bias)
 
 #	if BGFX_SHADER_LANGUAGE_GLSL >= 130
 #		define texture2D(_sampler, _coord)      texture(_sampler, _coord)


### PR DESCRIPTION
and fixed a typo.

I have tested it with modifying shaders of 06-bump and 09-hdr. It worked with D3D11 and OpenGL renderer on windows, also checked compilation for metal and spirv. Metal shaders looked ok to me. 

I am unsure about handling 'BGFX_SHADER_LANGUAGE_GLSL >= 130'. 
Current version of handling texture functions seems incomplete too me, but maybe shaderc does some magic for other versions.
https://github.com/bkaradzic/bgfx/blob/72eb05b71e569ba55db0152c054e83abd639acd4/src/bgfx_shader.sh#L546
