### PR TITLE
avoid gcc warnings: cast-function-type

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -44,6 +44,8 @@
 		, _handleAlloc.getMaxHandles()                             \
 		)
 
+#define BGFX_CAST_FUNCTION(proto, func) ((proto)(void(*)(void))func)
+
 #if BGFX_CONFIG_MULTITHREADED
 #	define BGFX_MUTEX_SCOPE(_mutex) bx::MutexScope BX_CONCATENATE(mutexScope, __LINE__)(_mutex)
 #else

--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -450,7 +450,7 @@ EGL_IMPORT
 			{                                                                                                                                                    \
 				if (NULL == _func)                                                                                                                               \
 				{                                                                                                                                                \
-					_func = (_proto)bx::dlsym(glesv2, #_import);                                                                                                 \
+					_func = BGFX_CAST_FUNCTION(_proto, bx::dlsym(glesv2, #_import));                                                                             \
 					BX_TRACE("\t%p " #_func " (" #_import ")", _func);                                                                                           \
 					BGFX_FATAL(_optional || NULL != _func, Fatal::UnableToInitialize, "Failed to create OpenGLES context. eglGetProcAddress(\"%s\")", #_import); \
 				}                                                                                                                                                \
@@ -460,7 +460,7 @@ EGL_IMPORT
 			{                                                                                                                                                    \
 				if (NULL == _func)                                                                                                                               \
 				{                                                                                                                                                \
-					_func = (_proto)eglGetProcAddress(#_import);                                                                                                 \
+					_func = BGFX_CAST_FUNCTION(_proto , eglGetProcAddress(#_import));                                                                            \
 					BX_TRACE("\t%p " #_func " (" #_import ")", _func);                                                                                           \
 					BGFX_FATAL(_optional || NULL != _func, Fatal::UnableToInitialize, "Failed to create OpenGLES context. eglGetProcAddress(\"%s\")", #_import); \
 				}                                                                                                                                                \

--- a/src/glcontext_glx.cpp
+++ b/src/glcontext_glx.cpp
@@ -352,7 +352,7 @@ namespace bgfx { namespace gl
 				{ \
 					if (NULL == _func) \
 					{ \
-						_func = (_proto)glXGetProcAddress( (const GLubyte*)#_import); \
+						_func = BGFX_CAST_FUNCTION(_proto, glXGetProcAddress( (const GLubyte*)#_import)); \
 						BX_TRACE("%p " #_func " (" #_import ")", _func); \
 						BGFX_FATAL(_optional || NULL != _func, Fatal::UnableToInitialize, "Failed to create OpenGL context. glXGetProcAddress %s", #_import); \
 					} \

--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -188,7 +188,7 @@ namespace bgfx { namespace gl
 				{                                                                                                                                                \
 					_func = (_proto)emscripten_webgl1_get_proc_address(#_import);                                                                                \
 					if (!_func && webGLVersion >= 2)                                                                                                             \
-					    _func = (_proto)emscripten_webgl2_get_proc_address(#_import);                                                                            \
+					    _func = BGFX_CAST_FUNCTION(_proto, emscripten_webgl2_get_proc_address(#_import));                                                        \
 					BX_TRACE("\t%p " #_func " (" #_import ")", _func);                                                                                           \
 					BGFX_FATAL(_optional || NULL != _func, Fatal::UnableToInitialize, "Failed to create WebGL/OpenGLES context. GetProcAddress(\"%s\")", #_import); \
 				}                                                                                                                                                \

--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -106,7 +106,7 @@ namespace bgfx { namespace gl
 		m_opengl32dll = bx::dlopen("opengl32.dll");
 		BGFX_FATAL(NULL != m_opengl32dll, Fatal::UnableToInitialize, "Failed to load opengl32.dll.");
 
-		wglGetProcAddress = (PFNWGLGETPROCADDRESSPROC)bx::dlsym(m_opengl32dll, "wglGetProcAddress");
+		wglGetProcAddress = BGFX_CAST_FUNCTION(PFNWGLGETPROCADDRESSPROC, bx::dlsym(m_opengl32dll, "wglGetProcAddress"));
 		BGFX_FATAL(NULL != wglGetProcAddress, Fatal::UnableToInitialize, "Failed get wglGetProcAddress.");
 
 
@@ -136,13 +136,13 @@ namespace bgfx { namespace gl
 
 		if (NULL != g_platformData.nwh && NULL == g_platformData.context )
 		{
-			wglMakeCurrent = (PFNWGLMAKECURRENTPROC)bx::dlsym(m_opengl32dll, "wglMakeCurrent");
+			wglMakeCurrent = BGFX_CAST_FUNCTION(PFNWGLMAKECURRENTPROC, bx::dlsym(m_opengl32dll, "wglMakeCurrent"));
 			BGFX_FATAL(NULL != wglMakeCurrent, Fatal::UnableToInitialize, "Failed get wglMakeCurrent.");
 
-			wglCreateContext = (PFNWGLCREATECONTEXTPROC)bx::dlsym(m_opengl32dll, "wglCreateContext");
+			wglCreateContext = BGFX_CAST_FUNCTION(PFNWGLCREATECONTEXTPROC, bx::dlsym(m_opengl32dll, "wglCreateContext"));
 			BGFX_FATAL(NULL != wglCreateContext, Fatal::UnableToInitialize, "Failed get wglCreateContext.");
 
-			wglDeleteContext = (PFNWGLDELETECONTEXTPROC)bx::dlsym(m_opengl32dll, "wglDeleteContext");
+			wglDeleteContext = BGFX_CAST_FUNCTION(PFNWGLDELETECONTEXTPROC, bx::dlsym(m_opengl32dll, "wglDeleteContext"));
 			BGFX_FATAL(NULL != wglDeleteContext, Fatal::UnableToInitialize, "Failed get wglDeleteContext.");
 
 			m_hdc = GetDC( (HWND)g_platformData.nwh);
@@ -171,10 +171,10 @@ namespace bgfx { namespace gl
 
 			HGLRC context = createContext(hdc);
 
-			wglGetExtensionsStringARB  = (PFNWGLGETEXTENSIONSSTRINGARBPROC)wglGetProcAddress("wglGetExtensionsStringARB");
-			wglChoosePixelFormatARB    = (PFNWGLCHOOSEPIXELFORMATARBPROC)wglGetProcAddress("wglChoosePixelFormatARB");
-			wglCreateContextAttribsARB = (PFNWGLCREATECONTEXTATTRIBSARBPROC)wglGetProcAddress("wglCreateContextAttribsARB");
-			wglSwapIntervalEXT         = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
+			wglGetExtensionsStringARB  = BGFX_CAST_FUNCTION(PFNWGLGETEXTENSIONSSTRINGARBPROC, wglGetProcAddress("wglGetExtensionsStringARB"));
+			wglChoosePixelFormatARB    = BGFX_CAST_FUNCTION(PFNWGLCHOOSEPIXELFORMATARBPROC, wglGetProcAddress("wglChoosePixelFormatARB"));
+			wglCreateContextAttribsARB = BGFX_CAST_FUNCTION(PFNWGLCREATECONTEXTATTRIBSARBPROC, wglGetProcAddress("wglCreateContextAttribsARB"));
+			wglSwapIntervalEXT         = BGFX_CAST_FUNCTION(PFNWGLSWAPINTERVALEXTPROC, wglGetProcAddress("wglSwapIntervalEXT"));
 
 			if (NULL != wglGetExtensionsStringARB)
 			{
@@ -391,10 +391,10 @@ namespace bgfx { namespace gl
 				{ \
 					if (NULL == _func) \
 					{ \
-						_func = (_proto)wglGetProcAddress(#_import); \
+						_func = BGFX_CAST_FUNCTION(_proto, wglGetProcAddress(#_import)); \
 						if (_func == NULL) \
 						{ \
-							_func = (_proto)bx::dlsym(m_opengl32dll, #_import); \
+							_func = BGFX_CAST_FUNCTION(_proto, bx::dlsym(m_opengl32dll, #_import)); \
 							BX_TRACE("    %p " #_func " (" #_import ")", _func); \
 						} \
 						else \


### PR DESCRIPTION
gcc (8.2.0) reports a lot of `cast-function-type` warnings like:
```
../../../src/glcontext_wgl.cpp:394:49: warning: cast between incompatible function types from 'PROC' {aka 'long long int (*)()'} to 'bgfx::gl::PFNGLVIEWPORTPROC' {aka 'void (*)(int, int, int, int)'} [-Wcast-function-type]
       _func = (_proto)wglGetProcAddress(#_import); \
                                                 ^
../../../src/glimports.h:12:20: note: in expansion of macro 'GL_EXTENSION'
 # define GL_IMPORT GL_EXTENSION
                    ^~~~~~~~~~~~
../../../src/glimports.h:25:51: note: in expansion of macro 'GL_IMPORT'
 #define GL_IMPORT______(_optional, _proto, _func) GL_IMPORT(_optional, _proto, _func, _func)
                                                   ^~~~~~~~~
../../../src/glimports.h:417:1: note: in expansion of macro 'GL_IMPORT______'
 GL_IMPORT______(false, PFNGLVIEWPORTPROC,                          glViewport);
```

This patch add a macro `BGFX_CAST_FUNCTION` to avoid these warnings.

From the documentation of GCC 9.1.0:  https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/Warning-Options.html

> -Wcast-function-type
>
> Warn when a function pointer is cast to an incompatible function pointer. In a cast involving function types with a variable argument list only the types of initial arguments that are provided are considered. Any parameter of pointer-type matches any other pointer-type. Any benign differences in integral types are ignored, like int vs. long on ILP32 targets. Likewise type qualifiers are ignored. The function type void (*) (void) is special and matches everything, which can be used to suppress this warning. In a cast involving pointer to member types this warning warns whenever the type cast is changing the pointer to member type. This warning is enabled by -Wextra.