### PR TITLE
Added X86 to platform to allow metal support on iOS Simulator

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -53,6 +53,7 @@
 #	ifndef BGFX_CONFIG_RENDERER_METAL
 #		define BGFX_CONFIG_RENDERER_METAL (0           \
 					|| (BX_PLATFORM_IOS && BX_CPU_ARM) \
+					|| (BX_PLATFORM_IOS && BX_CPU_X86) \
 					|| (BX_PLATFORM_OSX >= 101100)     \
 					? 1 : 0)
 #	endif // BGFX_CONFIG_RENDERER_METAL


### PR DESCRIPTION
Tested on Catalina only, don't see why it shouldn't work on other x86 versions of MacOS