### PR TITLE
Restored old behavior of handling shaders with "#version 430" in them

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5375,7 +5375,8 @@ namespace bgfx { namespace gl
 
 		if (0 != m_id)
 		{
-			if (GL_COMPUTE_SHADER != m_type)
+			if (GL_COMPUTE_SHADER != m_type
+			&&  0 != bx::strCmp(code, "#version 430", 12) ) // #2000
 			{
 				int32_t tempLen = code.getLength() + (4<<10);
 				char* temp = (char*)alloca(tempLen);
@@ -5873,7 +5874,7 @@ namespace bgfx { namespace gl
 
 				code.set(temp);
 			}
-			else // GL_COMPUTE_SHADER
+			else if (GL_COMPUTE_SHADER == m_type)
 			{
 				int32_t codeLen = (int32_t)bx::strLen(code);
 				int32_t tempLen = codeLen + (4<<10);


### PR DESCRIPTION
Fixes #2000.

I've applied reverse patch to Cluster's older revision of bgfx and it stopped working (at least on Linux/GLSL/GLX) while logging the following error:

```
[23:02:35][critical] Failed to compile shader.
```

My application logs the same error (through `bgfx::CallbackI`) on newer/current bgfx, so i'm fairly sure this PR is fixing regression of some sorts.

It basically restores branching on shaders with `#version 430` to pre- 0c90be6 version without changing anything else. I've also checked that 41-tess works with this patch.