### PR TITLE
Add support for autogenerated mipmap

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1689,7 +1689,7 @@ namespace bgfx { namespace gl
 		const uint32_t min = (_flags&BGFX_SAMPLER_MIN_MASK)>>BGFX_SAMPLER_MIN_SHIFT;
 		const uint32_t mip = (_flags&BGFX_SAMPLER_MIP_MASK)>>BGFX_SAMPLER_MIP_SHIFT;
 		_magFilter = s_textureFilterMag[mag];
-		_minFilter = s_textureFilterMin[min][_hasMips ? mip+1 : 0];
+		_minFilter = s_textureFilterMin[min][_hasMips ? mip+1 : mip];
 	}
 
 	void updateExtension(const bx::StringView& _name)


### PR DESCRIPTION
By patching this line, we actually have this scenario:

mip = 0 -> no mip flag set
mip = 1 -> mip flag set to BGFX_SAMPLER_MIP_POINT
mip = 2 -> mip flag set and texture has mipmaps

This should allow OpenGL renderer to support mipmap autogeneration