### PR TITLE
fix declaration of sdfCoverageToDistance

### DIFF
--- a/3rdparty/sdf/sdf.h
+++ b/3rdparty/sdf/sdf.h
@@ -113,7 +113,7 @@ static float sdf__clamp01(float x)
 	return x < 0.0f ? 0.0f : (x > 1.0f ? 1.0f : x);
 }
 
-void sdfCoverageToDistance(unsigned char* out, int outstride,
+void sdfCoverageToDistance(unsigned char* out, int outstride, float maxdist,
 						   const unsigned char* img, int width, int height, int stride)
 {
 	int x, y;


### PR DESCRIPTION
When I include sdf.h in my C file, gcc reported
```
bgfx/3rdparty/sdf/sdf.h:116:6: error: conflicting types for 'sdfCoverageToDistance'
 void sdfCoverageToDistance(unsigned char* out, int outstride,
      ^~~~~~~~~~~~~~~~~~~~~
In file included from font_manager.c:11:
bgfx/3rdparty/sdf/sdf.h:55:6: note: previous declaration of 'sdfCoverageToDistance' was here
 void sdfCoverageToDistance(unsigned char* out, int outstride, float maxdist,
      ^~~~~~~~~~~~~~~~~~~~~
```
