### PR TITLE
check for BGFX_TEXTURE_READ_BACK flag

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1782,7 +1782,7 @@ namespace bgfx { namespace d3d11
 		void readTexture(TextureHandle _handle, void* _data, uint8_t _mip) override
 		{
 			const TextureD3D11& texture = m_textures[_handle.idx];
-			BX_CHECK(0 != (texture.m_flags&BGFX_TEXTURE_READ_BACK), "texture must be created with BGFX_TEXTURE_READ_BACK");
+			BX_ASSERT(0 != (texture.m_flags&BGFX_TEXTURE_READ_BACK), "texture must be created with BGFX_TEXTURE_READ_BACK");
 
 			D3D11_MAPPED_SUBRESOURCE mapped;
 			DX_CHECK(m_deviceCtx->Map(texture.m_ptr, _mip, D3D11_MAP_READ, 0, &mapped) );

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1782,6 +1782,8 @@ namespace bgfx { namespace d3d11
 		void readTexture(TextureHandle _handle, void* _data, uint8_t _mip) override
 		{
 			const TextureD3D11& texture = m_textures[_handle.idx];
+			BX_CHECK(0 != (texture.m_flags&BGFX_TEXTURE_READ_BACK), "texture must be created with BGFX_TEXTURE_READ_BACK");
+
 			D3D11_MAPPED_SUBRESOURCE mapped;
 			DX_CHECK(m_deviceCtx->Map(texture.m_ptr, _mip, D3D11_MAP_READ, 0, &mapped) );
 


### PR DESCRIPTION
Without this we end up failing on the next line down, `DX_CHECK(m_deviceCtx->Map(...`, which gives the "1 or more invalid args" error... not much info. The debug layer doesn't print anything either. This assert makes it easier to figure out what exactly you did wrong. Of course the docs on bgfx::readTexture already explicitly say you need this flag set so this is just extra training wheels.