### PR TITLE
Fix various Linux build link issues

### DIFF
--- a/scripts/geometryc.lua
+++ b/scripts/geometryc.lua
@@ -43,6 +43,11 @@ project "geometryc"
 			"psapi",
 		}
 
+	configuration { "linux*" }
+		links {
+			"dl",
+		}
+
 	configuration {}
 
 	strip()

--- a/scripts/geometryv.lua
+++ b/scripts/geometryv.lua
@@ -120,11 +120,12 @@ project ("geometryv")
 	configuration { "wasm*" }
 		kind "ConsoleApp"
 
-	configuration { "linux-* or freebsd" }
+	configuration { "linux* or freebsd" }
 		links {
 			"X11",
 			"GL",
 			"pthread",
+			"dl"
 		}
 
 	configuration { "rpi" }

--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -659,6 +659,7 @@ project "shaderc"
 	configuration { "osx or linux*" }
 		links {
 			"pthread",
+			"dl"
 		}
 
 	configuration {}

--- a/scripts/texturec.lua
+++ b/scripts/texturec.lua
@@ -41,4 +41,9 @@ project "texturec"
 			"psapi",
 		}
 
+	configuration { "linux*" }
+		links {
+			"dl",
+		}
+
 	configuration {}

--- a/scripts/texturev.lua
+++ b/scripts/texturev.lua
@@ -120,11 +120,12 @@ project ("texturev")
 	configuration { "wasm*" }
 		kind "ConsoleApp"
 
-	configuration { "linux-* or freebsd" }
+	configuration { "linux* or freebsd" }
 		links {
 			"X11",
 			"GL",
 			"pthread",
+			"dl"
 		}
 
 	configuration { "rpi" }


### PR DESCRIPTION
This patch fixes a series of missing linker flags that were detected while building BGFX with CMake.