### PR TITLE
Fixes example 41 on OpenGL

### DIFF
--- a/examples/41-tess/cs_terrain_lod.sc
+++ b/examples/41-tess/cs_terrain_lod.sc
@@ -54,7 +54,7 @@ void main()
 	}
 	else
 	{
-		targetLod = parentLod = findMSB(key);
+		targetLod = parentLod = findMSB_(key);
 	}
 
 	updateSubdBuffer(primID, key, targetLod, parentLod);

--- a/examples/41-tess/isubd.sh
+++ b/examples/41-tess/isubd.sh
@@ -1,4 +1,4 @@
-uint findMSB(uint x)
+uint findMSB_(uint x)
 {
 	uint i;
 	uint mask;
@@ -36,7 +36,7 @@ bool isRootKey(in uint key)
 
 bool isLeafKey(in uint key)
 {
-	return findMSB(key) == 31;
+	return findMSB_(key) == 31;
 }
 
 bool isChildZeroKey(in uint key)

--- a/examples/41-tess/terrain_common.sh
+++ b/examples/41-tess/terrain_common.sh
@@ -64,7 +64,7 @@ void updateSubdBuffer(
 	)
 {
 	// extract subdivision level associated to the key
-	uint keyLod = findMSB(key);
+	uint keyLod = findMSB_(key);
 
 	// update the key accordingly
 	if (/* subdivide ? */ keyLod < targetLod && !isLeafKey(key) && isVisible)


### PR DESCRIPTION
The glsl function findMSB is overriden, causing an error on Windows and Linux
when running on AMD or Intel gpus. Nvidia, for whatever reason, seems to allow
overriding the function.