### PR TITLE
Adds the ability to pass a WINDOWING_LIB variable to 'make' which sets `--with-sdl` or `--with-glfw`

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,8 +23,15 @@ endif
 
 # $(info $(OS))
 
+WITH_WINDOWING_LIB=
+ifeq ($(WINDOWING_LIB),sdl)
+	WITH_WINDOWING_LIB=--with-sdl
+else ifeq ($(WINDOWING_LIB),glfw)
+	WITH_WINDOWING_LIB=--with-glfw
+endif
+
 BX_DIR?=../bx
-GENIE?=$(BX_DIR)/tools/bin/$(OS)/genie
+GENIE?=$(BX_DIR)/tools/bin/$(OS)/genie $(WITH_WINDOWING_LIB)
 NINJA?=$(BX_DIR)/tools/bin/$(OS)/ninja
 
 .PHONY: help

--- a/makefile
+++ b/makefile
@@ -23,15 +23,8 @@ endif
 
 # $(info $(OS))
 
-WITH_WINDOWING_LIB=
-ifeq ($(WINDOWING_LIB),sdl)
-	WITH_WINDOWING_LIB=--with-sdl
-else ifeq ($(WINDOWING_LIB),glfw)
-	WITH_WINDOWING_LIB=--with-glfw
-endif
-
 BX_DIR?=../bx
-GENIE?=$(BX_DIR)/tools/bin/$(OS)/genie $(WITH_WINDOWING_LIB)
+GENIE?=$(BX_DIR)/tools/bin/$(OS)/genie $(EXTRA_GENIE_ARGS)
 NINJA?=$(BX_DIR)/tools/bin/$(OS)/ninja
 
 .PHONY: help


### PR DESCRIPTION
The [bgfx documentation states](https://bkaradzic.github.io/bgfx/overview.html#sdl-glfw-etc):
> You can use --with-sdl when runnning GENie to enable SDL2 integration with examples: genie --with-sdl vs2012

This change makes this possible when calling `make`. If a variable called `WINDOWING_LIBRARY` is set and its value is `sdl` it adds `--with-sdl` to the GENie invocation, and if its value is `glfw` it adds `--with-glfw` to the GENie invocation. In all other cases the previous behaviour is used.

The following examples are all valid:

```
make projgen
make projgen WINDOWING_LIB=sdl
make projgen WINDOWING_LIB=glfw
```
