### PR TITLE
Add opt-in flag for GL tex read back emulation

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2757,7 +2757,7 @@ namespace bgfx { namespace gl
 					: 0
 					;
 
-				g_caps.supported |= m_readBackSupported
+				g_caps.supported |= (m_readBackSupported || BX_ENABLED(BGFX_GL_CONFIG_TEXTURE_READ_BACK_EMULATION))
 					? BGFX_CAPS_TEXTURE_READ_BACK
 					: 0
 					;
@@ -3256,7 +3256,7 @@ namespace bgfx { namespace gl
 
 				GL_CHECK(glBindTexture(texture.m_target, 0) );
 			}
-			else
+			else if (BX_ENABLED(BGFX_GL_CONFIG_TEXTURE_READ_BACK_EMULATION))
 			{
 				const TextureGL& texture = m_textures[_handle.idx];
 				const bool compressed    = bimg::isCompressed(bimg::TextureFormat::Enum(texture.m_textureFormat) );

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -43,6 +43,10 @@
 #	define BGFX_GL_CONFIG_BLIT_EMULATION 0
 #endif // BGFX_GL_CONFIG_BLIT_EMULATION
 
+#ifndef BGFX_GL_CONFIG_TEXTURE_READ_BACK_EMULATION
+#	define BGFX_GL_CONFIG_TEXTURE_READ_BACK_EMULATION 0
+#endif // BGFX_GL_CONFIG_TEXTURE_READ_BACK_EMULATION
+
 #define BGFX_GL_PROFILER_BEGIN(_view, _abgr)                                               \
 	BX_MACRO_BLOCK_BEGIN                                                                   \
 		GL_CHECK(glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, s_viewName[view]) ); \


### PR DESCRIPTION
This change is for coherency with the backend's implementation of [readTexture()](https://github.com/goodartistscopy/bgfx/blob/1ef01f42f4e0dbe96b2536f68955a86baad097a3/src/renderer_gl.cpp#L3228), which always succeed. Right now the else block in this function (the "fallback") is dead code because of the protection in [bgfx::readTexture()](https://github.com/goodartistscopy/bgfx/blob/1ef01f42f4e0dbe96b2536f68955a86baad097a3/src/bgfx.cpp#L4617).

Maybe a cleaner alternative is to acknowledge that the else block is really an emulation, and introduce a compile flag similar to BGFX_GL_CONFIG_BLIT_EMULATION.
So we would have something like this instead
```
g_caps.supported |= (m_readBackSupported || BX_ENABLED(BGFX_GL_CONFIG_TEXTURE_READ_BACK_EMULATION))
    ? BGFX_CAPS_TEXTURE_READ_BACK
    : 0
    ;
```
I can do that if you think it's better.