### PR TITLE
Reenable MSAA for Metal

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -640,7 +640,7 @@ namespace bgfx { namespace mtl
 
 			for (uint32_t ii = 1, last = 0; ii < BX_COUNTOF(s_msaa); ++ii)
 			{
-				const int32_t sampleCount = 1; //1<<ii;
+				const int32_t sampleCount = 1<<ii;
 				if (m_device.supportsTextureSampleCount(sampleCount) )
 				{
 					s_msaa[ii] = sampleCount;


### PR DESCRIPTION
I am not sure why this code was commented, but it took me a while to understand why MSAA is not working for Metal (sample count is set to 1 for all MSAA settings). I reenabled it and it works.