### PR TITLE
Fix build for mingwgcc

### DIFF
--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -171,10 +171,10 @@ namespace bgfx { namespace gl
 
 			HGLRC context = createContext(hdc);
 
-			wglGetExtensionsStringARB  = bx::functionCast<PFNWGLGETEXTENSIONSSTRINGARBPROC >(wglGetProcAddress("wglGetExtensionsStringARB") );
-			wglChoosePixelFormatARB    = bx::functionCast<PFNWGLCHOOSEPIXELFORMATARBPROC   >(wglGetProcAddress("wglChoosePixelFormatARB") );
-			wglCreateContextAttribsARB = bx::functionCast<PFNWGLCREATECONTEXTATTRIBSARBPROC>(wglGetProcAddress("wglCreateContextAttribsARB") );
-			wglSwapIntervalEXT         = bx::functionCast<PFNWGLSWAPINTERVALEXTPROC        >(wglGetProcAddress("wglSwapIntervalEXT") );
+			wglGetExtensionsStringARB  = bx::functionCast<PFNWGLGETEXTENSIONSSTRINGARBPROC >((void *)wglGetProcAddress("wglGetExtensionsStringARB") );
+			wglChoosePixelFormatARB    = bx::functionCast<PFNWGLCHOOSEPIXELFORMATARBPROC   >((void *)wglGetProcAddress("wglChoosePixelFormatARB") );
+			wglCreateContextAttribsARB = bx::functionCast<PFNWGLCREATECONTEXTATTRIBSARBPROC>((void *)wglGetProcAddress("wglCreateContextAttribsARB") );
+			wglSwapIntervalEXT         = bx::functionCast<PFNWGLSWAPINTERVALEXTPROC        >((void *)wglGetProcAddress("wglSwapIntervalEXT") );
 
 			if (NULL != wglGetExtensionsStringARB)
 			{
@@ -392,7 +392,7 @@ namespace bgfx { namespace gl
 		{                                                                                      \
 			if (NULL == _func)                                                                 \
 			{                                                                                  \
-				_func = bx::functionCast<_proto>(wglGetProcAddress(#_import) );                \
+				_func = bx::functionCast<_proto>((void *)wglGetProcAddress(#_import) );        \
 				if (NULL == _func)                                                             \
 				{                                                                              \
 					_func = bx::dlsym<_proto>(m_opengl32dll, #_import);                        \


### PR DESCRIPTION
`wglGetProcAddress` returns `PROC` rather than `void *`

```
../../../src/glimports.h:451:1: ../../../../bx/include/bx/inline/bx.inl:37:26:note:  in expansion of macro 'note: GL_IMPORT_EXT__  template argument deduction/substitution failed:
'
 ../../../src/glcontext_wgl.cpp:395:55:GL_IMPORT_EXT__ (true,  PFNGLGENFRAMEBUFFERSPROC,                   glGenFramebuffers);
 note: ^~~~~~~~~~~~~~~  cannot convert '
bgfx::gl::wglGetProcAddress(((const char*)"glGenFramebuffersEXT"))' (type 'PROC../../../src/glcontext_wgl.cpp:395:66:' {aka ' long long int (*)()error: '}) to type 'no matching function for call to 'void*functionCast<bgfx::gl::PFNGLDELETEFRAMEBUFFERSPROC>(PROC)'
     _func = bx::functionCast<_proto>('
     _func = bx::functionCast<_proto>(wglGetProcAddress(#_import) wglGetProcAddress(#_import)) );                \
                                      ;                \
                                                                  ~~~~~~~~~~~~~~~~~^~~~~~~~~~^
```