### PR TITLE
Use emscripten_webgl2_get_proc_address for WebGL2 context

### DIFF
--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -134,7 +134,7 @@ namespace bgfx { namespace gl
 
 				SwapChainGL* swapChain = BX_NEW(g_allocator, SwapChainGL)(context, canvas);
 
-				import(1);
+				import(version);
 
 				return swapChain;
 			}


### PR DESCRIPTION
There is an issue that when compiling wasm with BGFX_CONFIG_RENDERER_OPENGLES_MIN_VERSION=30 (to target WebGL2), bgfx will have runtime error(function signature mismatch), and this will fix it.