### PR TITLE
fix error when create backbuffer with msaa and srgb format

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1087,7 +1087,12 @@ namespace bgfx { namespace d3d11
 							desc.Height     = m_scd.height;
 							desc.MipLevels  = 1;
 							desc.ArraySize  = 1;
-							desc.Format     = m_scd.format;
+							/*
+							* According to https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/converting-data-color-space ,
+							* ONLY the backbuffer from swapchain can be created without *_SRGB format, custom backbuffer should be created the same
+							* format as well as render target view.
+							*/
+							desc.Format     = (m_resolution.reset & BGFX_RESET_SRGB_BACKBUFFER) ? s_textureFormat[m_resolution.format].m_fmtSrgb : s_textureFormat[m_resolution.format].m_fmt;
 							desc.SampleDesc = m_scd.sampleDesc;
 							desc.Usage      = D3D11_USAGE_DEFAULT;
 							desc.BindFlags  = D3D11_BIND_RENDER_TARGET;
@@ -2461,7 +2466,7 @@ namespace bgfx { namespace d3d11
 						desc.Height     = m_scd.height;
 						desc.MipLevels  = 1;
 						desc.ArraySize  = 1;
-						desc.Format     = m_scd.format;
+						desc.Format     = (m_resolution.reset & BGFX_RESET_SRGB_BACKBUFFER) ? s_textureFormat[m_resolution.format].m_fmtSrgb : s_textureFormat[m_resolution.format].m_fmt;
 						desc.SampleDesc = m_scd.sampleDesc;
 						desc.Usage      = D3D11_USAGE_DEFAULT;
 						desc.BindFlags  = D3D11_BIND_RENDER_TARGET;


### PR DESCRIPTION
when calling bgfx::init with reset flags that have msaa and sRGB enable, it will casue an D3D error.

the reason is only back buffer from swapchain can create different format with render target view. see： 
https://docs.microsoft.com/en-us/windows/win32/direct3ddxgi/converting-data-color-space

> You can use the ID3D11Device::CreateRenderTargetView method to create DXGI_FORMAT_*_SRGB views on back buffers from a swap chain that you create only with a DXGI_FORMAT_*_UNORM format. This is **a special exception** to the rule for creating render-target views, which states that you can use a different format with ID3D11Device::CreateRenderTargetView only if you created the resource that you want to view with DXGI_FORMAT_*_TYPELESS.

