### PR TITLE
fix gcc warnings

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -665,6 +665,7 @@ namespace bgfx { namespace d3d11
 			, m_ags(NULL)
 			, m_featureLevel(D3D_FEATURE_LEVEL(0) )
 			, m_swapChain(NULL)
+			, m_needPresent(false)
 			, m_lost(false)
 			, m_numWindows(0)
 			, m_device(NULL)
@@ -686,7 +687,6 @@ namespace bgfx { namespace d3d11
 			, m_rtMsaa(false)
 			, m_timerQuerySupport(false)
 			, m_directAccessSupport(false)
-			, m_needPresent(false)
 		{
 			m_fbh.idx = kInvalidHandle;
 			bx::memSet(&m_scd, 0, sizeof(m_scd) );

--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -676,8 +676,6 @@ namespace bgfx { namespace hlsl
 			if (_firstPass
 			&&  unusedUniforms.size() > 0)
 			{
-				const size_t strLength = bx::strLen("uniform");
-
 				// first time through, we just find unused uniforms and get rid of them
 				std::string output;
 				bx::LineReader reader(_code.c_str() );


### PR DESCRIPTION
Two warnings : 
```
../../../src/renderer_d3d11.cpp: In constructor 'bgfx::d3d11::RendererContextD3D11::RendererContextD3D11()':
../../../src/renderer_d3d11.cpp:3532:8: warning: 'bgfx::d3d11::RendererContextD3D11::m_directAccessSupport' will be initialized after [-Wreorder]
   bool m_directAccessSupport;
        ^~~~~~~~~~~~~~~~~~~~~
../../../src/renderer_d3d11.cpp:3468:8: warning:   'bool bgfx::d3d11::RendererContextD3D11::m_needPresent' [-Wreorder]
   bool m_needPresent;
        ^~~~~~~~~~~~~
../../../src/renderer_d3d11.cpp:660:3: warning:   when initialized here [-Wreorder]
   RendererContextD3D11()
   ^~~~~~~~~~~~~~~~~~~~
```

```
../../../tools/shaderc/shaderc_hlsl.cpp: In function 'bool bgfx::hlsl::compile(const bgfx::Options&, uint32_t, const string&, bx::WriterI*, bool)':
../../../tools/shaderc/shaderc_hlsl.cpp:679:18: warning: unused variable 'strLength' [-Wunused-variable]
     const size_t strLength = bx::strLen("uniform");
                  ^~~~~~~~~
```
