### PR TITLE
fix uninitialized read

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1209,6 +1209,7 @@ namespace bgfx
 		UniformBuffer* uniformBuffer = m_frame->m_uniformBuffer[m_uniformIdx];
 		m_uniformEnd = uniformBuffer->getPos();
 
+		m_key.reset();
 		m_key.m_program = isValid(_program)
 			? _program
 			: ProgramHandle{0}


### PR DESCRIPTION
I was running valgrind on my own project and found an uninitialized read (`m_trans` in `SortKey`) in bgfx incidentally. It might affect `encodeDraw`.

Here is a minimum example. Valgrind reports uninitialized read in `radixSort`, which can be traced back to `m_trans`. Not quite sure if I call bgfx functions correctly. Please let me know.

```
int main()
{
    int width=800,height=600;

    glfwInit();
    glfwWindowHint(GLFW_CLIENT_API,GLFW_NO_API);
    glfwWindowHint(GLFW_RESIZABLE,GLFW_FALSE);
    GLFWwindow* window=glfwCreateWindow(width,height,"test_proj",nullptr,nullptr);
    glfwSetKeyCallback(window,key_callback);

    bgfx::PlatformData pd;
    pd.ndt=glfwGetX11Display();
    pd.nwh=(void*)glfwGetX11Window(window);
    bgfx::setPlatformData(pd);

    bgfx::Init init;
    init.type=bgfx::RendererType::Vulkan;
    init.resolution.width=width;
    init.resolution.height=height;
    init.resolution.reset=BGFX_RESET_VSYNC;
    bgfx::renderFrame();
    bgfx::init(init);

    bgfx::setViewClear(0,BGFX_CLEAR_COLOR|BGFX_CLEAR_DEPTH,0x443355ff,1.0f,0);
    while(!glfwWindowShouldClose(window)){
        glfwPollEvents();
        bgfx::setViewRect(0,0,0,width,height);
        bgfx::touch(0);
        bgfx::frame();
    }

    glfwDestroyWindow(window);
    bgfx::shutdown();
    glfwTerminate();
    return 0;
}
```
Platform: Xubuntu 18.04 LTS
Compiler: g++ (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0
Valgrind: valgrind-3.13.0