### PR TITLE
Added description labels to 08-update

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4498,7 +4498,12 @@ namespace bgfx { namespace d3d11
 		const uint32_t subres = _mip + ( (layer + _side) * m_numMips);
 		const bool     depth  = bimg::isDepth(bimg::TextureFormat::Enum(m_textureFormat) );
 		const uint32_t bpp    = bimg::getBitsPerPixel(bimg::TextureFormat::Enum(m_textureFormat) );
-		const uint32_t rectpitch  = _rect.m_width*bpp/8;
+		uint32_t rectpitch  = _rect.m_width*bpp/8;
+		if (bimg::isCompressed(bimg::TextureFormat::Enum(m_textureFormat)))
+		{
+			const bimg::ImageBlockInfo& blockInfo = bimg::getBlockInfo(bimg::TextureFormat::Enum(m_textureFormat));
+			rectpitch = (_rect.m_width / blockInfo.blockWidth)*blockInfo.blockSize;
+		}
 		const uint32_t srcpitch   = UINT16_MAX == _pitch ? rectpitch : _pitch;
 		const uint32_t slicepitch = rectpitch*_rect.m_height;
 


### PR DESCRIPTION
Description labels overlap geometry to save space, but can be toggled on/off to see textures only. 

Added row of cubes whose compressed texture is created with empty content then updated using bgfx::updateTexture2D.

Fixed default srcPitch in d3d11 renderer for compressed textures. I think for 3d compressed textures slicepitch needs modification too, but as I wasn't be able test I haven't modified it.

I have tested on d3d11 and d3d9 and it works. I will test it on metal and (hopefully) fix issues. (https://github.com/bkaradzic/bgfx/issues/2004)

Edited:
I couldn't figure out how to upload mips that have smaller then block size dimensions on D3D11. 

Edited2:
I have added second commit with fix for metal renderer.

