### PR TITLE
Fix #2071 again

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4104,7 +4104,7 @@ VK_IMPORT_DEVICE
 					);
 				}
 			}
-			while ((result == VK_ERROR_OUT_OF_HOST_MEMORY || result == VK_ERROR_OUT_OF_DEVICE_MEMORY) && searchIndex >= 0);
+			while (result != VK_SUCCESS && searchIndex >= 0);
 
 			return result;
 		}


### PR DESCRIPTION
Apparently `vkAllocateMemory` returns different errors if validation layers are on. Changed it to just checking if it succeeded or not before trying the next memory type.