### PR TITLE
Fixed isampler and usampler for metal/spirv

### DIFF
--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -564,6 +564,22 @@ namespace bgfx { namespace metal
 		return bgfx::Attrib::Count;
 	}
 
+	static const char* s_samplerTypes[] =
+	{
+		"BgfxSampler2D",
+		"BgfxISampler2D",
+		"BgfxUSampler2D",
+		"BgfxSampler2DArray",
+		"BgfxSampler2DShadow",
+		"BgfxSampler2DArrayShadow",
+		"BgfxSampler3D",
+		"BgfxISampler3D",
+		"BgfxUSampler3D",
+		"BgfxSamplerCube",
+		"BgfxSamplerCubeShadow",
+		"BgfxSampler2DMS",
+	};
+
 	static uint16_t writeUniformArray(bx::WriterI* _writer, const UniformArray& uniforms, bool isFragmentShader)
 	{
 		uint16_t size = 0;
@@ -713,13 +729,17 @@ namespace bgfx { namespace metal
 							if (index != std::string::npos)
 							{
 								bool found = false;
-
-								if (!bx::findIdentifierMatch(strLine.c_str(), "SamplerState").isEmpty() ||
-									!bx::findIdentifierMatch(strLine.c_str(), "SamplerComparisonState").isEmpty())
+								
+								for (int32_t ii = 0; ii < BX_COUNTOF(s_samplerTypes); ++ii)
 								{
-									found = true;
+									if (!bx::findIdentifierMatch(strLine.c_str(), s_samplerTypes[ii]).isEmpty())
+									{
+										found = true;
+										break;
+									}
 								}
-								else
+								
+								if (!found)
 								{
 									for (int32_t ii = 0, num = program->getNumLiveUniformVariables(); ii < num; ++ii)
 									{

--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -613,6 +613,22 @@ namespace bgfx { namespace spirv
 		return bgfx::Attrib::Count;
 	}
 
+	static const char* s_samplerTypes[] =
+	{
+		"BgfxSampler2D",
+		"BgfxISampler2D",
+		"BgfxUSampler2D",
+		"BgfxSampler2DArray",
+		"BgfxSampler2DShadow",
+		"BgfxSampler2DArrayShadow",
+		"BgfxSampler3D",
+		"BgfxISampler3D",
+		"BgfxUSampler3D",
+		"BgfxSamplerCube",
+		"BgfxSamplerCubeShadow",
+		"BgfxSampler2DMS",
+	};
+
 	static uint16_t writeUniformArray(bx::WriterI* _writer, const UniformArray& uniforms, bool isFragmentShader)
 	{
 		uint16_t size = 0;
@@ -767,12 +783,16 @@ namespace bgfx { namespace spirv
 							{
 								bool found = false;
 
-								if (!bx::findIdentifierMatch(strLine.c_str(), "SamplerState").isEmpty() ||
-									!bx::findIdentifierMatch(strLine.c_str(), "SamplerComparisonState").isEmpty())
+								for (int32_t ii = 0; ii < BX_COUNTOF(s_samplerTypes); ++ii)
 								{
-									found = true;
+									if (!bx::findIdentifierMatch(strLine.c_str(), s_samplerTypes[ii]).isEmpty())
+									{
+										found = true;
+										break;
+									}
 								}
-								else
+								
+								if (!found)
 								{
 									for (int32_t ii = 0, num = program->getNumLiveUniformVariables(); ii < num; ++ii)
 									{


### PR DESCRIPTION
This checks for BgfxSampler names instead of d3d sampler states. Every sampler type is included in check.

On Metal: Textures shouldn't be ever removed with changing to static because compiler gives error for them. Cannot construct texture on global scope.

I did some research on this issue
https://github.com/KhronosGroup/glslang/issues/1727
Samplers/Textures are accessed through a static program variable struct (eg BgfxSampler2D) , The reflection code doesn't see raw samplers/texture as used. It sees the struct and its member variables as used, but as it is a static variable not a uniform (https://github.com/bkaradzic/bgfx/blob/master/src/bgfx_shader.sh#L341 ) it doesn't reports it as live uniform. 

 It doesn't seem to be an easy fix for them, so I wouldn't count on it anytime soon. Static variables can be reassigned theoretically, so a proper fix could be even harder.