### PR TITLE
Support disabling Vsync on Vulkan

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2760,6 +2760,38 @@ VK_IMPORT_DEVICE
 					VK_CHECK(vkDeviceWaitIdle(m_device) );
 					releaseSwapchainFramebuffer();
 					releaseSwapchain();
+					
+					uint32_t presentModeIdx = numPresentModes;
+					VkPresentModeKHR preferredPresentMode[] = {
+						VK_PRESENT_MODE_FIFO_KHR,
+						VK_PRESENT_MODE_FIFO_RELAXED_KHR,
+						VK_PRESENT_MODE_MAILBOX_KHR,
+						VK_PRESENT_MODE_IMMEDIATE_KHR,
+					};
+					bool has_vsync[] = { true, true, true, false };
+					bool vsync = (flags & BGFX_RESET_VSYNC ? true : false);
+
+					for (uint32_t ii = 0; ii < BX_COUNTOF(preferredPresentMode); ++ii)
+					{
+						for (uint32_t jj = 0; jj < numPresentModes; ++jj)
+						{
+							if ((presentModes[jj] == preferredPresentMode[ii]) && (vsync == has_vsync[ii]))
+							{
+								presentModeIdx = jj;
+								BX_TRACE("present mode: %d", (int)preferredPresentMode[ii]);
+								break;
+							}
+						}
+						if (presentModeIdx < numPresentModes)
+						{
+							break;
+						}
+					}
+					if (presentModeIdx == numPresentModes)
+					{
+						presentModeIdx = 0;
+					}
+					m_sci.presentMode = presentModes[presentModeIdx];
 
 					VkSurfaceCapabilitiesKHR surfaceCapabilities;
 					VK_CHECK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_physicalDevice, m_surface, &surfaceCapabilities) );


### PR DESCRIPTION
This change lets the Vulkan backend support the BGFX_RESET_VSYNC flag so that vsync can be disabled.  This is important for MAME as many emulated systems don't sync at 60.0 Hz and forcing them to do so causes weird behavior.

The original patch is by @couriersud but due to real-life syndrome I'm handling the pull request for him.