### PR TITLE
More capacity needed in wds array to avoid all overruns.

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3652,7 +3652,7 @@ VK_IMPORT_DEVICE
 			VkDescriptorImageInfo imageInfo[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
 			VkDescriptorBufferInfo bufferInfo[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
 			VkWriteDescriptorSet wds[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS+2];
-			bx::memSet(wds, 0, sizeof(VkWriteDescriptorSet) * BGFX_CONFIG_MAX_TEXTURE_SAMPLERS+2);
+			bx::memSet(wds, 0, sizeof(VkWriteDescriptorSet) * (BGFX_CONFIG_MAX_TEXTURE_SAMPLERS+2));
 			uint32_t wdsCount    = 0;
 			uint32_t bufferCount = 0;
 			uint32_t imageCount  = 0;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3651,8 +3651,8 @@ VK_IMPORT_DEVICE
 
 			VkDescriptorImageInfo imageInfo[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
 			VkDescriptorBufferInfo bufferInfo[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
-			VkWriteDescriptorSet wds[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
-			bx::memSet(wds, 0, sizeof(VkWriteDescriptorSet) * BGFX_CONFIG_MAX_TEXTURE_SAMPLERS);
+			VkWriteDescriptorSet wds[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS+2];
+			bx::memSet(wds, 0, sizeof(VkWriteDescriptorSet) * BGFX_CONFIG_MAX_TEXTURE_SAMPLERS+2);
 			uint32_t wdsCount    = 0;
 			uint32_t bufferCount = 0;
 			uint32_t imageCount  = 0;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3635,6 +3635,8 @@ VK_IMPORT_DEVICE
 			return pipeline;
 		}
 
+#define MAX_DESCRIPTOR_SETS		(2*BGFX_CONFIG_MAX_TEXTURE_SAMPLERS+2)
+
 		void allocDescriptorSet(ProgramVK& program, const RenderBind& renderBind, ScratchBufferVK& scratchBuffer)
 		{
 			VkDescriptorSetLayout dsl = m_descriptorSetLayoutCache.find(program.m_descriptorSetLayoutHash);
@@ -3651,8 +3653,8 @@ VK_IMPORT_DEVICE
 
 			VkDescriptorImageInfo imageInfo[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
 			VkDescriptorBufferInfo bufferInfo[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
-			VkWriteDescriptorSet wds[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS+2];
-			bx::memSet(wds, 0, sizeof(VkWriteDescriptorSet) * (BGFX_CONFIG_MAX_TEXTURE_SAMPLERS+2));
+			VkWriteDescriptorSet wds[MAX_DESCRIPTOR_SETS];
+			bx::memSet(wds, 0, sizeof(wds));
 			uint32_t wdsCount    = 0;
 			uint32_t bufferCount = 0;
 			uint32_t imageCount  = 0;


### PR DESCRIPTION
The worst-case use of the descriptor set is larger than I first thought: 2 * nr-of-samplers + 2.

This patch adjusts that range, so no overflow of wds[] array is caused.
