### PR TITLE
setMouseLock windows fix for  _lock = false case

### DIFF
--- a/examples/common/entry/entry_windows.cpp
+++ b/examples/common/entry/entry_windows.cpp
@@ -1023,7 +1023,9 @@ namespace entry
 
 		void setMouseLock(HWND _hwnd, bool _lock)
 		{
-			if (_hwnd != m_mouseLock)
+			HWND newMouseLock = _lock ? _hwnd : 0;
+
+			if (newMouseLock != m_mouseLock)
 			{
 				if (_lock)
 				{
@@ -1038,7 +1040,7 @@ namespace entry
 					ShowCursor(true);
 				}
 
-				m_mouseLock = _hwnd;
+				m_mouseLock = newMouseLock;
 			}
 		}
 


### PR DESCRIPTION
I assume that with setMouseLock I can enable/disable locking for the same window, but
when calling setMouseLock(window, true) then setMouseLock(window, false) the second call did nothing because of `if (_hwnd != m_mouseLock)` check at the beginning of the function.

Also m_mouseLock was never set back to zero for the false case. So the message processing function was stuck in lock mode.
https://github.com/bkaradzic/bgfx/blob/master/examples/common/entry/entry_windows.cpp#L769
