### PR TITLE
Add support ARB_shader_viewport_layer_array

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -90,6 +90,16 @@ namespace bgfx
 		NULL
 	};
 
+	// To be use from vertex program require :
+	// https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_shader_viewport_layer_array.txt
+	// DX11 11_1 feature level
+	static const char* s_ARB_shader_viewport_layer_array[] =
+	{
+		"gl_ViewportIndex",
+		"gl_Layer",
+		NULL
+	};
+
 	static const char* s_ARB_gpu_shader5[] =
 	{
 		"bitfieldReverse",
@@ -1769,6 +1779,8 @@ namespace bgfx
 					{
 						const bool hasVertexId    = !bx::strFind(input, "gl_VertexID").isEmpty();
 						const bool hasInstanceId  = !bx::strFind(input, "gl_InstanceID").isEmpty();
+						const bool hasViewportId = !bx::strFind(input, "gl_ViewportIndex").isEmpty();
+						const bool hasLayerId = !bx::strFind(input, "gl_Layer").isEmpty();
 
 						bx::StringView brace = bx::strFind(bx::StringView(entry.getPtr(), shader.getTerm() ), "{");
 						if (!brace.isEmpty() )
@@ -1786,6 +1798,7 @@ namespace bgfx
 							"\tvec4 gl_Position : SV_POSITION;\n"
 							"#define gl_Position _varying_.gl_Position\n"
 							);
+
 						for (InOut::const_iterator it = shaderOutputs.begin(), itEnd = shaderOutputs.end(); it != itEnd; ++it)
 						{
 							VaryingMap::const_iterator varyingIt = varyingMap.find(*it);
@@ -1806,6 +1819,23 @@ namespace bgfx
 									);
 							}
 						}
+
+						if (hasLayerId)
+						{
+							if (d3d > 9)
+							{
+								preprocessor.writef(
+									"\tuint gl_Layer : SV_RenderTargetArrayIndex;\n"
+									"#define gl_Layer _varying_.gl_Layer\n"
+									);
+							}
+							else
+							{
+								bx::printf("gl_Layer builtin is not supported by this D3D9 HLSL.\n");
+								return false;
+							}
+						}
+
 						preprocessor.writef(
 							"};\n"
 							);
@@ -1970,13 +2000,14 @@ namespace bgfx
 									|| !bx::findIdentifierMatch(input, s_ARB_shader_texture_lod).isEmpty()
 									|| !bx::findIdentifierMatch(input, s_EXT_shader_texture_lod).isEmpty()
 									;
-								const bool usesInstanceID   = !bx::findIdentifierMatch(input, "gl_InstanceID").isEmpty();
+								const bool usesInstanceID   = !bx::findIdentifierMatch(input, "gl_InstanceID").isEmpty();								
 								const bool usesGpuShader4   = !bx::findIdentifierMatch(input, s_EXT_gpu_shader4).isEmpty();
 								const bool usesGpuShader5   = !bx::findIdentifierMatch(input, s_ARB_gpu_shader5).isEmpty();
 								const bool usesTexelFetch   = !bx::findIdentifierMatch(input, s_texelFetch).isEmpty();
 								const bool usesTextureMS    = !bx::findIdentifierMatch(input, s_ARB_texture_multisample).isEmpty();
 								const bool usesTextureArray = !bx::findIdentifierMatch(input, s_textureArray).isEmpty();
 								const bool usesPacking      = !bx::findIdentifierMatch(input, s_ARB_shading_language_packing).isEmpty();
+								const bool usesARB_shader_viewport_layer_array = !bx::findIdentifierMatch(input, s_ARB_shader_viewport_layer_array).isEmpty();
 
 								if (0 == essl)
 								{
@@ -2000,6 +2031,13 @@ namespace bgfx
 									{
 										bx::stringPrintf(code
 											, "#extension GL_ARB_draw_instanced : enable\n"
+											);
+									}
+
+									if (usesARB_shader_viewport_layer_array)
+									{
+										bx::stringPrintf(code
+											, "#extension GL_ARB_shader_viewport_layer_array : enable\n"
 											);
 									}
 


### PR DESCRIPTION
In order to achieve efficient stereo rendering for the hololens device we use draw instancing couple with the ability to select the render target output from the vertex program.

I add the support for gl_Layer varying (SV_RenderTargetArrayIndex DX11 equivalent) to shaderc, this
allow to select the target layer to render in from vertex shader output
- DX9 backend not supported (feature not available)

With this evolution it's now possible to modify the render target from vertex shader with the DX11 backend:

uniform mat4 u_viewProjStereo[2];
void main()
{
	vec4 worldPos = mul(u_model[0], vec4(a_position, 1.0));
	gl_Position = mul(u_viewProjStereo[gl_InstanceID], worldPos);
	gl_Layer = gl_InstanceID;
}


