### PR TITLE
Fixes example 42

### DIFF
--- a/examples/42-bunnylod/bunnylod.cpp
+++ b/examples/42-bunnylod/bunnylod.cpp
@@ -265,7 +265,7 @@ public:
 		u_tint = bgfx::createUniform("u_tint", bgfx::UniformType::Vec4);
 
 		// Create program from shaders.
-		m_program = loadProgram("vs_callback", "fs_callback");
+		m_program = loadProgram("vs_bunnylod", "fs_bunnylod");
 
 		Mesh* mesh = meshLoad("meshes/bunny_patched.bin", true);
 		loadMesh(mesh);

--- a/examples/42-bunnylod/fs_bunnylod.sc
+++ b/examples/42-bunnylod/fs_bunnylod.sc
@@ -1,0 +1,17 @@
+$input v_world, v_color0
+
+/*
+ * Copyright 2011-2020 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#include "../common/common.sh"
+
+void main()
+{
+	vec3 normal = normalize(cross(dFdx(v_world), dFdy(v_world) ) );
+	vec3 lightDir = vec3(0.0, 0.0, 1.0);
+	float ndotl = max(dot(normal, lightDir), 0.0);
+	float spec = pow(ndotl, 30.0);
+	gl_FragColor = pow(pow(v_color0, vec4_splat(2.2) ) * ndotl + spec, vec4_splat(1.0/2.2) );
+}

--- a/examples/42-bunnylod/makefile
+++ b/examples/42-bunnylod/makefile
@@ -1,0 +1,10 @@
+#
+# Copyright 2011-2020 Branimir Karadzic. All rights reserved.
+# License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+#
+
+BGFX_DIR=../..
+RUNTIME_DIR=$(BGFX_DIR)/examples/runtime
+BUILD_DIR=../../.build
+
+include $(BGFX_DIR)/scripts/shader.mk

--- a/examples/42-bunnylod/varying.def.sc
+++ b/examples/42-bunnylod/varying.def.sc
@@ -1,0 +1,5 @@
+vec3 v_world     : TEXCOORD0 = vec3(0.0, 0.0, 0.0);
+vec4 v_color0    : COLOR0    = vec4(1.0, 0.0, 0.0, 1.0);
+
+vec3 a_position  : POSITION;
+vec3 a_normal    : NORMAL;

--- a/examples/42-bunnylod/vs_bunnylod.sc
+++ b/examples/42-bunnylod/vs_bunnylod.sc
@@ -1,0 +1,16 @@
+$input a_position, a_normal
+$output v_world, v_color0
+
+/*
+ * Copyright 2011-2020 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#include "../common/common.sh"
+
+void main()
+{
+	gl_Position = mul(u_modelViewProj, vec4(a_position, 1.0) );
+	v_world = mul(u_model[0], vec4(a_position, 1.0) ).xyz;
+	v_color0 = vec4(a_normal, 1.0);
+}


### PR DESCRIPTION
Because example 42 was using the shaders from example 07 (callback), which have
input vertex attributes position and color, while the mesh from example 42 has
attributes position and normal, this causes problems on Windows when using
AMD gpus (no bunny mesh would appear on the window).