### PR TITLE
[ VK/DX12] Bring setScissor on par with the other renderers

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -5893,7 +5893,7 @@ namespace bgfx { namespace d3d12
 
 		bool wasCompute = false;
 		bool viewHasScissor = false;
-		bool restoreScissor = false;
+		bool scissorEnabled = false;
 		Rect viewScissorRect;
 		viewScissorRect.clear();
 
@@ -6033,7 +6033,6 @@ namespace bgfx { namespace d3d12
 					rc.right  = viewScissorRect.m_x + viewScissorRect.m_width;
 					rc.bottom = viewScissorRect.m_y + viewScissorRect.m_height;
 					m_commandList->RSSetScissorRects(1, &rc);
-					restoreScissor = false;
 
 					Clear& clr = _render->m_view[view].m_clear;
 					if (BGFX_CLEAR_NONE != clr.m_flags)
@@ -6530,10 +6529,9 @@ namespace bgfx { namespace d3d12
 
 						if (UINT16_MAX == scissor)
 						{
-							if (restoreScissor
-							||  viewHasScissor)
+							scissorEnabled = viewHasScissor;
+							if (viewHasScissor)
 							{
-								restoreScissor = false;
 								D3D12_RECT rc;
 								rc.left   = viewScissorRect.m_x;
 								rc.top    = viewScissorRect.m_y;
@@ -6544,14 +6542,11 @@ namespace bgfx { namespace d3d12
 						}
 						else
 						{
-							restoreScissor = true;
+							
 							Rect scissorRect;
 							scissorRect.setIntersect(viewScissorRect, _render->m_frameCache.m_rectCache.m_cache[scissor]);
-							if (scissorRect.isZeroArea() )
-							{
-								continue;
-							}
 
+							scissorEnabled = true;
 							D3D12_RECT rc;
 							rc.left   = scissorRect.m_x;
 							rc.top    = scissorRect.m_y;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -5944,7 +5944,7 @@ VK_DESTROY
 
 		bool wasCompute     = false;
 		bool viewHasScissor = false;
-		bool restoreScissor = false;
+		bool scissorEnabled = false;
 		Rect viewScissorRect;
 		viewScissorRect.clear();
 
@@ -6096,8 +6096,6 @@ VK_DESTROY
 						rc.extent.width  = viewScissorRect.m_width;
 						rc.extent.height = viewScissorRect.m_height;
 						vkCmdSetScissor(m_commandBuffer, 0, 1, &rc);
-
-						restoreScissor = false;
 
 						Clear& clr = _render->m_view[view].m_clear;
 						if (BGFX_CLEAR_NONE != clr.m_flags)
@@ -6396,10 +6394,9 @@ VK_DESTROY
 
 						if (UINT16_MAX == scissor)
 						{
-							if (restoreScissor
-							||  viewHasScissor)
+							scissorEnabled = viewHasScissor;
+							if (viewHasScissor)
 							{
-								restoreScissor = false;
 								VkRect2D rc;
 								rc.offset.x      = viewScissorRect.m_x;
 								rc.offset.y      = viewScissorRect.m_y;
@@ -6410,10 +6407,10 @@ VK_DESTROY
 						}
 						else
 						{
-							restoreScissor = true;
 							Rect scissorRect;
 							scissorRect.setIntersect(viewScissorRect, _render->m_frameCache.m_rectCache.m_cache[scissor]);
 
+							scissorEnabled = true;
 							VkRect2D rc;
 							rc.offset.x      = scissorRect.m_x;
 							rc.offset.y      = scissorRect.m_y;


### PR DESCRIPTION
This PR should bring the `setScissor` API call on par with the other renderers.

The main issue was that the scissor logic when is set, and is the first draw call of the view after a `bgfx::frame()` call, is overridden but the internal reset state, which sets the view scissor rect, and then doesn't allow the flow to pick the user chosen setScissor region.

This patch aims in fixing this, as well as bring uniformity in the code making sure the flow is exactly the same like it is happening on DX11/GL renderers for eg.

Feel free to approach me on Discord if you have questions!

Thank you in advance