### PR TITLE
Fix a couple framebuffer related bugs in D3D renderer

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4465,13 +4465,18 @@ namespace bgfx { namespace d3d11
 	void TextureD3D11::overrideInternal(uintptr_t _ptr)
 	{
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
-		m_srv->GetDesc(&srvDesc);
+		const bool readable = (m_srv != NULL);
+		if (readable) {
+			m_srv->GetDesc(&srvDesc);
+		}
 
 		destroy();
 		m_flags |= BGFX_SAMPLER_INTERNAL_SHARED;
 		m_ptr = (ID3D11Resource*)_ptr;
 
-		s_renderD3D11->m_device->CreateShaderResourceView(m_ptr, &srvDesc, &m_srv);
+		if (readable) {
+			s_renderD3D11->m_device->CreateShaderResourceView(m_ptr, &srvDesc, &m_srv);
+		}
 	}
 
 	void TextureD3D11::update(uint8_t _side, uint8_t _mip, const Rect& _rect, uint16_t _z, uint16_t _depth, uint16_t _pitch, const Memory* _mem)

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -2434,14 +2434,17 @@ namespace bgfx { namespace d3d12
 
 			if (!isValid(_fbh) )
 			{
-				m_rtvHandle = getCPUHandleHeapStart(m_rtvDescriptorHeap);
-				uint32_t rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
-				m_rtvHandle.ptr += m_backBufferColorIdx * rtvDescriptorSize;
-				m_dsvHandle = getCPUHandleHeapStart(m_dsvDescriptorHeap);
+				if (NULL != m_swapChain)
+				{
+					m_rtvHandle = getCPUHandleHeapStart(m_rtvDescriptorHeap);
+					uint32_t rtvDescriptorSize = m_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+					m_rtvHandle.ptr += m_backBufferColorIdx * rtvDescriptorSize;
+					m_dsvHandle = getCPUHandleHeapStart(m_dsvDescriptorHeap);
 
-				m_currentColor        = &m_rtvHandle;
-				m_currentDepthStencil = &m_dsvHandle;
-				m_commandList->OMSetRenderTargets(1, m_currentColor, true, m_currentDepthStencil);
+					m_currentColor        = &m_rtvHandle;
+					m_currentDepthStencil = &m_dsvHandle;
+					m_commandList->OMSetRenderTargets(1, m_currentColor, true, m_currentDepthStencil);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
1. A crash in D3D11 renderer when create a texture with flag BGFX_TEXTURE_RT_WRITE_ONLY then override it, bcause m_srv is NULL.
2. In headless mode, RendererContextD3D12::m_swapChain is NULL, clear it resulting a D3D12 debug error