### PR TITLE
Update bgfx_compute.sh

### DIFF
--- a/src/bgfx_compute.sh
+++ b/src/bgfx_compute.sh
@@ -333,7 +333,7 @@ __IMAGE_IMPL_ATOMIC(r32ui,       x,    uvec4, xxxx)
 	, _numY               \
 	, _numZ               \
 	)                     \
-	_buffer[_offset*2+0] = uvec4(_numX, _numY, _numZ, 0u)
+	_buffer[(_offset)*2+0] = uvec4(_numX, _numY, _numZ, 0u)
 
 #define drawIndirect( \
 	  _buffer         \
@@ -343,7 +343,7 @@ __IMAGE_IMPL_ATOMIC(r32ui,       x,    uvec4, xxxx)
 	, _startVertex    \
 	, _startInstance  \
 	)                 \
-	_buffer[_offset*2+0] = uvec4(_numVertices, _numInstances, _startVertex, _startInstance)
+	_buffer[(_offset)*2+0] = uvec4(_numVertices, _numInstances, _startVertex, _startInstance)
 
 #define drawIndexedIndirect( \
 	  _buffer                \
@@ -354,8 +354,8 @@ __IMAGE_IMPL_ATOMIC(r32ui,       x,    uvec4, xxxx)
 	, _startVertex           \
 	, _startInstance         \
 	)                        \
-	_buffer[_offset*2+0] = uvec4(_numIndices, _numInstances, _startIndex, _startVertex); \
-	_buffer[_offset*2+1] = uvec4(_startInstance, 0u, 0u, 0u)
+	_buffer[(_offset)*2+0] = uvec4(_numIndices, _numInstances, _startIndex, _startVertex); \
+	_buffer[(_offset)*2+1] = uvec4(_startInstance, 0u, 0u, 0u)
 
 #endif // __cplusplus
 


### PR DESCRIPTION
fix the indirect define declarations

this works
```
    const uint offset = indirect_offset + 1;
    drawIndexedIndirect(indirectBuffer, offset, numIndices, numInstances, startVertex, startIndex, startInstance);
```
but this has silent error
```
    drawIndexedIndirect(indirectBuffer, indirect_offset + 1, numIndices, numInstances, startVertex, startIndex, startInstance);
```
thr reason is in the define declaration
```
    _buffer[_offset*2+0] = uvec4(_numIndices, _numInstances, _startIndex, _startVertex); \
    _buffer[_offset*2+1] = uvec4(_startInstance, 0u, 0u, 0u)
```
it becomes _buffer[indirect_offset + 1 * 2 + 1] !
this should fix
```
     _buffer[(_offset)*2+0] = uvec4(_numIndices, _numInstances, _startIndex, _startVertex); \
    _buffer[(_offset)*2+1] = uvec4(_startInstance, 0u, 0u, 0u)
```
should be done for the other _buffer dispatches