### PR TITLE
Fix calls to emscripten functions

### DIFF
--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -374,7 +374,9 @@ EGL_IMPORT
 // will take the first canvas element found on the web page.
 #define HTML5_TARGET_CANVAS_SELECTOR "#canvas"
 
-		BX_ASSERT(emscripten_set_canvas_element_size(HTML5_TARGET_CANVAS_SELECTOR, _width, _height) == EMSCRIPTEN_RESULT_SUCCESS, "emscripten_set_canvas_element_size() failed in GlContext::resize()!");
+		EMSCRIPTEN_RESULT res = emscripten_set_canvas_element_size(HTML5_TARGET_CANVAS_SELECTOR, _width, _height);
+		BX_ASSERT(res == EMSCRIPTEN_RESULT_SUCCESS, "emscripten_set_canvas_element_size() failed in GlContext::resize()!");
+		BX_UNUSED(res);
 #	else
 		BX_UNUSED(_width, _height);
 #	endif // BX_PLATFORM_*

--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -19,6 +19,18 @@ extern "C" void* emscripten_GetProcAddress(const char *name_);
 extern "C" void* emscripten_webgl1_get_proc_address(const char *name_);
 extern "C" void* emscripten_webgl2_get_proc_address(const char *name_);
 
+#define _EMSCRIPTEN_CHECK(_check, _call)                                                                     \
+	BX_MACRO_BLOCK_BEGIN                                                                                     \
+		EMSCRIPTEN_RESULT __result__ = _call;                                                                \
+		BX_ASSERT(EMSCRIPTEN_RESULT_SUCCESS == __result__, #_call " FAILED 0x%08x\n", (uint32_t)__result__); \
+	BX_MACRO_BLOCK_END
+
+#if BGFX_CONFIG_DEBUG
+#	define EMSCRIPTEN_CHECK(_call) _EMSCRIPTEN_CHECK(BX_ASSERT, _call)
+#else
+#	define EMSCRIPTEN_CHECK(_call) _call
+#endif // BGFX_CONFIG_DEBUG
+
 namespace bgfx { namespace gl
 {
 
@@ -51,7 +63,7 @@ namespace bgfx { namespace gl
 
 		void makeCurrent()
 		{
-			BX_ASSERT(emscripten_webgl_make_context_current(m_context) == EMSCRIPTEN_RESULT_SUCCESS, "emscripten_webgl_make_context_current() failed!");
+			EMSCRIPTEN_CHECK(emscripten_webgl_make_context_current(m_context));
 		}
 
 		void swapBuffers()
@@ -75,7 +87,7 @@ namespace bgfx { namespace gl
 		m_primary = createSwapChain((void*)canvas);
 
 		if (_width && _height)
-			BX_ASSERT(emscripten_set_canvas_element_size(canvas, (int)_width, (int)_height) == EMSCRIPTEN_RESULT_SUCCESS, "emscripten_set_canvas_element_size() failed in GlContext::create()!");
+			EMSCRIPTEN_CHECK(emscripten_set_canvas_element_size(canvas, (int)_width, (int)_height));
 
 		makeCurrent(m_primary);
 	}
@@ -101,7 +113,7 @@ namespace bgfx { namespace gl
 			return;
 		}
 
-		BX_ASSERT(emscripten_set_canvas_element_size(m_primary->m_canvas, (int) _width, (int) _height) == EMSCRIPTEN_RESULT_SUCCESS, "emscripten_set_canvas_element_size() failed in GlContext::resize()!");
+		EMSCRIPTEN_CHECK(emscripten_set_canvas_element_size(m_primary->m_canvas, (int) _width, (int) _height));
 	}
 
 	SwapChainGL* GlContext::createSwapChain(void* _nwh)
@@ -127,7 +139,7 @@ namespace bgfx { namespace gl
 			EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context(canvas, &s_attrs);
 			if (context > 0)
 			{
-				BX_ASSERT(emscripten_webgl_make_context_current(context) == EMSCRIPTEN_RESULT_SUCCESS, "emscripten_webgl_make_context_current() failed in GlContext::createSwapChain()!");
+				EMSCRIPTEN_CHECK(emscripten_webgl_make_context_current(context));
 
 				SwapChainGL* swapChain = BX_NEW(g_allocator, SwapChainGL)(context, canvas);
 

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1599,7 +1599,9 @@ namespace bgfx { namespace gl
 		// Avoid creating test textures for WebGL, that causes error noise in the browser console; instead examine the supported texture formats from the spec.
 		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_get_current_context();
 		EmscriptenWebGLContextAttributes attrs;
-		BX_ASSERT(emscripten_webgl_get_context_attributes(ctx, &attrs) == EMSCRIPTEN_RESULT_SUCCESS, "emscripten_webgl_get_context_attributes() failed in isTextureFormatValidPerSpec()!");
+		EMSCRIPTEN_RESULT res = emscripten_webgl_get_context_attributes(ctx, &attrs);
+		BX_ASSERT(res == EMSCRIPTEN_RESULT_SUCCESS, "emscripten_webgl_get_context_attributes() failed in isTextureFormatValidPerSpec()!");
+		BX_UNUSED(res);
 		int glesVersion = attrs.majorVersion + 1;
 		switch(_format)
 		{


### PR DESCRIPTION
This is a followup to https://github.com/bkaradzic/bgfx/pull/2160 to actually fix the html5 release build.

There is an unfortunate copy-paste of the EMSCRIPTEN_CHECK macro, because I didn't were else to put it. Maybe in bx itself ?