### PR TITLE
Front facing

### DIFF
--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -90,6 +90,9 @@
 #define BGFX_STATE_CULL_SHIFT               36                           //!< Culling mode bit shift
 #define BGFX_STATE_CULL_MASK                UINT64_C(0x0000003000000000) //!< Culling mode bit mask
 
+/// Front winding direction. Will default to clockwise unless otherwise specified.
+#define BGFX_STATE_FRONT_CCW               	UINT64_C(0x0000008000000000) //!< Front counter-clockwise (default is clockwise).
+
 /**
  * Alpha reference value.
  *

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -91,7 +91,7 @@
 #define BGFX_STATE_CULL_MASK                UINT64_C(0x0000003000000000) //!< Culling mode bit mask
 
 /// Front winding direction. Will default to clockwise unless otherwise specified.
-#define BGFX_STATE_FRONT_CCW               	UINT64_C(0x0000008000000000) //!< Front counter-clockwise (default is clockwise).
+#define BGFX_STATE_FRONT_CCW                UINT64_C(0x0000008000000000) //!< Front counter-clockwise (default is clockwise).
 
 /**
  * Alpha reference value.

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -83,6 +83,10 @@ flag.StateCull { bits = 64, shift = 36, range = 2, base = 1, desc = "Culling mod
 	.Ccw		  --- Cull counter-clockwise triangles.
 	()
 
+--- Font facing. When BGFX_STATE_FRONT_CCW is not specified, front facing is CW
+flag.StateFrontCCW { bits = 64, shift = 39, range = 1, base = 1, desc = "Front facing" }
+	()
+
 --- Alpha reference value.
 flag.StateAlphaRef { bits = 64, shift = 40, range = 8, desc = "Alpha reference", "helper" }
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -2846,6 +2846,7 @@ namespace bgfx { namespace d3d11
 				| BGFX_STATE_MSAA
 				| BGFX_STATE_LINEAA
 				| BGFX_STATE_CONSERVATIVE_RASTER
+				| BGFX_STATE_FRONT_CCW
 				;
 			_state |= _wireframe ? BGFX_STATE_PT_LINES : BGFX_STATE_NONE;
 			_state |= _scissor   ? BGFX_STATE_RESERVED_MASK : 0;
@@ -2862,7 +2863,7 @@ namespace bgfx { namespace d3d11
 					D3D11_RASTERIZER_DESC2 desc;
 					desc.FillMode = _wireframe ? D3D11_FILL_WIREFRAME : D3D11_FILL_SOLID;
 					desc.CullMode = s_cullMode[cull];
-					desc.FrontCounterClockwise = false;
+					desc.FrontCounterClockwise = !!(_state&BGFX_STATE_FRONT_CCW);
 					desc.DepthBias             = 0;
 					desc.DepthBiasClamp        = 0.0f;
 					desc.SlopeScaledDepthBias  = 0.0f;

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -2557,8 +2557,8 @@ namespace bgfx { namespace d3d12
 				? D3D12_FILL_MODE_WIREFRAME
 				: D3D12_FILL_MODE_SOLID
 				;
-			_desc.CullMode = s_cullMode[cull];
-			_desc.FrontCounterClockwise = false;
+			_desc.CullMode              = s_cullMode[cull];
+			_desc.FrontCounterClockwise = !!(_state&BGFX_STATE_FRONT_CCW);;
 			_desc.DepthBias             = 0;
 			_desc.DepthBiasClamp        = 0.0f;
 			_desc.SlopeScaledDepthBias  = 0.0f;

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6861,8 +6861,14 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 					 | BGFX_STATE_MSAA
 					 | BGFX_STATE_LINEAA
 					 | BGFX_STATE_CONSERVATIVE_RASTER
+					 | BGFX_STATE_FRONT_CCW
 					 ) & changedFlags)
 				{
+					if (BGFX_STATE_FRONT_CCW & changedFlags)
+					{
+						GL_CHECK(glFrontFace((BGFX_STATE_FRONT_CCW & newFlags) ? GL_CCW : GL_CW) );
+					}
+
 					if (BGFX_STATE_CULL_MASK & changedFlags)
 					{
 						if (BGFX_STATE_CULL_CCW & newFlags)

--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -426,6 +426,11 @@ namespace bgfx { namespace mtl
 			[m_obj setBlendColorRed:_red green:_green blue:_blue alpha:_alpha];
 		}
 
+        void setFrontFacing(MTLWinding _frontFacing)
+        {
+            [m_obj setFrontFacing:_frontFacing];
+        }
+
 		void setCullMode(MTLCullMode _cullMode)
 		{
 			[m_obj setCullMode:_cullMode];

--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -426,10 +426,10 @@ namespace bgfx { namespace mtl
 			[m_obj setBlendColorRed:_red green:_green blue:_blue alpha:_alpha];
 		}
 
-        void setFrontFacing(MTLWinding _frontFacing)
-        {
-            [m_obj setFrontFacing:_frontFacing];
-        }
+		void setFrontFacing(MTLWinding _frontFacing)
+		{
+			[m_obj setFrontFacing:_frontFacing];
+		}
 
 		void setCullMode(MTLCullMode _cullMode)
 		{

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -4224,7 +4224,7 @@ namespace bgfx { namespace mtl
 				{
 					if (BGFX_STATE_FRONT_CCW & changedFlags)
 					{
-						rce.setFrontFacing((newFlags&BGFX_STATE_FRONT_CCW) ? counterClockwise : clockwise);
+						rce.setFrontFacing((newFlags&BGFX_STATE_FRONT_CCW) ? MTLWindingCounterClockwise : MTLWindingClockwise);
 					}
 
 					if (BGFX_STATE_CULL_MASK & changedFlags)

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -4219,8 +4219,14 @@ namespace bgfx { namespace mtl
 					 | BGFX_STATE_CULL_MASK
 					 | BGFX_STATE_ALPHA_REF_MASK
 					 | BGFX_STATE_PT_MASK
+					 | BGFX_STATE_FRONT_CCW
 					 ) & changedFlags)
 				{
+					if (BGFX_STATE_FRONT_CCW & changedFlags)
+					{
+						rce.setFrontFacing((newFlags&BGFX_STATE_FRONT_CCW) ? counterClockwise : clockwise);
+					}
+
 					if (BGFX_STATE_CULL_MASK & changedFlags)
 					{
 						const uint64_t pt = newFlags&BGFX_STATE_CULL_MASK;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3074,7 +3074,7 @@ VK_IMPORT_DEVICE
 				: VK_POLYGON_MODE_FILL
 				;
 			_desc.cullMode  = s_cullMode[cull];
-			_desc.frontFace = VK_FRONT_FACE_CLOCKWISE;
+			_desc.frontFace = (_state&BGFX_STATE_FRONT_CCW) ? VK_FRONT_FACE_COUNTER_CLOCKWISE : VK_FRONT_FACE_CLOCKWISE;
 			_desc.depthBiasEnable = VK_FALSE;
 			_desc.depthBiasConstantFactor = 0.0f;
 			_desc.depthBiasClamp          = 0.0f;


### PR DESCRIPTION
Added BGFX_STATE_FRONT_CCW flag to set front facing winding.
Supported by every API but D3D9. 
Some file formats (like GLTF) support changing the winding.
