### PR TITLE
CSharp bindings: move DllName definition to other, optional file

### DIFF
--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -4368,13 +4368,5 @@ public static partial class bgfx
 	[DllImport(DllName, EntryPoint="bgfx_blit", CallingConvention = CallingConvention.Cdecl)]
 	public static extern unsafe void blit(ushort _id, TextureHandle _dst, byte _dstMip, ushort _dstX, ushort _dstY, ushort _dstZ, TextureHandle _src, byte _srcMip, ushort _srcX, ushort _srcY, ushort _srcZ, ushort _width, ushort _height, ushort _depth);
 	
-
-#if !BGFX_CSHARP_CUSTOM_DLLNAME
-#if DEBUG
-	const string DllName = "bgfx_debug.dll";
-#else
-	const string DllName = "bgfx.dll";
-#endif
-#endif
 }
 }

--- a/bindings/cs/bgfx_dllname.cs
+++ b/bindings/cs/bgfx_dllname.cs
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2011-2020 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx/blob/master/LICENSE
+ */
+
+/*
+ *
+ * AUTO GENERATED! DO NOT EDIT!
+ *
+ * Include this file in your build if you want to use the default DllImport
+ * names of bgfx.dll and bgfx_debug.dll.  Otherwise, define your own
+ * partial class like the below with a const DllName for your use.
+ *
+ */
+
+namespace Bgfx
+{
+public static partial class bgfx
+{
+#if DEBUG
+       const string DllName = "bgfx_debug.dll";
+#else
+       const string DllName = "bgfx.dll";
+#endif
+}
+}

--- a/scripts/bindings-cs.lua
+++ b/scripts/bindings-cs.lua
@@ -23,13 +23,34 @@ public static partial class bgfx
 	$types
 
 	$funcs
+}
+}
+]]
 
-#if !BGFX_CSHARP_CUSTOM_DLLNAME
+local csharp_dllname_template = [[
+/*
+ * Copyright 2011-2020 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx/blob/master/LICENSE
+ */
+
+/*
+ *
+ * AUTO GENERATED! DO NOT EDIT!
+ *
+ * Include this file in your build if you want to use the default DllImport
+ * names of bgfx.dll and bgfx_debug.dll.  Otherwise, define your own
+ * partial class like the below with a const DllName for your use.
+ *
+ */
+
+namespace Bgfx
+{
+public static partial class bgfx
+{
 #if DEBUG
-	const string DllName = "bgfx_debug.dll";
+       const string DllName = "bgfx_debug.dll";
 #else
-	const string DllName = "bgfx.dll";
-#endif
+       const string DllName = "bgfx.dll";
 #endif
 }
 }
@@ -136,6 +157,10 @@ function gen.gen()
 		return table.concat(tmp, "\n\t")
 	end)
 	return r
+end
+
+function gen.gen_dllname()
+	return csharp_dllname_template
 end
 
 local combined = { "State", "Stencil", "Buffer", "Texture", "Sampler", "Reset" }

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -69,6 +69,7 @@ newaction {
 		do
 			local csgen = require "bindings-cs"
 			csgen.write(csgen.gen(), "../bindings/cs/bgfx.cs")
+			csgen.write(csgen.gen_dllname(), "../bindings/cs/bgfx_dllname.cs")
 			
 			local dgen = require "bindings-d"
 			dgen.write(dgen.gen_types(), "../bindings/d/types.d")


### PR DESCRIPTION
This avoids the hacky `BGFX_CSHARP_CUSTOM_DLLNAME` thing that didn't actually ever work properly, and gives people the ability to use the cs file directly as-is even with a custom DllName (by just providing their own second file).