### PR TITLE
Fix uniform stripping procedure for unexpected newlines in Metal shaderc.

### DIFF
--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -730,6 +730,15 @@ namespace bgfx { namespace metal
 
 						if (!str.isEmpty() )
 						{
+							// If the line declares a uniform, merge all next
+							// lines until we encounter a semicolon.
+							bx::StringView lineEnd = strFind(strLine, ";");
+							while (lineEnd.isEmpty() && !reader.isDone()) {
+								bx::StringView nextLine = reader.next();
+								strLine.set(strLine.getPtr(), nextLine.getTerm());
+								lineEnd = strFind(nextLine, ";");
+							}
+
 							bool found = false;
 
 							for (uint32_t ii = 0; ii < BX_COUNTOF(s_samplerTypes); ++ii)


### PR DESCRIPTION
Fixes #2166. Probably not the very very best solution, but definitely an improvement that fixes most cases I assume. (Counterexample: declare two uniforms on the same line... but that didn't work before either.)