### PR TITLE
Change asmjs to wasm2js

### DIFF
--- a/makefile
+++ b/makefile
@@ -50,7 +50,7 @@ projgen: ## Generate project files for all configurations.
 	$(GENIE)              --with-combined-examples                   --gcc=android-arm     gmake
 	$(GENIE)              --with-combined-examples                   --gcc=android-arm64   gmake
 	$(GENIE)              --with-combined-examples                   --gcc=android-x86     gmake
-	$(GENIE)              --with-examples                            --gcc=asmjs           gmake
+	$(GENIE)              --with-examples                            --gcc=wasm2js         gmake
 	$(GENIE)              --with-combined-examples                   --gcc=ios-arm         gmake
 	$(GENIE)              --with-combined-examples                   --gcc=ios-arm64       gmake
 	$(GENIE)              --with-combined-examples                   --gcc=ios-simulator   gmake


### PR DESCRIPTION
I can't build bgfx today
```
../bx/tools/bin/windows/genie               --with-examples                            --gcc=asmjs           gmake
Error: invalid value 'asmjs' for option 'gcc'
stack traceback:
        [C]: in function 'error'
        [string "_WORKING_DIR        = os.getcwd()..."]:63: in function '_premake_main'
```

Option asmjs changes to wasm2js in this commit : 

https://github.com/bkaradzic/bx/commit/8d1e6bbe75639d5af80d4145a4f26254aa786aae

