### PR TITLE
gcc fix warning

### DIFF
--- a/examples/common/font/font_manager.h
+++ b/examples/common/font/font_manager.h
@@ -114,8 +114,8 @@ struct GlyphInfo
 	uint16_t regionIndex;
 };
 
-BGFX_HANDLE(TrueTypeHandle);
-BGFX_HANDLE(FontHandle);
+BGFX_HANDLE(TrueTypeHandle)
+BGFX_HANDLE(FontHandle)
 
 class FontManager
 {

--- a/examples/common/font/text_buffer_manager.h
+++ b/examples/common/font/text_buffer_manager.h
@@ -8,7 +8,7 @@
 
 #include "font_manager.h"
 
-BGFX_HANDLE(TextBufferHandle);
+BGFX_HANDLE(TextBufferHandle)
 
 #define MAX_TEXT_BUFFER_COUNT 64
 


### PR DESCRIPTION
error: extra ‘;’ [-Werror=pedantic]