### PR TITLE
Package runtime data alongside HTML5 examples

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -367,7 +367,8 @@ function exampleProjectDefaults()
 
 		linkoptions {
 			"-s TOTAL_MEMORY=32MB",
-			"-s ALLOW_MEMORY_GROWTH=1"
+			"-s ALLOW_MEMORY_GROWTH=1",
+			"--preload-file ../../../examples/runtime@/"
 		}
 
 		removeflags {


### PR DESCRIPTION
It's not fine-grained at all everything is pull in for each examples, but I don't think its a major issue. Many more examples can now be evaluated in HTML5. It also makes investigating why some of the others don't work easier.