### PR TITLE
Fix target extension on android for shared-library

### DIFF
--- a/scripts/bgfx.lua
+++ b/scripts/bgfx.lua
@@ -69,6 +69,8 @@ function bgfxProjectBase(_kind, _defines)
 				"GL",
 				"pthread",
 			}
+		configuration { "android*" }
+			targetextension ".so"
 
 		configuration {}
 	end

--- a/scripts/bgfx.lua
+++ b/scripts/bgfx.lua
@@ -71,6 +71,12 @@ function bgfxProjectBase(_kind, _defines)
 			}
 		configuration { "android*" }
 			targetextension ".so"
+		
+		configuration { "android*" ,"Debug"}
+			linkoptions{"-soname libbgfx-shared-libDebug.so"  }
+
+		configuration { "android*" ,"Release"}
+			linkoptions{"-soname libbgfx-shared-libRelease.so"  }
 
 		configuration {}
 	end


### PR DESCRIPTION
Fixing android shared library build making target extension ``.dll`` instead on ``.so`` when compiling on windows