### PR TITLE
[shaderc] Metal and SPIR-V disassembly output format option uses associated SPIRV Target Env.

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -903,7 +903,7 @@ namespace bgfx
 				"           s_5\n"
 				"           metal\n"
 				"           pssl\n"
-				"           spirv              Alias for spirv10-10. \n"
+				"           spirv                Alias for spirv10-10. \n"
 				"           spirv10-10\n"
 				"           spirv13-11\n"
 				"           spirv14-11\n"

--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -909,7 +909,7 @@ namespace bgfx { namespace metal
 					{
 						if (g_verbose)
 						{
-							glslang::SpirvToolsDisassemble(std::cout, spirv);
+							glslang::SpirvToolsDisassemble(std::cout, spirv, SPV_ENV_VULKAN_1_0);
 						}
 
 						spirv_cross::CompilerMSL msl(std::move(spirv) );

--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -1041,7 +1041,7 @@ namespace bgfx { namespace spirv
 
 					if (g_verbose)
 					{
-						glslang::SpirvToolsDisassemble(std::cout, spirv);
+						glslang::SpirvToolsDisassemble(std::cout, spirv, getSpirvTargetVersion(_version) );
 					}
 
 					// Loop through the separate_images, and extract the uniform names:


### PR DESCRIPTION
This aims to resolve: https://github.com/bkaradzic/bgfx/issues/2285

Updates the `--verbose` option's call to `glslang::SpirvToolsDisassemble` to output based on the spirv target env context being used by Metal and SPIRV.

Also a small alignment fix up in the shaderc help string.