### PR TITLE
Use getResourceDesc instead of GetDesc, See #1239

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -2078,11 +2078,11 @@ namespace bgfx { namespace d3d12
 						? s_textureFormat[m_resolution.format].m_fmtSrgb
 						: s_textureFormat[m_resolution.format].m_fmt;
 
-					if (1 < m_backBufferColor[ii]->GetDesc().DepthOrArraySize)
+					if (1 < getResourceDesc(m_backBufferColor[ii]).DepthOrArraySize)
 					{
 						rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
 						rtvDesc.Texture2DArray.FirstArraySlice = 0;
-						rtvDesc.Texture2DArray.ArraySize = m_backBufferColor[ii]->GetDesc().DepthOrArraySize;
+						rtvDesc.Texture2DArray.ArraySize = getResourceDesc(m_backBufferColor[ii]).DepthOrArraySize;
 						rtvDesc.Texture2DArray.MipSlice = 0;
 						rtvDesc.Texture2DArray.PlaneSlice = 0;
 					}

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -2080,7 +2080,8 @@ namespace bgfx { namespace d3d12
 
 					if (1 < getResourceDesc(m_backBufferColor[ii]).DepthOrArraySize)
 					{
-						rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2DARRAY;
+						rtvDesc.ViewDimension = (NULL == m_msaaRt) ?
+							D3D12_RTV_DIMENSION_TEXTURE2DARRAY : D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY;
 						rtvDesc.Texture2DArray.FirstArraySlice = 0;
 						rtvDesc.Texture2DArray.ArraySize = getResourceDesc(m_backBufferColor[ii]).DepthOrArraySize;
 						rtvDesc.Texture2DArray.MipSlice = 0;
@@ -2088,7 +2089,8 @@ namespace bgfx { namespace d3d12
 					}
 					else
 					{
-						rtvDesc.ViewDimension = D3D12_RTV_DIMENSION_TEXTURE2D;
+						rtvDesc.ViewDimension = (NULL == m_msaaRt) ?
+							D3D12_RTV_DIMENSION_TEXTURE2D : D3D12_RTV_DIMENSION_TEXTURE2DMS;
 						rtvDesc.Texture2D.MipSlice = 0;
 						rtvDesc.Texture2D.PlaneSlice = 0;
 					}


### PR DESCRIPTION
https://github.com/bkaradzic/bgfx/pull/2042

`ID3D12Resource::GetDesc` has an issue on gcc . This is an old issue, see #1239 .
