### PR TITLE
Macro expansion for registers with shader profile <= 4

### DIFF
--- a/src/bgfx_shader.sh
+++ b/src/bgfx_shader.sh
@@ -50,11 +50,13 @@
 #	define bvec3 bool3
 #	define bvec4 bool4
 
+#	define CONCAT_(_a, _b) _a ## _b
+#	define CONCAT(_a, _b) CONCAT_(_a, _b)
 
 #	if BGFX_SHADER_LANGUAGE_HLSL > 4
 #		define REGISTER(_type, _reg) register(_type[_reg])
 #	else
-#		define REGISTER(_type, _reg) register(_type ## _reg)
+#		define REGISTER(_type, _reg) register(CONCAT(CONCAT(_type, 0), _reg))
 #	endif // BGFX_SHADER_LANGUAGE_HLSL
 
 #	if BGFX_SHADER_LANGUAGE_HLSL > 3 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL


### PR DESCRIPTION
This change correctly expands macros in resource definitions when compiling with HLSL shader profile 4_0 and below, including targetting SPIRV via glslang.

With shader profile 5/GLSL you could already do the following:
```c++
#define SAMPLER_COLOR 0
SAMPLER2D(s_texColor, SAMPLER_COLOR);
```

but with shader profile <= 4 it would concatenate the identifier, yielding something like `uniform SamplerState s_texColorSampler : register(sSAMPLER_COLOR)`.

The added CONCAT macro is the usual [token pasting with macro expansion](https://stackoverflow.com/questions/12630548/c-expand-macro-with-token-pasting) but the double CONCAT with 0 seems to be needed for fcpp to produce the correct result.

I've only fixed macro expansion for this specific case because it's the only place where I think it makes sense.