### PR TITLE
Fix Vulkan texture update/upload

### DIFF
--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -514,7 +514,8 @@ VK_DESTROY
 	struct TextureVK
 	{
 		TextureVK()
-			: m_vkTextureFormat(VK_FORMAT_UNDEFINED)
+			: m_directAccessPtr(NULL)
+			, m_vkTextureFormat(VK_FORMAT_UNDEFINED)
 			, m_textureImage(VK_NULL_HANDLE)
 			, m_textureDeviceMem(VK_NULL_HANDLE)
 			, m_textureImageView(VK_NULL_HANDLE)
@@ -539,8 +540,8 @@ VK_DESTROY
 		uint32_t m_numLayers;
 		uint32_t m_numSides;
 		VkImageViewType m_type;
-		uint8_t m_requestedFormat;
-		uint8_t m_textureFormat;
+		bgfx::TextureFormat::Enum m_requestedFormat;
+		bgfx::TextureFormat::Enum m_textureFormat;
 		uint8_t m_numMips;
 		VkFormat m_vkTextureFormat;
 		VkComponentMapping m_vkComponentMapping;


### PR DESCRIPTION
This fixes a bunch of bugs related to Vulkan texture creation and update
Currently, running 06-update example crashes on my machine for a bunch of reasons
- Creating 3D textures is broken due to memory corruption by writing to an undersized array
- When a compressed format is not supported, the TextureVK::update function does not do any conversion to the actual texture format, and it breaks
- Also it's a minor tweak, but storing the formats as Enums doesn't cost anything and helps tremendously while debugging (instead of seeing an integer value)
- Updating 3D textures might be broken in general, I'm not even sure my code is correct, but nothing in the examples tests that