### PR TITLE
OpenGL: Disable scissor testing while blitting framebuffers when MSAA is enabled

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6746,6 +6746,7 @@ namespace bgfx { namespace gl
 
 					if (!bimg::isDepth(format) )
 					{
+						GL_CHECK(glDisable(GL_SCISSOR_TEST));
 						GL_CHECK(glBindFramebuffer(GL_READ_FRAMEBUFFER, m_fbo[0]) );
 						GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fbo[1]) );
 						GL_CHECK(glReadBuffer(GL_COLOR_ATTACHMENT0 + colorIdx) );
@@ -6764,7 +6765,7 @@ namespace bgfx { namespace gl
 							) );
 
 					} else if (!writeOnly) {
-
+						GL_CHECK(glDisable(GL_SCISSOR_TEST));
 						// blit depth attachment as well if it doesn't have
 						// BGFX_TEXTURE_RT_WRITE_ONLY render target flag. In most cases it's
 						// not necessary to blit the depth buffer.


### PR DESCRIPTION
I've found this issue while rendering my scene where the last draw call, before the `glBlitFramebuffer` is being called, does have scissoring enabled.

This behavior causes the blit to inherit the scissoring copying only the region within the scissor region. Not sure why, but I noticed that this is being done also on line https://github.com/bkaradzic/bgfx/blob/master/src/renderer_gl.cpp#L3778 but not on the other two calls.

The patch should fix this behavior.

Example of the issue (Left is OK, Right is WRONG):
![image](https://user-images.githubusercontent.com/1237070/87431497-03cb6500-c5e7-11ea-8356-000c4fceda97.png)
![image](https://user-images.githubusercontent.com/1237070/87431527-0f1e9080-c5e7-11ea-8bbf-2da444cfdfac.png)

