### PR TITLE
add an assert to catch unknown opcodes earlier

### DIFF
--- a/src/shader_dxbc.cpp
+++ b/src/shader_dxbc.cpp
@@ -1065,6 +1065,8 @@ namespace bgfx
 		// +-------------------------------- extended
 
 		_instruction.opcode = DxbcOpcode::Enum( (token & UINT32_C(0x000007ff) )      );
+		BX_CHECK(_instruction.opcode < DxbcOpcode::Enum::Count, "unknown opcode");
+		
 		_instruction.length =          uint8_t( (token & UINT32_C(0x7f000000) ) >> 24);
 		bool extended       =              0 != (token & UINT32_C(0x80000000) );
 


### PR DESCRIPTION
I hit this while trying to do something goofy, trying to sample a cubemap with an offset... which is unsupported as per the HLSL docs. The shader actually compiled ok, but would blow up in this file.

I'd hit the assert down at shader_dxbc.cpp:2032. `BX_CHECK(size/4 == instruction.length, "read %d, expected %d", size/4, instruction.length); BX_UNUSED(size);` This change catches the bad state much sooner. Seems like a good idea to add this in-case the HLSL spec and what you handle in this file diverges.