### PR TITLE
Add support for non main thread rendering for WGL and NSGL when developer provides context

### DIFF
--- a/src/glcontext_nsgl.mm
+++ b/src/glcontext_nsgl.mm
@@ -150,6 +150,10 @@ namespace bgfx { namespace gl
 			m_view    = glView;
 			m_context = glContext;
 		}
+        else
+        {
+            [g_platformData.context makeCurrentContext];
+        }
 
 		import();
 
@@ -175,9 +179,12 @@ namespace bgfx { namespace gl
 
 #if defined(MAC_OS_X_VERSION_MAX_ALLOWED) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
 		bool hidpi = !!(_flags&BGFX_RESET_HIDPI);
-		NSOpenGLView* glView = (NSOpenGLView*)m_view;
-		if ([glView respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)])
-			[glView setWantsBestResolutionOpenGLSurface:hidpi];
+        if (m_view)
+        {
+            NSOpenGLView* glView = (NSOpenGLView*)m_view;
+            if ([glView respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)])
+                [glView setWantsBestResolutionOpenGLSurface:hidpi];
+        }
 #endif // defined(MAC_OS_X_VERSION_MAX_ALLOWED) && (MAC_OS_X_VERSION_MAX_ALLOWED >= 1070)
 
 		bool vsync = !!(_flags&BGFX_RESET_VSYNC);

--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -111,8 +111,16 @@ namespace bgfx { namespace gl
 
 
 
-		if( g_platformData.context )
+		// If g_platformHooks.nwh is NULL, the assumption is that GL context was created
+		// by user (for example, using SDL, GLFW, etc.)
+		BX_WARN(NULL != g_platformData.nwh
+			, "bgfx::setPlatform with valid window is not called. This might "
+				"be intentional when GL context is created by the user."
+			);
+
+		if (NULL != g_platformData.nwh && NULL != g_platformData.context )
 		{
+			// user has provided a context and a window
 			wglMakeCurrent = (PFNWGLMAKECURRENTPROC)bx::dlsym(m_opengl32dll, "wglMakeCurrent");
 			BGFX_FATAL(NULL != wglMakeCurrent, Fatal::UnableToInitialize, "Failed get wglMakeCurrent.");
 
@@ -124,15 +132,6 @@ namespace bgfx { namespace gl
 			BGFX_FATAL(0 != result, Fatal::UnableToInitialize, "wglMakeCurrent failed!");
 
 			m_context = context;
-		}
-		else
-		{
-			// If g_platformHooks.nwh is NULL, the assumption is that GL context was created
-			// by user (for example, using SDL, GLFW, etc.)
-			BX_WARN(NULL != g_platformData.nwh
-				, "bgfx::setPlatform with valid window is not called. This might "
-				  "be intentional when GL context is created by the user."
-				);
 		}
 
 		if (NULL != g_platformData.nwh && NULL == g_platformData.context )

--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -109,14 +109,33 @@ namespace bgfx { namespace gl
 		wglGetProcAddress = (PFNWGLGETPROCADDRESSPROC)bx::dlsym(m_opengl32dll, "wglGetProcAddress");
 		BGFX_FATAL(NULL != wglGetProcAddress, Fatal::UnableToInitialize, "Failed get wglGetProcAddress.");
 
-		// If g_platformHooks.nwh is NULL, the assumption is that GL context was created
-		// by user (for example, using SDL, GLFW, etc.)
-		BX_WARN(NULL != g_platformData.nwh
-			, "bgfx::setPlatform with valid window is not called. This might "
-			  "be intentional when GL context is created by the user."
-			);
 
-		if (NULL != g_platformData.nwh)
+
+		if( g_platformData.context )
+		{
+			wglMakeCurrent = (PFNWGLMAKECURRENTPROC)bx::dlsym(m_opengl32dll, "wglMakeCurrent");
+			BGFX_FATAL(NULL != wglMakeCurrent, Fatal::UnableToInitialize, "Failed get wglMakeCurrent.");
+
+			m_hdc = GetDC( (HWND)g_platformData.nwh);
+			BGFX_FATAL(NULL != m_hdc, Fatal::UnableToInitialize, "GetDC failed!");
+
+			HGLRC context = (HGLRC)g_platformData.context;
+			int result = wglMakeCurrent(m_hdc, context );
+			BGFX_FATAL(0 != result, Fatal::UnableToInitialize, "wglMakeCurrent failed!");
+
+			m_context = context;
+		}
+		else
+		{
+			// If g_platformHooks.nwh is NULL, the assumption is that GL context was created
+			// by user (for example, using SDL, GLFW, etc.)
+			BX_WARN(NULL != g_platformData.nwh
+				, "bgfx::setPlatform with valid window is not called. This might "
+				  "be intentional when GL context is created by the user."
+				);
+		}
+
+		if (NULL != g_platformData.nwh && NULL == g_platformData.context )
 		{
 			wglMakeCurrent = (PFNWGLMAKECURRENTPROC)bx::dlsym(m_opengl32dll, "wglMakeCurrent");
 			BGFX_FATAL(NULL != wglMakeCurrent, Fatal::UnableToInitialize, "Failed get wglMakeCurrent.");
@@ -283,8 +302,12 @@ namespace bgfx { namespace gl
 		{
 			wglMakeCurrent(NULL, NULL);
 
-			wglDeleteContext(m_context);
-			m_context = NULL;
+			if (NULL == g_platformData.context)
+			{
+				wglDeleteContext(m_context);
+				m_context = NULL;
+
+			}
 
 			ReleaseDC( (HWND)g_platformData.nwh, m_hdc);
 			m_hdc = NULL;


### PR DESCRIPTION
These changes to glcontext_wgl.cpp and glcontext_nsgl.mm add support for a non-main thread rendering (renderFrame not called so bgfx creates a render thread) for WGL and NSGL when the developer provides a context.

GLX context already works in this scenario, and the code changes make the behaviour of these three desktop GL backends more similar.

The code changes should not have any backwards compatibility issues, and I have run a wide range of examples with backend set to OpenGL to test. 

These changes are useful when a developer wants to interface their code with an external framework / plugin system which has performance critical code running on the main thread (for example audio plugins), and where either a context has already been created or where the developer needs to create the context on the main thread - creation of an NSGL context uses the UI API which should not be called from a non-main thread, so context creation should be called first on the main thread.

A test project which runs using a non-main thread rendering is available on (my apologies for using cmake but that's what I'm most familiar with):
https://github.com/dougbinks/bgfx-renderthread-test

Note: Whilst these changes are aimed at OpenGL, the approach used by the test is suitable for most supported backends on desktop systems (DX9-12, OpenGL, Metal, Vulkan) as on OSX the Metal and Vulkan backends do not need to call UI API if the NSView contentView is passed rather than the NSWindow.

Let me know if any changes are needed, I'll be happy to make them - and thanks for providing & maintaining bgfx!