### PR TITLE
Move more Mac UI-thread-only calls to main thread

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3019,24 +3019,30 @@ namespace bgfx { namespace mtl
 				}
 				else
 				{
-					NSView *contentView;
-
-					if ([nvh isKindOfClass:[NSView class]])
-					{
-						contentView = (NSView*)nvh;
-					}
-					else if ([nvh isKindOfClass:[NSWindow class]])
-					{
-						NSWindow* nsWindow = (NSWindow*)nvh;
-						contentView = [nsWindow contentView];
-					}
-					else
+					if (![nvh isKindOfClass:[NSView class]] &&
+					    ![nvh isKindOfClass:[NSWindow class]])
 					{
 						BX_WARN(0, "Unable to create Metal device. Please set platform data window to an NSWindow, NSView, or CAMetalLayer");
 						return;
 					}
 
 					void (^setLayer)(void) = ^{
+						NSView *contentView;
+
+						if ([nvh isKindOfClass:[NSView class]])
+						{
+							contentView = (NSView*)nvh;
+						}
+						else if ([nvh isKindOfClass:[NSWindow class]])
+						{
+							NSWindow* nsWindow = (NSWindow*)nvh;
+							contentView = [nsWindow contentView];
+						}
+						else
+						{
+							BX_CHECK(0, "Should never have gotten here.");
+						}
+
 						CALayer* layer = contentView.layer;
 						if(NULL != layer && [layer isKindOfClass:NSClassFromString(@"CAMetalLayer")])
 						{


### PR DESCRIPTION
This is sort of a follow-on from #2001:

- `[nsWindow contentView]` must be called on main thread as well
- all the similar code in `glcontext_nsgl.mm` must have the same treatment

However, all of this (and #2001) introduces a new problem; if `bgfx::frame` is called on the main thread, then if this code is ever hit it will cause a deadlock (because frame will wait for renderFrame to complete, and renderFrame will hit this code which wants to execute on the main thread).

I would actually suggest that we ditch all of this and just restrict what can be passed as `nwh`, and stop allowing it to be a NSView/NSWindow:
- For `GlContext`, require that `nwh` is a ` NSOpenGLView*`, and that `context` is a `NSOpenGLCOntext*`.
- For Metal, require that `nwh` is a `CAMetalLayer`.

The existing code could remain as static method helpers on glcontext_nsgl and/or renderer_mtl to ease transition.