### PR TITLE
document color order

### DIFF
--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -83,7 +83,9 @@ namespace bgfx
 		};
 	};
 
-	/// Vertex attribute enum.
+	/// Vertex attribute enum. 
+	///
+	/// Colors are ordered ABGR.
 	///
 	/// @attention C99 equivalent is `bgfx_attrib_t`.
 	///


### PR DESCRIPTION
This is also documented some in the cubes example, with the color member being named m_abgr. Coming from a codebase that's ARGB this was fun to track down.