### PR TITLE
Use MTLRenderCommandEncoder setFrontFacingWinding instead of setFrontFacing

### DIFF
--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -426,11 +426,6 @@ namespace bgfx { namespace mtl
 			[m_obj setBlendColorRed:_red green:_green blue:_blue alpha:_alpha];
 		}
 
-		void setFrontFacing(MTLWinding _frontFacing)
-		{
-			[m_obj setFrontFacing:_frontFacing];
-		}
-
 		void setCullMode(MTLCullMode _cullMode)
 		{
 			[m_obj setCullMode:_cullMode];

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -4232,7 +4232,7 @@ namespace bgfx { namespace mtl
 				{
 					if (BGFX_STATE_FRONT_CCW & changedFlags)
 					{
-						rce.setFrontFacing((newFlags&BGFX_STATE_FRONT_CCW) ? MTLWindingCounterClockwise : MTLWindingClockwise);
+						rce.setFrontFacingWinding((newFlags&BGFX_STATE_FRONT_CCW) ? MTLWindingCounterClockwise : MTLWindingClockwise);
 					}
 
 					if (BGFX_STATE_CULL_MASK & changedFlags)


### PR DESCRIPTION
**The Problem:**

macOS 10.15 does not define the `MTLRenderCommandEncoder setFrontFacing` message.  This warning occurs when compiling:
```
==== Building bgfx-shared-lib (release64) ====
renderer_mtl.mm
In file included from ../../../src/renderer_mtl.mm:10:
../../../src/renderer_mtl.h:431:11: warning: instance method '-setFrontFacing:' not found
      (return type defaults to 'id') [-Wobjc-method-access]
                        [m_obj setFrontFacing:_frontFacing];
                               ^~~~~~~~~~~~~~
```

The examples crash with this error:
```
2019-11-02 20:33:51.954 examplesRelease[90366:433716] -[BronzeMtlRenderCmdEncoder setFrontFacing:]: unrecognized selector sent to instance 0x7ff53007f800
2019-11-02 20:33:51.955 examplesRelease[90366:433716] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[BronzeMtlRenderCmdEncoder setFrontFacing:]: unrecognized selector sent to instance 0x7ff53007f800'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff30472d63 __exceptionPreprocess + 250
	1   libobjc.A.dylib                     0x00007fff661c8bd4 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff304fd206 -[NSObject(NSObject) __retain_OA] + 0
	3   CoreFoundation                      0x00007fff3041951b ___forwarding___ + 1427
	4   CoreFoundation                      0x00007fff30418ef8 _CF_forwarding_prep_0 + 120
	5   examplesRelease                     0x0000000109ab7e2b _ZN4bgfx3mtl18RendererContextMtl6submitEPNS_5FrameERNS_9ClearQuadERNS_19TextVideoMemBlitterE + 3643
	6   examplesRelease                     0x0000000109a7f88d _ZN4bgfx7Context11renderFrameEi + 493
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

**Proposed Solution:**

I replaced `setFrontFacing` with the next closest message `setFrontFacingWinding`. The examples run as expected with the change. Apple doesn't seem to document that this was changed, so I'm just taking a shot in the dark that this is correct. Let me know what you think. Thanks!