### PR TITLE
renderer_d3d12.h: Update __mingw_uuidof declaration for C++17

### DIFF
--- a/src/renderer_d3d12.h
+++ b/src/renderer_d3d12.h
@@ -20,8 +20,13 @@
 
 #if defined(__MINGW32__) // BK - temp workaround for MinGW until I nuke d3dx12 usage.
 extern "C++" {
+#if __cpp_constexpr >= 200704L && __cpp_inline_variables >= 201606L
+	__extension__ template<typename Ty>
+	constexpr const GUID& __mingw_uuidof();
+#else
 	__extension__ template<typename Ty>
 	const GUID& __mingw_uuidof();
+#endif
 
 	template<>
 	const GUID& __mingw_uuidof<ID3D12Device>()


### PR DESCRIPTION
This allows bgfx to be built as C++17 with MinGW tools.