### PR TITLE
Fix to errors when mixing flat and texture2DArray

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5660,6 +5660,7 @@ namespace bgfx { namespace gl
 						else
 						{
 							bx::write(&writer, "#define texture2DArrayLodEXT texture2DArrayLod\n");
+							bx::write(&writer, "#define textureArray texture\n");
 						}
 					}
 

--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -125,6 +125,17 @@ namespace bgfx { namespace glsl
 						continue;
 					}
 
+					if (0 == bx::strCmp(qualifier, "flat", 4)
+					||  0 == bx::strCmp(qualifier, "smooth", 6)
+					||  0 == bx::strCmp(qualifier, "noperspective", 13)
+					||  0 == bx::strCmp(qualifier, "centroid", 8)
+					   )
+					{
+						// skip interpolation qualifiers
+						parse.set(eol.getPtr() + 1, parse.getTerm() );
+						continue;
+					}
+
 					if (0 == bx::strCmp(parse, "tmpvar", 6) )
 					{
 						// skip temporaries


### PR DESCRIPTION
Fixes #1891

In a glsl pixel shader, when sampling a 2DArray with `texture2DArray` while using a `flat` varying, shaderc will generate of `textureArray` calls instead of `texture2DArray`.

And bgfx  will fail to load the produced shader while compiling with opengl:
```
[2019-09-24 11:14:26.525] [debug] bgfx: bgfx/src/renderer_gl.cpp:5904: BGFX Failed to compile shader. 0: 0(45) : error C1503: undefined variable "textureArray"
0(45) : error C1503: undefined variable "textureArray"
0(47) : error C1503: undefined variable "textureArray"
0(47) : error C1503: undefined variable "textureArray"
0(49) : error C1503: undefined variable "textureArray"
0(49) : error C1503: undefined variable "textureArray"
```

When the `flat` qualifier is in the source, `glslopt` will generate glsl 130 code.
This, then causes `glslopt_optimize` to output `textureArray`, whereas it would output `texture2DArray` for glsl 120 code.

The fix allows shaderc to skip `flat` qualifiers when parsing and allows bgfx to alias `textureArray` with `texture.

See #1891 for more information about this bug and see https://github.com/bkaradzic/bgfx/commit/b6b0ed3cbacd1d2d9c3d2b233aa9770d27c35c39 for a minimal example.