### PR TITLE
Add Valid property to handle types for C# bindings

### DIFF
--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -2157,29 +2157,65 @@ public static partial class bgfx
 	{
 	}
 	
-	public struct DynamicIndexBufferHandle{ public ushort idx; }
+	public struct DynamicIndexBufferHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct DynamicVertexBufferHandle{ public ushort idx; }
+	public struct DynamicVertexBufferHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct FrameBufferHandle{ public ushort idx; }
+	public struct FrameBufferHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct IndexBufferHandle{ public ushort idx; }
+	public struct IndexBufferHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct IndirectBufferHandle{ public ushort idx; }
+	public struct IndirectBufferHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct OcclusionQueryHandle{ public ushort idx; }
+	public struct OcclusionQueryHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct ProgramHandle{ public ushort idx; }
+	public struct ProgramHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct ShaderHandle{ public ushort idx; }
+	public struct ShaderHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct TextureHandle{ public ushort idx; }
+	public struct TextureHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct UniformHandle{ public ushort idx; }
+	public struct UniformHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct VertexBufferHandle{ public ushort idx; }
+	public struct VertexBufferHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
-	public struct VertexLayoutHandle{ public ushort idx; }
+	public struct VertexLayoutHandle {
+	    public ushort idx;
+	    public bool Valid => idx != UInt16.MaxValue;
+	}
 	
 
 	/// <summary>

--- a/scripts/bindings-cs.lua
+++ b/scripts/bindings-cs.lua
@@ -267,7 +267,10 @@ function converter.types(typ)
 	if typ.handle then
 		lastCombinedFlagBlock()
 
-		yield("public struct " .. typ.name .. "{ public ushort idx; }")
+		yield("public struct " .. typ.name .. " {")
+        yield("    public ushort idx;")
+        yield("    public bool Valid => idx != UInt16.MaxValue;")
+        yield("}")
 	elseif hasSuffix(typ.name, "::Enum") then
 		lastCombinedFlagBlock()
 


### PR DESCRIPTION
There's currently no good way to check if a handle is valid from the C# bindings.  This adds a `Valid` property.