### PR TITLE
Fix Windows ARM build

### DIFF
--- a/examples/common/entry/entry_windows.cpp
+++ b/examples/common/entry/entry_windows.cpp
@@ -23,6 +23,7 @@
 #include <windows.h>
 #include <windowsx.h>
 #include <xinput.h>
+#include <shellapi.h>
 
 #ifndef XINPUT_GAMEPAD_GUIDE
 #	define XINPUT_GAMEPAD_GUIDE 0x400


### PR DESCRIPTION
`HDROP` is defined in `shellapi.h` which is needed.