### PR TITLE
shader read optimization

### DIFF
--- a/tools/shaderc/shaderc.h
+++ b/tools/shaderc/shaderc.h
@@ -87,7 +87,7 @@ namespace bgfx
 
 			uint32_t pos = m_pos;
 			const char* str = &m_str[pos];
-			const char* nl = bx::strFindNl(str).getPtr();
+			const char* nl = bx::strFindNl(bx::StringView(str, str + (m_size - pos))).getPtr();
 			pos += (uint32_t)(nl - str);
 
 			const char* eol = &m_str[pos];


### PR DESCRIPTION
Currently `const char * str` gets converted to a StringView when its passed to `bx::strFindNl`, incurring a strlen. We have the data to calculate the strlen and fully construct the StringView.