### PR TITLE
Fix Vulkan renderer crash when submitting without index buffer

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -6383,10 +6383,10 @@ VK_DESTROY
 					if (!isValid(draw.m_indexBuffer) )
 					{
 						const VertexBufferVK& vertexBuffer = m_vertexBuffers[draw.m_stream[0].m_handle.idx];
-						const VertexLayout& layout = m_vertexLayouts[draw.m_stream[0].m_layoutHandle.idx];
+						const VertexLayout* layout = layouts[0];
 
 						const uint32_t numVertices = UINT32_MAX == draw.m_numVertices
-							? vertexBuffer.m_size / layout.m_stride
+							? vertexBuffer.m_size / layout->m_stride
 							: draw.m_numVertices
 							;
 						vkCmdDraw(m_commandBuffer


### PR DESCRIPTION
When submitting a draw with just a vertex buffer and no index buffer, `RendererContextVK::submit` uses an unititialized vertex layout to calculate the number of vertices and crashes.