### PR TITLE
Add support for building shaders in MINGW bash shell

### DIFF
--- a/scripts/tools.mk
+++ b/scripts/tools.mk
@@ -9,16 +9,21 @@ THISDIR:=$(dir $(lastword $(MAKEFILE_LIST)))
 
 UNAME:=$(shell uname)
 ifeq ($(UNAME),$(filter $(UNAME),Linux Darwin))
-CMD_MKDIR=mkdir -p "$(1)"
-CMD_RMDIR=rm -r "$(1)"
+CMD_MKDIR=if [ ! -d "$(1)" ]; then mkdir -p "$(1)"; fi
+CMD_RMDIR=if [ -d "$(1)" ]; then rm -r "$(1)"; fi
 ifeq ($(UNAME),$(filter $(UNAME),Darwin))
 OS=darwin
 else
 OS=linux
 endif
 else
+ifeq ($(findstring MINGW,$(UNAME)),MINGW)
+CMD_MKDIR=if [ ! -d "$(1)" ]; then mkdir -p "$(1)"; fi
+CMD_RMDIR=if [ -d "$(1)" ]; then rm -r "$(1)"; fi
+else
 CMD_MKDIR=cmd /C "if not exist "$(subst /,\,$(1))" mkdir "$(subst /,\,$(1))""
 CMD_RMDIR=cmd /C "if exist "$(subst /,\,$(1))" rmdir /S /Q "$(subst /,\,$(1))""
+endif
 OS=windows
 endif
 


### PR DESCRIPTION
I cannot test it with make rebuild-shaders as it seems to be broken now, but an equivalent change does work with mame downstream:
https://github.com/mamedev/mame/pull/5740