### PR TITLE
Optimize redundant state hashing in Vulkan & D3D12

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -2845,26 +2845,11 @@ namespace bgfx { namespace d3d12
 
 			_stencil &= packStencil(~BGFX_STENCIL_FUNC_REF_MASK, ~BGFX_STENCIL_FUNC_REF_MASK);
 
-			VertexLayout layout;
-			if (0 < _numStreams)
-			{
-				bx::memCopy(&layout, _layouts[0], sizeof(VertexLayout) );
-				const uint16_t* attrMask = program.m_vsh->m_attrMask;
-
-				for (uint32_t ii = 0; ii < Attrib::Count; ++ii)
-				{
-					uint16_t mask = attrMask[ii];
-					uint16_t attr = (layout.m_attributes[ii] & mask);
-					layout.m_attributes[ii] = attr == 0 ? UINT16_MAX : attr == UINT16_MAX ? 0 : attr;
-				}
-			}
-
 			bx::HashMurmur2A murmur;
 			murmur.begin();
 			murmur.add(_state);
 			murmur.add(_stencil);
 			murmur.add(program.m_vsh->m_hash);
-			murmur.add(program.m_vsh->m_attrMask, sizeof(program.m_vsh->m_attrMask) );
 
 			if (NULL != program.m_fsh)
 			{
@@ -2876,7 +2861,6 @@ namespace bgfx { namespace d3d12
 				murmur.add(_layouts[ii]->m_hash);
 			}
 
-			murmur.add(layout.m_attributes, sizeof(layout.m_attributes) );
 			murmur.add(m_fbh.idx);
 			murmur.add(_numInstanceData);
 			const uint32_t hash = murmur.end();

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3576,26 +3576,11 @@ VK_IMPORT_DEVICE
 
 			_stencil &= packStencil(~BGFX_STENCIL_FUNC_REF_MASK, ~BGFX_STENCIL_FUNC_REF_MASK);
 
-			VertexLayout layout;
-			if (0 < _numStreams)
-			{
-				bx::memCopy(&layout, _layouts[0], sizeof(VertexLayout) );
-				const uint16_t* attrMask = program.m_vsh->m_attrMask;
-
-				for (uint32_t ii = 0; ii < Attrib::Count; ++ii)
-				{
-					uint16_t mask = attrMask[ii];
-					uint16_t attr = (layout.m_attributes[ii] & mask);
-					layout.m_attributes[ii] = attr == 0 ? UINT16_MAX : attr == UINT16_MAX ? 0 : attr;
-				}
-			}
-
 			bx::HashMurmur2A murmur;
 			murmur.begin();
 			murmur.add(_state);
 			murmur.add(_stencil);
 			murmur.add(program.m_vsh->m_hash);
-			murmur.add(program.m_vsh->m_attrMask, sizeof(program.m_vsh->m_attrMask) );
 			if (NULL != program.m_fsh)
 			{
 				murmur.add(program.m_fsh->m_hash);
@@ -3604,7 +3589,6 @@ VK_IMPORT_DEVICE
 			{
 				murmur.add(_layouts[ii]->m_hash);
 			}
-			murmur.add(layout.m_attributes, sizeof(layout.m_attributes) );
 			murmur.add(m_fbh.idx);
 			murmur.add(_numInstanceData);
 			const uint32_t hash = murmur.end();


### PR DESCRIPTION
I was trying the drawstress example and noticed we are losing some amount of performance due to redundant hashing of entire arrays on each draw call
Correct me if I'm wrong and it is not redundant, but:
- the attrMask is already hashed inside the shader hash itself, so hashing it again for the PSO hash is redundant
- the layout attributes vs attrMask array hash would only avoid collisions that are already avoided by adding in the layout hash and vertex shader hash

It doesn't seem like removing those is likely to introduce any unwanted collisions ?
@bkaradzic @pezcode 