### PR TITLE
only use srgb views into non-srgb backbuffers to enable flip

### DIFF
--- a/src/dxgi.cpp
+++ b/src/dxgi.cpp
@@ -381,7 +381,13 @@ namespace bgfx
 			hr = factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing, sizeof(allowTearing) );
 			BX_TRACE("Allow tearing is %ssupported.", allowTearing ? "" : "not ");
 
-			scdFlags |= allowTearing ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING | DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT : 0;
+			scdFlags |= allowTearing ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+			scdFlags |=
+				(_scd.swapEffect == DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL
+					|| _scd.swapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD)
+				? DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT
+				: 0;
+
 
 			DX_RELEASE_I(factory5);
 		}
@@ -658,7 +664,11 @@ namespace bgfx
 			hr = factory5->CheckFeatureSupport(DXGI_FEATURE_PRESENT_ALLOW_TEARING, &allowTearing, sizeof(allowTearing));
 			BX_TRACE("Allow tearing is %ssupported.", allowTearing ? "" : "not ");
 
-			scdFlags |= allowTearing ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING | DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT : 0;
+			scdFlags |= allowTearing ? DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING : 0;
+			scdFlags |= (_scd.swapEffect == DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL
+				|| _scd.swapEffect == DXGI_SWAP_EFFECT_FLIP_DISCARD)
+				? DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT
+				: 0;
 
 			DX_RELEASE_I(factory5);
 		}


### PR DESCRIPTION
In master, the swapchain fails to create when BGFX_RESET_SRGB_BACKBUFFER is set, and fails over to DXGI_SWAP_EFFECT_DISCARD.

In this PR, we use the exception listed here: https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/converting-data-color-space
to use a _SRGB format render target view into a non- _SRGB format backbuffer. 

This allows the swapchain to be created successfully with DXGI_SWAP_EFFECT_FLIP_DISCARD.

Also, we make sure to only set DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT when using the flip presentation model, as it only works there.