### PR TITLE
Implement the overrideInternal in D3D12 renderer

### DIFF
--- a/src/renderer_d3d12.h
+++ b/src/renderer_d3d12.h
@@ -331,6 +331,7 @@ namespace bgfx { namespace d3d12
 
 		void* create(const Memory* _mem, uint64_t _flags, uint8_t _skip);
 		void destroy();
+		void overrideInternal(uintptr_t _ptr);
 		void update(ID3D12GraphicsCommandList* _commandList, uint8_t _side, uint8_t _mip, const Rect& _rect, uint16_t _z, uint16_t _depth, uint16_t _pitch, const Memory* _mem);
 		void resolve(uint8_t _resolve) const;
 		D3D12_RESOURCE_STATES setState(ID3D12GraphicsCommandList* _commandList, D3D12_RESOURCE_STATES _state);


### PR DESCRIPTION
Align to the overrideInternal in other renderers.