### PR TITLE
Allow passing config macros from env

### DIFF
--- a/scripts/bgfx.lua
+++ b/scripts/bgfx.lua
@@ -79,9 +79,7 @@ function bgfxProjectBase(_kind, _defines)
 		path.join(BIMG_DIR, "include"),
 	}
 
-	defines {
-		_defines,
-	}
+	defines (_defines)
 
 	links {
 		"bx",

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -498,7 +498,22 @@ end
 dofile "bgfx.lua"
 
 group "libs"
-bgfxProject("", "StaticLib", {})
+
+local function userdefines()
+	local defines = {}
+	local BGFX_CONFIG = os.getenv("BGFX_CONFIG")
+	if BGFX_CONFIG then
+		for def in BGFX_CONFIG:gmatch "[^%s:]+" do
+			table.insert(defines, "BGFX_CONFIG_" .. def)
+		end
+	end
+
+	return defines
+end
+
+BGFX_CONFIG = userdefines()
+
+bgfxProject("", "StaticLib", BGFX_CONFIG)
 
 dofile(path.join(BX_DIR,   "scripts/bx.lua"))
 dofile(path.join(BIMG_DIR, "scripts/bimg.lua"))
@@ -575,7 +590,7 @@ end
 
 if _OPTIONS["with-shared-lib"] then
 	group "libs"
-	bgfxProject("-shared-lib", "SharedLib", {})
+	bgfxProject("-shared-lib", "SharedLib", BGFX_CONFIG)
 end
 
 if _OPTIONS["with-tools"] then


### PR DESCRIPTION
bgfx defines many config macros in `src/config.h` . If it allows changing these macros before generating projects would be better.

For examples, we can use

 ```
make BGFX_CONFIG=MAX_COMMAND_BUFFER_SIZE=131072:MAX_INSTANCE_DATA_COUNT=6
```

 to change `BGFX_DEFINE_MAX_COMMAND_BUFFER_SIZE` and `BGFX_DEFINE_MAX_INSTANCE_DATA_COUNT`.