### PR TITLE
user parameter for screenshot request

### DIFF
--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -3862,9 +3862,10 @@ public static partial class bgfx
 	///
 	/// <param name="_handle">Frame buffer handle. If handle is `BGFX_INVALID_HANDLE` request will be made for main window back buffer.</param>
 	/// <param name="_filePath">Will be passed to `bgfx::CallbackI::screenShot` callback.</param>
+	/// <param name="_userData">User defined data if needed.</param>
 	///
 	[DllImport(DllName, EntryPoint="bgfx_request_screen_shot", CallingConvention = CallingConvention.Cdecl)]
-	public static extern unsafe void request_screen_shot(FrameBufferHandle _handle, [MarshalAs(UnmanagedType.LPStr)] string _filePath);
+	public static extern unsafe void request_screen_shot(FrameBufferHandle _handle, [MarshalAs(UnmanagedType.LPStr)] string _filePath, void* _userData);
 	
 	/// <summary>
 	/// Render frame.

--- a/bindings/d/funcs.d
+++ b/bindings/d/funcs.d
@@ -1613,8 +1613,9 @@ version(BindBgfx_Static)
 	 * _handle = Frame buffer handle. If handle is `BGFX_INVALID_HANDLE` request will be
 	 * made for main window back buffer.
 	 * _filePath = Will be passed to `bgfx::CallbackI::screenShot` callback.
+	 * _userData = User defined data if needed.
 	 */
-	void bgfx_request_screen_shot(bgfx_frame_buffer_handle_t _handle, const(char)* _filePath);
+	void bgfx_request_screen_shot(bgfx_frame_buffer_handle_t _handle, const(char)* _filePath, void* _userData);
 	
 	/**
 	 * Render frame.
@@ -3811,8 +3812,9 @@ else
 		 * _handle = Frame buffer handle. If handle is `BGFX_INVALID_HANDLE` request will be
 		 * made for main window back buffer.
 		 * _filePath = Will be passed to `bgfx::CallbackI::screenShot` callback.
+		 * _userData = User defined data if needed.
 		 */
-		alias da_bgfx_request_screen_shot = void function(bgfx_frame_buffer_handle_t _handle, const(char)* _filePath);
+		alias da_bgfx_request_screen_shot = void function(bgfx_frame_buffer_handle_t _handle, const(char)* _filePath, void* _userData);
 		da_bgfx_request_screen_shot bgfx_request_screen_shot;
 		
 		/**

--- a/examples/07-callback/callback.cpp
+++ b/examples/07-callback/callback.cpp
@@ -184,7 +184,7 @@ struct BgfxCallback : public bgfx::CallbackI
 		}
 	}
 
-	virtual void screenShot(const char* _filePath, uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _data, uint32_t /*_size*/, bool _yflip) override
+	virtual void screenShot(const char* _filePath, uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _data, uint32_t /*_size*/, bool _yflip, void* /*_userData*/) override
 	{
 		char temp[1024];
 

--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -549,6 +549,7 @@ namespace bgfx
 		/// @param[in] _data Image data.
 		/// @param[in] _size Image size.
 		/// @param[in] _yflip If true, image origin is bottom left.
+		/// @param[in] _userData user data 
 		///
 		/// @attention C99 equivalent is `bgfx_callback_vtbl.screen_shot`.
 		///
@@ -560,6 +561,7 @@ namespace bgfx
 			, const void* _data
 			, uint32_t _size
 			, bool _yflip
+			, void* _userData
 			) = 0;
 
 		/// Called when a video capture begins.
@@ -4067,6 +4069,7 @@ namespace bgfx
 	/// @param[in] _handle Frame buffer handle. If handle is `BGFX_INVALID_HANDLE` request will be
 	///   made for main window back buffer.
 	/// @param[in] _filePath Will be passed to `bgfx::CallbackI::screenShot` callback.
+	/// @param[in] _userData Will be passed to `bgfx::CallbackI::screenShot` callback.
 	///
 	/// @remarks
 	///   `bgfx::CallbackI::screenShot` must be implemented.
@@ -4077,6 +4080,7 @@ namespace bgfx
 	void requestScreenShot(
 		  FrameBufferHandle _handle
 		, const char* _filePath
+		, void* _userData = NULL
 		);
 
 } // namespace bgfx

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -432,7 +432,7 @@ typedef struct bgfx_callback_vtbl_s
     uint32_t (*cache_read_size)(bgfx_callback_interface_t* _this, uint64_t _id);
     bool (*cache_read)(bgfx_callback_interface_t* _this, uint64_t _id, void* _data, uint32_t _size);
     void (*cache_write)(bgfx_callback_interface_t* _this, uint64_t _id, const void* _data, uint32_t _size);
-    void (*screen_shot)(bgfx_callback_interface_t* _this, const char* _filePath, uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _data, uint32_t _size, bool _yflip);
+    void (*screen_shot)(bgfx_callback_interface_t* _this, const char* _filePath, uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _data, uint32_t _size, bool _yflip, void* _userData);
     void (*capture_begin)(bgfx_callback_interface_t* _this, uint32_t _width, uint32_t _height, uint32_t _pitch, bgfx_texture_format_t _format, bool _yflip);
     void (*capture_end)(bgfx_callback_interface_t* _this);
     void (*capture_frame)(bgfx_callback_interface_t* _this, const void* _data, uint32_t _size);
@@ -2714,9 +2714,10 @@ BGFX_C_API void bgfx_encoder_blit(bgfx_encoder_t* _this, bgfx_view_id_t _id, bgf
  * @param[in] _handle Frame buffer handle. If handle is `BGFX_INVALID_HANDLE` request will be
  *  made for main window back buffer.
  * @param[in] _filePath Will be passed to `bgfx::CallbackI::screenShot` callback.
+ * @param[in] _userData User defined data if needed.
  *
  */
-BGFX_C_API void bgfx_request_screen_shot(bgfx_frame_buffer_handle_t _handle, const char* _filePath);
+BGFX_C_API void bgfx_request_screen_shot(bgfx_frame_buffer_handle_t _handle, const char* _filePath, void* _userData);
 
 /**
  * Render frame.
@@ -3560,7 +3561,7 @@ struct bgfx_interface_vtbl
     void (*encoder_dispatch_indirect)(bgfx_encoder_t* _this, bgfx_view_id_t _id, bgfx_program_handle_t _program, bgfx_indirect_buffer_handle_t _indirectHandle, uint16_t _start, uint16_t _num);
     void (*encoder_discard)(bgfx_encoder_t* _this, uint8_t _flags);
     void (*encoder_blit)(bgfx_encoder_t* _this, bgfx_view_id_t _id, bgfx_texture_handle_t _dst, uint8_t _dstMip, uint16_t _dstX, uint16_t _dstY, uint16_t _dstZ, bgfx_texture_handle_t _src, uint8_t _srcMip, uint16_t _srcX, uint16_t _srcY, uint16_t _srcZ, uint16_t _width, uint16_t _height, uint16_t _depth);
-    void (*request_screen_shot)(bgfx_frame_buffer_handle_t _handle, const char* _filePath);
+    void (*request_screen_shot)(bgfx_frame_buffer_handle_t _handle, const char* _filePath, void* _userData);
     bgfx_render_frame_t (*render_frame)(int32_t _msecs);
     void (*set_platform_data)(const bgfx_platform_data_t * _data);
     const bgfx_internal_data_t* (*get_internal_data)(void);

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -2521,6 +2521,7 @@ func.requestScreenShot
 	.handle   "FrameBufferHandle" --- Frame buffer handle. If handle is `BGFX_INVALID_HANDLE` request will be
 	                              --- made for main window back buffer.
 	.filePath "const char*"       --- Will be passed to `bgfx::CallbackI::screenShot` callback.
+	.userData "void*"             --- User defined data if needed.
 
 --- Render frame.
 ---

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -121,7 +121,7 @@ namespace bgfx
 		{
 		}
 
-		virtual void screenShot(const char* _filePath, uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _data, uint32_t _size, bool _yflip) override
+		virtual void screenShot(const char* _filePath, uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _data, uint32_t _size, bool _yflip, void* /*_userData*/) override
 		{
 			BX_UNUSED(_filePath, _width, _height, _pitch, _data, _size, _yflip);
 
@@ -3158,7 +3158,10 @@ namespace bgfx
 
 					const char* filePath = (const char*)_cmdbuf.skip(len);
 
-					m_renderCtx->requestScreenShot(handle, filePath);
+					void* userData;
+					_cmdbuf.read(userData);
+
+					m_renderCtx->requestScreenShot(handle, filePath, userData);
 				}
 				break;
 
@@ -5009,10 +5012,10 @@ namespace bgfx
 		s_ctx->m_encoder0->blit(_id, _dst, _dstMip, _dstX, _dstY, _dstZ, _src, _srcMip, _srcX, _srcY, _srcZ, _width, _height, _depth);
 	}
 
-	void requestScreenShot(FrameBufferHandle _handle, const char* _filePath)
+	void requestScreenShot(FrameBufferHandle _handle, const char* _filePath, void* _userData)
 	{
 		BGFX_CHECK_API_THREAD();
-		s_ctx->requestScreenShot(_handle, _filePath);
+		s_ctx->requestScreenShot(_handle, _filePath, _userData);
 	}
 } // namespace bgfx
 
@@ -5290,9 +5293,9 @@ namespace bgfx
 			m_interface->vtbl->cache_write(m_interface, _id, _data, _size);
 		}
 
-		virtual void screenShot(const char* _filePath, uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _data, uint32_t _size, bool _yflip) override
+		virtual void screenShot(const char* _filePath, uint32_t _width, uint32_t _height, uint32_t _pitch, const void* _data, uint32_t _size, bool _yflip, void* _userData) override
 		{
-			m_interface->vtbl->screen_shot(m_interface, _filePath, _width, _height, _pitch, _data, _size, _yflip);
+			m_interface->vtbl->screen_shot(m_interface, _filePath, _width, _height, _pitch, _data, _size, _yflip, _userData);
 		}
 
 		virtual void captureBegin(uint32_t _width, uint32_t _height, uint32_t _pitch, TextureFormat::Enum _format, bool _yflip) override

--- a/src/bgfx.idl.inl
+++ b/src/bgfx.idl.inl
@@ -926,10 +926,10 @@ BGFX_C_API void bgfx_encoder_blit(bgfx_encoder_t* _this, bgfx_view_id_t _id, bgf
 	This->blit((bgfx::ViewId)_id, dst.cpp, _dstMip, _dstX, _dstY, _dstZ, src.cpp, _srcMip, _srcX, _srcY, _srcZ, _width, _height, _depth);
 }
 
-BGFX_C_API void bgfx_request_screen_shot(bgfx_frame_buffer_handle_t _handle, const char* _filePath)
+BGFX_C_API void bgfx_request_screen_shot(bgfx_frame_buffer_handle_t _handle, const char* _filePath, void* _userData)
 {
 	union { bgfx_frame_buffer_handle_t c; bgfx::FrameBufferHandle cpp; } handle = { _handle };
-	bgfx::requestScreenShot(handle.cpp, _filePath);
+	bgfx::requestScreenShot(handle.cpp, _filePath, _userData);
 }
 
 BGFX_C_API bgfx_render_frame_t bgfx_render_frame(int32_t _msecs)

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2816,7 +2816,7 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 		virtual void destroyFrameBuffer(FrameBufferHandle _handle) = 0;
 		virtual void createUniform(UniformHandle _handle, UniformType::Enum _type, uint16_t _num, const char* _name) = 0;
 		virtual void destroyUniform(UniformHandle _handle) = 0;
-		virtual void requestScreenShot(FrameBufferHandle _handle, const char* _filePath) = 0;
+		virtual void requestScreenShot(FrameBufferHandle _handle, const char* _filePath, void* _userData) = 0;
 		virtual void updateViewName(ViewId _id, const char* _name) = 0;
 		virtual void updateUniform(uint16_t _loc, const void* _data, uint32_t _size) = 0;
 		virtual void invalidateOcclusionQuery(OcclusionQueryHandle _handle) = 0;
@@ -4666,7 +4666,7 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 			m_freeOcclusionQueryHandle[m_numFreeOcclusionQueryHandles++] = _handle;
 		}
 
-		BGFX_API_FUNC(void requestScreenShot(FrameBufferHandle _handle, const char* _filePath) )
+		BGFX_API_FUNC(void requestScreenShot(FrameBufferHandle _handle, const char* _filePath, void* _userData) )
 		{
 			BGFX_MUTEX_SCOPE(m_resourceApiLock);
 
@@ -4687,6 +4687,7 @@ constexpr uint64_t kSortKeyComputeProgramMask  = uint64_t(BGFX_CONFIG_MAX_PROGRA
 			cmdbuf.write(_handle);
 			cmdbuf.write(len);
 			cmdbuf.write(_filePath, len);
+			cmdbuf.write(_userData);
 		}
 
 		BGFX_API_FUNC(void setPaletteColor(uint8_t _index, const float _rgba[4]) )

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1917,7 +1917,7 @@ namespace bgfx { namespace d3d11
 			m_uniformReg.remove(_handle);
 		}
 
-		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath) override
+		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath, void* _userData) override
 		{
 			IDXGISwapChain* swapChain = isValid(_handle)
 				? m_frameBuffers[_handle.idx].m_swapChain
@@ -1983,6 +1983,7 @@ namespace bgfx { namespace d3d11
 					, mapped.pData
 					, backBufferDesc.Height*mapped.RowPitch
 					, false
+					, _userData
 					);
 				m_deviceCtx->Unmap(texture, 0);
 

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1799,7 +1799,7 @@ namespace bgfx { namespace d3d12
 			m_uniformReg.remove(_handle);
 		}
 
-		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath) override
+		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath, void* _userData) override
 		{
 			BX_UNUSED(_handle);
 
@@ -1861,6 +1861,7 @@ namespace bgfx { namespace d3d12
 				, data
 				, (uint32_t)total
 				, false
+				, _userData
 				);
 			readback->Unmap(0, NULL);
 

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1227,7 +1227,7 @@ namespace bgfx { namespace d3d9
 			m_uniformReg.remove(_handle);
 		}
 
-		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath) override
+		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath, void* _userData) override
 		{
 			IDirect3DSwapChain9* swapChain = isValid(_handle)
 				? m_frameBuffers[_handle.idx].m_swapChain
@@ -1288,6 +1288,7 @@ namespace bgfx { namespace d3d9
 				, &data[point.y*rect.Pitch+point.x*bytesPerPixel]
 				, params.BackBufferHeight*rect.Pitch
 				, false
+				, _userData
 				);
 
 			DX_CHECK(surface->UnlockRect() );

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2965,7 +2965,7 @@ namespace bgfx { namespace gl
 			m_uniformReg.remove(_handle);
 		}
 
-		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath) override
+		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath, void* _userData) override
 		{
 			SwapChainGL* swapChain = NULL;
 			uint32_t width  = m_resolution.width;
@@ -3005,6 +3005,7 @@ namespace bgfx { namespace gl
 				, data
 				, length
 				, true
+				, _userData
 				);
 			BX_FREE(g_allocator, data);
 		}

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -981,7 +981,7 @@ namespace bgfx { namespace mtl
 			m_saveScreenshot = true;
 		}
 
-		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath) override
+		void requestScreenShot(FrameBufferHandle _handle, const char* _filePath, void* _userData) override
 		{
 			BX_UNUSED(_handle);
 

--- a/src/renderer_noop.cpp
+++ b/src/renderer_noop.cpp
@@ -214,7 +214,7 @@ namespace bgfx { namespace noop
 		{
 		}
 
-		void requestScreenShot(FrameBufferHandle /*_handle*/, const char* /*_filePath*/) override
+		void requestScreenShot(FrameBufferHandle /*_handle*/, const char* /*_filePath*/, void* /*_userData*/) override
 		{
 		}
 

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2483,7 +2483,7 @@ VK_IMPORT_DEVICE
 			m_uniforms[_handle.idx] = NULL;
 		}
 
-		void requestScreenShot(FrameBufferHandle /*_handle*/, const char* /*_filePath*/) override
+		void requestScreenShot(FrameBufferHandle /*_handle*/, const char* /*_filePath*/, void* /*_userData*/) override
 		{
 		}
 


### PR DESCRIPTION
I was not able to have the _userData parameter in the callback method here:
https://github.com/bkaradzic/bgfx/compare/master...CedricGuillemet:userParamRequestScreenShot?expand=1#diff-e342145dff78090198294f9fc149968cR435
Do you know why?
