### PR TITLE
rebind instance data buffer if index buffer changes

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -7159,6 +7159,8 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 
 					{
 						bool diffStreamHandles = false;
+						bool diffIndexBuffer = false;
+
 						for (uint32_t idx = 0, streamMask = draw.m_streamMask
 							; 0 != streamMask
 							; streamMask >>= 1, idx += 1
@@ -7216,6 +7218,8 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 							{
 								GL_CHECK(glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0) );
 							}
+
+							diffIndexBuffer = true;
 						}
 
 						if (0 != currentState.m_streamMask)
@@ -7272,7 +7276,10 @@ BX_TRACE("%d, %d, %d, %s", _array, _srgb, _mipAutogen, getName(_format) );
 								}
 
 								program.bindAttributesEnd();
+							}
 
+							if (bindAttribs || diffStartVertex || diffIndexBuffer)
+							{
 								if (isValid(draw.m_instanceDataBuffer) )
 								{
 									GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, m_vertexBuffers[draw.m_instanceDataBuffer.idx].m_id) );


### PR DESCRIPTION
Fix case of drawing different indices of same vertex buffer using same
instance data.

This can happen in the case of conditionally drawing subsets of vertex
buffer stored in different index buffers while re-using non-transient
instance buffers.

With the following diff, you can reproduce this bug.
It does three things differently from the instancing example:

1. It uses a dynamic buffer instead of a transient one. For performance reasons, in our application, we only occasionally update the instance buffer based on a dirty flag.
2. We're using two index buffers. In our application, these two buffers represent different components of a mesh, which aren't always shown (e.g. different stages of building a house).
3. It draws the geometry twice. In our application, we don't draw the exact same indices as in this example, but we don't change the state, vertex buffer or instance buffer.

<details>
<summary><b>(Click to expand)</b> Diff to instancing example</summary><p>

```patch
diff --git a/examples/05-instancing/instancing.cpp b/examples/05-instancing/instancing.cpp
index 83c78e49c..fd3f9dd73 100644
--- a/examples/05-instancing/instancing.cpp
+++ b/examples/05-instancing/instancing.cpp
@@ -31,6 +31,30 @@ struct PosColorVertex
 
 bgfx::VertexLayout PosColorVertex::ms_layout;
 
+struct TransformColorUniform
+{
+	float m_matrix[16];
+	float m_color[4];
+
+	static void init()
+	{
+		ms_layout
+			.begin()
+			.add(bgfx::Attrib::TexCoord7, 4, bgfx::AttribType::Float)
+			.add(bgfx::Attrib::TexCoord6, 4, bgfx::AttribType::Float)
+			.add(bgfx::Attrib::TexCoord5, 4, bgfx::AttribType::Float)
+			.add(bgfx::Attrib::TexCoord4, 4, bgfx::AttribType::Float)
+			.add(bgfx::Attrib::TexCoord3, 4, bgfx::AttribType::Float)
+			.end();
+	};
+
+	static bgfx::VertexLayout ms_layout;
+	// 11x11 cubes
+	static const uint32_t ms_numInstances = 121;
+};
+
+bgfx::VertexLayout TransformColorUniform::ms_layout;
+
 static PosColorVertex s_cubeVertices[8] =
 {
 	{-1.0f,  1.0f,  1.0f, 0xff000000 },
@@ -104,11 +128,23 @@ public:
 					, PosColorVertex::ms_layout
 					);
 
-		// Create static index buffer.
-		m_ibh = bgfx::createIndexBuffer(
+		// Create static index buffers.
+		m_ibh[0] = bgfx::createIndexBuffer(
+					bgfx::makeRef(s_cubeIndices, sizeof(s_cubeIndices) )
+					);
+		m_ibh[1] = bgfx::createIndexBuffer(
 					bgfx::makeRef(s_cubeIndices, sizeof(s_cubeIndices) )
 					);
 
+		// Create instance stream declaration.
+		TransformColorUniform::init();
+
+		// Create dynamic instance buffer.
+		m_idbh = bgfx::createDynamicVertexBuffer(
+			TransformColorUniform::ms_numInstances
+			, TransformColorUniform::ms_layout
+		);
+
 		// Create program from shaders.
 		m_program = loadProgram("vs_instancing", "fs_instancing");
 
@@ -122,8 +158,10 @@ public:
 		imguiDestroy();
 
 		// Cleanup.
-		bgfx::destroy(m_ibh);
+		bgfx::destroy(m_ibh[0]);
+		bgfx::destroy(m_ibh[1]);
 		bgfx::destroy(m_vbh);
+		bgfx::destroy(m_idbh);
 		bgfx::destroy(m_program);
 
 		// Shutdown bgfx.
@@ -188,17 +226,9 @@ public:
 					bgfx::setViewRect(0, 0, 0, uint16_t(m_width), uint16_t(m_height) );
 				}
 
-				// 80 bytes stride = 64 bytes for 4x4 matrix + 16 bytes for RGBA color.
-				const uint16_t instanceStride = 80;
-				// 11x11 cubes
-				const uint32_t numInstances   = 121;
+                              const bgfx::Memory* mem = bgfx::alloc(TransformColorUniform::ms_numInstances * TransformColorUniform::ms_layout.m_stride);
 
-				if (numInstances == bgfx::getAvailInstanceDataBuffer(numInstances, instanceStride) )
-				{
-					bgfx::InstanceDataBuffer idb;
-					bgfx::allocInstanceDataBuffer(&idb, numInstances, instanceStride);
-
-					uint8_t* data = idb.data;
+					uint8_t* data = mem->data;
 
 					// Write instance data for 11x11 cubes.
 					for (uint32_t yy = 0; yy < 11; ++yy)
@@ -217,16 +247,19 @@ public:
 							color[2] = bx::sin(time*3.0f)*0.5f+0.5f;
 							color[3] = 1.0f;
 
-							data += instanceStride;
+							data += TransformColorUniform::ms_layout.m_stride;
 						}
 					}
+					bgfx::update(m_idbh, 0, mem);
 
+				for (uint8_t i = 0; i < 2; ++i)
+				{
 					// Set vertex and index buffer.
 					bgfx::setVertexBuffer(0, m_vbh);
-					bgfx::setIndexBuffer(m_ibh);
+					bgfx::setIndexBuffer(m_ibh[i]);
 
 					// Set instance data buffer.
-					bgfx::setInstanceDataBuffer(&idb);
+					bgfx::setInstanceDataBuffer(m_idbh, 0, TransformColorUniform::ms_numInstances);
 
 					// Set render states.
 					bgfx::setState(BGFX_STATE_DEFAULT);
@@ -253,7 +286,8 @@ public:
 	uint32_t m_debug;
 	uint32_t m_reset;
 	bgfx::VertexBufferHandle m_vbh;
-	bgfx::IndexBufferHandle  m_ibh;
+	bgfx::IndexBufferHandle  m_ibh[2];
+	bgfx::DynamicVertexBufferHandle m_idbh;
 	bgfx::ProgramHandle m_program;
 
 	int64_t m_timeOffset;

```

</p></details>

When running the changes to the example without this fix, the first draw call draws the geometry correctly, but the second draw call has bad bindings for the instance data and draws based on invalid data for the matrix (seen here with the line across the image)
![Screenshot from 2019-10-25 15-20-17](https://user-images.githubusercontent.com/1013356/67574621-12ad7700-f73b-11e9-84aa-54923238fd60.png)
If debugging in renderdoc, we can see the instance data buffer being bound for the first draw:
![Screenshot from 2019-10-25 15-24-46](https://user-images.githubusercontent.com/1013356/67574935-bd259a00-f73b-11e9-9669-36177e33a720.png)
But unbound for the second draw:
![Screenshot from 2019-10-25 15-25-13](https://user-images.githubusercontent.com/1013356/67574960-c6af0200-f73b-11e9-9107-20801beb8b46.png)
