### PR TITLE
Broadened bypass mechanism for GLSL default headers

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5824,7 +5824,7 @@ namespace bgfx { namespace gl
 		if (0 != m_id)
 		{
 			if (GL_COMPUTE_SHADER != m_type
-			&&  0 != bx::strCmp(code, "#version 430", 12) ) // #2000
+			&&  0 != bx::strCmp(code, "#version", 8) ) // #2000
 			{
 				int32_t tempLen = code.getLength() + (4<<10);
 				char* temp = (char*)alloca(tempLen);


### PR DESCRIPTION
Broadened bypass mechanism for GLSL default headers in the OpenGL renderer. This reflects the fact that, if the first line of a shader is already a #version declaration, we never want to write lines above that regardless of what version is declared.

The motivation for this change is that Babylon Native uses a custom pipeline to cross-compile shaders and make them compatible with bgfx at runtime. An obstacle we encountered was that, when our shader output targeted GL version 310 (for Android), the logic in renderer_gl.cpp would write additional information to the tops of our shaders above the `#version` declaration, which the shader compiler would then reject because it doesn't allow for duplicate versions or for code to appear above the version. Noting that there was already a mechanism to bypass this logic if a specific version (430) of GL had been targeted, we slightly broadened this to work if _any_ GL version has been targeted at the top. This allows us to runtime-transpile shaders directly using glslang/SPIRV-Cross and use external mechanisms to make the results compatible with bgfx.