### PR TITLE
rebind instance data buffer if index offset changes

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -7258,6 +7258,11 @@ namespace bgfx { namespace gl
 							diffIndexBuffer = true;
 						}
 
+						if (currentState.m_startIndex != draw.m_startIndex)
+						{
+							diffIndexBuffer = true;
+						}
+
 						if (0 != currentState.m_streamMask)
 						{
 							bool diffStartVertex = false;


### PR DESCRIPTION
Fix case of drawing different offsets of indices of same vertex buffer
using same instance data.

This can happen in the case of conditionally drawing subsets of vertex
buffer stored in different offsets of the same index buffer while re-using
non-transient instance buffers.

This is a follow-up to #1919 for a corner case of using different offsets of the same index buffers.