### PR TITLE
fix crash on osx Catalina 10.15.1

### DIFF
--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -428,7 +428,7 @@ namespace bgfx { namespace mtl
 
 		void setFrontFacing(MTLWinding _frontFacing)
 		{
-			[m_obj setFrontFacing:_frontFacing];
+			[m_obj setFrontFacingWinding:_frontFacing];
 		}
 
 		void setCullMode(MTLCullMode _cullMode)


### PR DESCRIPTION
fix crash on osx Catalina 10.15.1 cause setFrontFacing was renamed to setFrontFacingWinding