### PR TITLE
Link shaderc to libdl

### DIFF
--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -652,6 +652,11 @@ project "shaderc"
 			"pthread",
 		}
 
+        configuration { "linux*" }
+                links {
+                        "dl",
+                }
+
 	configuration {}
 
 	if filesexist(BGFX_DIR, path.join(BGFX_DIR, "../bgfx-gnm"), {


### PR DESCRIPTION
Shaderc requires a link to libdl on linux, which is presently missing