### PR TITLE
WebGPU - Fix order of uniforms staging and render commands

### DIFF
--- a/src/renderer_webgpu.h
+++ b/src/renderer_webgpu.h
@@ -314,10 +314,10 @@ namespace bgfx
 			void release();
 
 			StagingBufferWgpu* m_staging = NULL;
-			wgpu::Buffer m_stagingAlloc;
 			wgpu::Buffer m_buffer;
 			uint32_t m_offset;
 			uint32_t m_size;
+			uint8_t m_stagingIndex = 0;
 		};
 
 		class BindStateCacheWgpu
@@ -479,7 +479,8 @@ namespace bgfx
 		{
 			void init(wgpu::Queue _queue);
 			void shutdown();
-			void begin();
+			void beginRender();
+			void beginStaging();
 			void kick(bool _endFrame, bool _waitForFinish = false);
 			void finish(bool _finishAll = false);
 			void release(wgpu::Buffer _buffer);
@@ -490,7 +491,8 @@ namespace bgfx
 #endif
 
 			wgpu::Queue		     m_queue;
-			wgpu::CommandEncoder m_encoder;
+			wgpu::CommandEncoder m_stagingEncoder;
+			wgpu::CommandEncoder m_renderEncoder;
 
 			int m_releaseWriteIndex = 0;
 			int m_releaseReadIndex = 0;


### PR DESCRIPTION
I was in the process of trying to fix this bug when you merged my PR 😄 
My changes to how uniform buffers are written to (removing the deprecated `setSubData` function and use pre-mapped staging buffers instead) introduced a bug that I was trying to isolate.
We were sending the copy of the staging buffer to the uniform buffer *after* the render commands. So we need two different command encoders to make sure that we stage the uniforms *before* the render commands while preserving the same render loop structure.
This does this change, which fixes the remaining bugs introduced while I was addressing the comments of the PR.