### PR TITLE
Shaderc OpenGL fixes.

### DIFF
--- a/examples/31-rsm/fs_rsm_lbuffer.sc
+++ b/examples/31-rsm/fs_rsm_lbuffer.sc
@@ -29,7 +29,7 @@ vec3 clipToWorld(mat4 _invViewProj, vec3 _clipPos)
 
 void main()
 {
-#if BGFX_SHADER_LANGUAGE_HLSL && (BGFX_SHADER_LANGUAGE_HLSL < 4)
+#if BGFX_SHADER_LANGUAGE_HLSL && (BGFX_SHADER_LANGUAGE_HLSL < 400)
 	vec2 texCoord = gl_FragCoord.xy * u_viewTexel.xy + u_viewTexel.xy * vec2_splat(0.5);
 #else
 	vec2 texCoord = gl_FragCoord.xy * u_viewTexel.xy;

--- a/examples/31-rsm/fs_rsm_shadow.sc
+++ b/examples/31-rsm/fs_rsm_shadow.sc
@@ -11,7 +11,7 @@ uniform vec4 u_tint;
 
 void main()
 {
-#if BGFX_SHADER_LANGUAGE_HLSL && (BGFX_SHADER_LANGUAGE_HLSL < 4)
+#if BGFX_SHADER_LANGUAGE_HLSL && (BGFX_SHADER_LANGUAGE_HLSL < 400)
 	vec2 texCoord = gl_FragCoord.xy * u_viewTexel.xy + u_viewTexel.xy * vec2_splat(0.5);
 #else
 	vec2 texCoord = gl_FragCoord.xy * u_viewTexel.xy;

--- a/examples/common/nanovg/vs_nanovg_fill.sc
+++ b/examples/common/nanovg/vs_nanovg_fill.sc
@@ -3,7 +3,7 @@ $output v_position, v_texcoord0
 
 #include "../common.sh"
 
-#define NEED_HALF_TEXEL (BGFX_SHADER_LANGUAGE_HLSL < 4)
+#define NEED_HALF_TEXEL (BGFX_SHADER_LANGUAGE_HLSL < 400)
 
 uniform vec4 u_viewSize;
 

--- a/examples/common/shaderlib.sh
+++ b/examples/common/shaderlib.sh
@@ -387,7 +387,7 @@ vec3 fixCubeLookup(vec3 _v, float _lod, float _topLevelCubeSize)
 
 vec2 texture2DBc5(sampler2D _sampler, vec2 _uv)
 {
-#if BGFX_SHADER_LANGUAGE_HLSL && BGFX_SHADER_LANGUAGE_HLSL <= 3
+#if BGFX_SHADER_LANGUAGE_HLSL && BGFX_SHADER_LANGUAGE_HLSL <= 300
 	return texture2D(_sampler, _uv).yx;
 #else
 	return texture2D(_sampler, _uv).xy;

--- a/src/bgfx_shader.sh
+++ b/src/bgfx_shader.sh
@@ -563,6 +563,8 @@ vec4  mod(vec4  _a, vec4  _b) { return _a - _b * floor(_a / _b); }
 #		define texture2D(_sampler, _coord)      texture(_sampler, _coord)
 #		define texture2DArray(_sampler, _coord) texture(_sampler, _coord)
 #		define texture3D(_sampler, _coord)      texture(_sampler, _coord)
+#		define texture2DLod(_sampler, _coord_, _lod)               textureLod(_sampler, _coord, _lod)
+#		define texture2DLodOffset(_sampler, _coord, _lod, _offset) textureLodOffset(_sampler, _coord, _lod, _offset)
 #	endif // BGFX_SHADER_LANGUAGE_GLSL >= 130
 
 vec3 instMul(vec3 _vec, mat3 _mtx) { return mul(_vec, _mtx); }

--- a/src/bgfx_shader.sh
+++ b/src/bgfx_shader.sh
@@ -12,7 +12,7 @@
 
 #ifndef __cplusplus
 
-#if BGFX_SHADER_LANGUAGE_HLSL > 3
+#if BGFX_SHADER_LANGUAGE_HLSL > 300
 #	define BRANCH [branch]
 #	define LOOP   [loop]
 #	define UNROLL [unroll]
@@ -20,13 +20,13 @@
 #	define BRANCH
 #	define LOOP
 #	define UNROLL
-#endif // BGFX_SHADER_LANGUAGE_HLSL > 3
+#endif // BGFX_SHADER_LANGUAGE_HLSL > 300
 
-#if BGFX_SHADER_LANGUAGE_HLSL > 3 && BGFX_SHADER_TYPE_FRAGMENT
+#if BGFX_SHADER_LANGUAGE_HLSL > 300 && BGFX_SHADER_TYPE_FRAGMENT
 #	define EARLY_DEPTH_STENCIL [earlydepthstencil]
 #else
 #	define EARLY_DEPTH_STENCIL
-#endif // BGFX_SHADER_LANGUAGE_HLSL > 3 && BGFX_SHADER_TYPE_FRAGMENT
+#endif // BGFX_SHADER_LANGUAGE_HLSL > 300 && BGFX_SHADER_TYPE_FRAGMENT
 
 #if BGFX_SHADER_LANGUAGE_GLSL
 #	define ARRAY_BEGIN(_type, _name, _count) _type _name[_count] = _type[](
@@ -52,19 +52,19 @@
 
 // To be able to patch the uav registers on the DXBC SPDB Chunk (D3D11 renderer) the whitespaces around
 // '_type[_reg]' are necessary. This only affects shaders with debug info (i.e., those that have the SPDB Chunk).
-#	if BGFX_SHADER_LANGUAGE_HLSL > 4
+#	if BGFX_SHADER_LANGUAGE_HLSL > 400
 #		define REGISTER(_type, _reg) register( _type[_reg] )
 #	else
 #		define REGISTER(_type, _reg) register(_type ## _reg)
 #	endif // BGFX_SHADER_LANGUAGE_HLSL
 
-#	if BGFX_SHADER_LANGUAGE_HLSL > 3 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
-#		if BGFX_SHADER_LANGUAGE_HLSL > 4 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
+#	if BGFX_SHADER_LANGUAGE_HLSL > 300 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
+#		if BGFX_SHADER_LANGUAGE_HLSL > 400 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
 #			define dFdxCoarse(_x) ddx_coarse(_x)
 #			define dFdxFine(_x)   ddx_fine(_x)
 #			define dFdyCoarse(_y) ddy_coarse(-_y)
 #			define dFdyFine(_y)   ddy_fine(-_y)
-#		endif // BGFX_SHADER_LANGUAGE_HLSL > 4
+#		endif // BGFX_SHADER_LANGUAGE_HLSL > 400
 
 #		if BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
 float intBitsToFloat(int   _x) { return asfloat(_x); }
@@ -482,19 +482,12 @@ float bgfxShadow2DProj(sampler2DShadow _sampler, vec4 _coord)
 #		define SAMPLERCUBE(_name, _reg) uniform samplerCUBE _name : REGISTER(s, _reg)
 #		define textureCube(_sampler, _coord) texCUBE(_sampler, _coord)
 
-#		if BGFX_SHADER_LANGUAGE_HLSL == 2
-#			define texture2DLod(_sampler, _coord, _level) tex2D(_sampler, (_coord).xy)
-#			define texture2DGrad(_sampler, _coord, _dPdx, _dPdy) tex2D(_sampler, _coord)
-#			define texture3DLod(_sampler, _coord, _level) tex3D(_sampler, (_coord).xyz)
-#			define textureCubeLod(_sampler, _coord, _level) texCUBE(_sampler, (_coord).xyz)
-#		else
-#			define texture2DLod(_sampler, _coord, _level) tex2Dlod(_sampler, vec4( (_coord).xy, 0.0, _level) )
-#			define texture2DGrad(_sampler, _coord, _dPdx, _dPdy) tex2Dgrad(_sampler, _coord, _dPdx, _dPdy)
-#			define texture3DLod(_sampler, _coord, _level) tex3Dlod(_sampler, vec4( (_coord).xyz, _level) )
-#			define textureCubeLod(_sampler, _coord, _level) texCUBElod(_sampler, vec4( (_coord).xyz, _level) )
-#		endif // BGFX_SHADER_LANGUAGE_HLSL == 2
+#		define texture2DLod(_sampler, _coord, _level) tex2Dlod(_sampler, vec4( (_coord).xy, 0.0, _level) )
+#		define texture2DGrad(_sampler, _coord, _dPdx, _dPdy) tex2Dgrad(_sampler, _coord, _dPdx, _dPdy)
+#		define texture3DLod(_sampler, _coord, _level) tex3Dlod(_sampler, vec4( (_coord).xyz, _level) )
+#		define textureCubeLod(_sampler, _coord, _level) texCUBElod(_sampler, vec4( (_coord).xyz, _level) )
 
-#	endif // BGFX_SHADER_LANGUAGE_HLSL > 3
+#	endif // BGFX_SHADER_LANGUAGE_HLSL > 300
 
 vec3 instMul(vec3 _vec, mat3 _mtx) { return mul(_mtx, _vec); }
 vec3 instMul(mat3 _mtx, vec3 _vec) { return mul(_vec, _mtx); }

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -74,10 +74,10 @@ namespace bgfx
 		ESSL, 310, "310_es",
 		ESSL, 320, "320_es",
 
-		HLSL, 2, "s_3",
+		HLSL, 2, "s_3_0",
 		HLSL, 3, "s_4_0_level",
-		HLSL, 4, "s_4",
-		HLSL, 5, "s_5",
+		HLSL, 4, "s_4_0",
+		HLSL, 5, "s_5_0",
 
 		Metal, 1, "metal",
 		
@@ -2241,7 +2241,7 @@ namespace bgfx
 										bx::stringPrintf(code, "#define varying %s\n"
 											, 'f' == _options.shaderType ? "in" : "out"
 											);
-										bx::stringPrintf(code, "precision mediump float;\n");
+										bx::stringPrintf(code, "precision highp float;\n");
 										bx::stringPrintf(code, "precision highp int;\n");
 									}
 									else

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -89,6 +89,7 @@ namespace bgfx
 		Spirv, 1010, "spirv10-10",
 		Spirv, 1010, "spirv",
 
+		GLSL, 120, "120",
 		GLSL, 130, "130",
 		GLSL, 140, "140",
 		GLSL, 150, "150",
@@ -1010,7 +1011,7 @@ namespace bgfx
 				}
 			}
 			if(profile_id == count) {
-				bx::printf("Unknown profile: %s", profile_opt);
+				bx::printf("Unknown profile: %s\n", profile_opt);
 				return false;
 			}
 		}

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -2393,9 +2393,6 @@ namespace bgfx
 									glsl_profile |= 0x80000000;
 								}
 								compiled = compileGLSLShader(_options, glsl_profile, code, _writer);
-                                if(!compiled) {
-                                    fprintf(stderr, "%s\n", code.c_str());
-                                }
 							}
 						}
 						else

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -1624,13 +1624,6 @@ namespace bgfx
 						}
 					}
 
-					// bgfx shadow2D/Proj behave like EXT_shadow_samplers
-					// not as GLSL language 1.2 specs shadow2D/Proj.
-					preprocessor.writef(
-						"#define shadow2D(_sampler, _coord) bgfxShadow2D(_sampler, _coord).x\n"
-						"#define shadow2DProj(_sampler, _coord) bgfxShadow2DProj(_sampler, _coord).x\n"
-						);
-
 					for (InOut::const_iterator it = shaderInputs.begin(), itEnd = shaderInputs.end(); it != itEnd; ++it)
 					{
 						VaryingMap::const_iterator varyingIt = varyingMap.find(*it);
@@ -2219,15 +2212,8 @@ namespace bgfx
 									if (need130)
 									{
 										bx::stringPrintf(code
-											, "#define bgfxShadow2D(_sampler, _coord)     vec4_splat(texture(_sampler, _coord))\n"
-											  "#define bgfxShadow2DProj(_sampler, _coord) vec4_splat(textureProj(_sampler, _coord))\n"
-											);
-									}
-									else
-									{
-										bx::stringPrintf(code
-											, "#define bgfxShadow2D     shadow2D\n"
-											  "#define bgfxShadow2DProj shadow2DProj\n"
+											, "#define shadow2D(_sampler, _coord)     vec4_splat(texture(_sampler, _coord))\n"
+											  "#define shadow2DProj(_sampler, _coord) vec4_splat(textureProj(_sampler, _coord))\n"
 											);
 									}
 								}
@@ -2312,19 +2298,19 @@ namespace bgfx
 										bx::stringPrintf(code, "#extension GL_OES_texture_3D : enable\n");
 									}
 
-									if ((glsl_profile < 300) && (!bx::findIdentifierMatch(input, s_EXT_shadow_samplers).isEmpty()) )
+									if ((glsl_profile < 300) && (!bx::findIdentifierMatch(input, s_EXT_shadow_samplers).isEmpty()))
 									{
 										bx::stringPrintf(code
 											, "#extension GL_EXT_shadow_samplers : enable\n"
-											  "#define bgfxShadow2D shadow2DEXT\n"
-											  "#define bgfxShadow2DProj shadow2DProjEXT\n"
+											  "#define shadow2D shadow2DEXT\n"
+											  "#define shadow2DProj shadow2DProjEXT\n"
 											);
 									}
 									else
 									{
 										bx::stringPrintf(code
-											, "#define bgfxShadow2D(_sampler, _coord)     vec4_splat(texture(_sampler, _coord))\n"
-											  "#define bgfxShadow2DProj(_sampler, _coord) vec4_splat(textureProj(_sampler, _coord))\n"
+											, "#define shadow2D(_sampler, _coord)     vec4_splat(texture(_sampler, _coord))\n"
+											  "#define shadow2DProj(_sampler, _coord) vec4_splat(textureProj(_sampler, _coord))\n"
 											);
 									}
 
@@ -2342,7 +2328,7 @@ namespace bgfx
 											);
 									}
 
-									if ((profile->lang != ESSL) && (!bx::findIdentifierMatch(input, "gl_FragDepth").isEmpty() ))
+									if ((glsl_profile < 300) && (!bx::findIdentifierMatch(input, "gl_FragDepth").isEmpty() ))
 									{
 										bx::stringPrintf(code
 											, "#extension GL_EXT_frag_depth : enable\n"
@@ -2407,6 +2393,9 @@ namespace bgfx
 									glsl_profile |= 0x80000000;
 								}
 								compiled = compileGLSLShader(_options, glsl_profile, code, _writer);
+                                if(!compiled) {
+                                    fprintf(stderr, "%s\n", code.c_str());
+                                }
 							}
 						}
 						else

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -1601,6 +1601,15 @@ namespace bgfx
 				if (profile->lang == GLSL
 				||  profile->lang == ESSL)
 				{
+					if(profile->lang != ESSL) {
+						// bgfx shadow2D/Proj behave like EXT_shadow_samplers
+						// not as GLSL language 1.2 specs shadow2D/Proj.
+						preprocessor.writef(
+							"#define shadow2D(_sampler, _coord) bgfxShadow2D(_sampler, _coord).x\n"
+							"#define shadow2DProj(_sampler, _coord) bgfxShadow2DProj(_sampler, _coord).x\n"
+							);
+					}
+
 					// gl_FragColor and gl_FragData are deprecated for essl > 300
 					if((profile->lang == ESSL) && (profile->id >= 300))
 					{
@@ -1898,7 +1907,7 @@ namespace bgfx
 
 						if (hasViewportId)
 						{
-							if (d3d > 9)
+							if (profile->id >= 400)
 							{
 								preprocessor.writef(
 									"\tuint gl_ViewportIndex : SV_ViewportArrayIndex;\n"
@@ -1914,7 +1923,7 @@ namespace bgfx
 
 						if (hasLayerId)
 						{
-							if (d3d > 9)
+							if (profile->id >= 400)
 							{
 								preprocessor.writef(
 									"\tuint gl_Layer : SV_RenderTargetArrayIndex;\n"
@@ -2212,8 +2221,15 @@ namespace bgfx
 									if (need130)
 									{
 										bx::stringPrintf(code
-											, "#define shadow2D(_sampler, _coord)     vec4_splat(texture(_sampler, _coord))\n"
-											  "#define shadow2DProj(_sampler, _coord) vec4_splat(textureProj(_sampler, _coord))\n"
+											, "#define bgfxShadow2D(_sampler, _coord)     vec4_splat(texture(_sampler, _coord))\n"
+											  "#define bgfxShadow2DProj(_sampler, _coord) vec4_splat(textureProj(_sampler, _coord))\n"
+											);
+									}
+									else
+									{
+										bx::stringPrintf(code
+											, "#define bgfxShadow2D     shadow2D\n"
+											  "#define bgfxShadow2DProj shader2DProj\n"
 											);
 									}
 								}
@@ -2304,13 +2320,6 @@ namespace bgfx
 											, "#extension GL_EXT_shadow_samplers : enable\n"
 											  "#define shadow2D shadow2DEXT\n"
 											  "#define shadow2DProj shadow2DProjEXT\n"
-											);
-									}
-									else
-									{
-										bx::stringPrintf(code
-											, "#define shadow2D(_sampler, _coord)     vec4_splat(texture(_sampler, _coord))\n"
-											  "#define shadow2DProj(_sampler, _coord) vec4_splat(textureProj(_sampler, _coord))\n"
 											);
 									}
 

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -74,10 +74,9 @@ namespace bgfx
 		ESSL, 310, "310_es",
 		ESSL, 320, "320_es",
 
-		HLSL, 2, "s_3_0",
-		HLSL, 3, "s_4_0_level",
-		HLSL, 4, "s_4_0",
-		HLSL, 5, "s_5_0",
+		HLSL, 300, "s_3_0",
+		HLSL, 400, "s_4_0",
+		HLSL, 500, "s_5_0",
 
 		Metal, 1, "metal",
 		
@@ -1006,7 +1005,7 @@ namespace bgfx
 				}
 				else if((s_profiles[profile_id].lang == HLSL)&& (0 == bx::strCmp(&profile_opt[1], s_profiles[profile_id].name))) {
 					// This test is here to allow hlsl profile names e.g:
-					// cs_4_0, cs_5_0, ps_4_0_level_0, etc...
+					// cs_4_0, gs_5_0, etc...
 					// There's no check to ensure that the profile name matches the shader type set via the cli.
 					// This means that you can pass `hs_5_0` when compiling a fragment shader.
 					break;
@@ -1263,7 +1262,7 @@ namespace bgfx
 					var.m_name.assign(name.getPtr(), name.getTerm() );
 					var.m_semantics.assign(semantics.getPtr(), semantics.getTerm() );
 
-					if ((profile->lang == HLSL && profile->id == 2)
+					if ((profile->lang == HLSL && profile->id < 400)
 					&&  var.m_semantics == "BITANGENT")
 					{
 						var.m_semantics = "BINORMAL";
@@ -1704,7 +1703,7 @@ namespace bgfx
 						);
 
 					if (profile->lang == HLSL
-					&&  profile->id < 4)
+					&&  profile->id < 400)
 					{
 						preprocessor.writef(
 							"#define centroid\n"
@@ -1725,7 +1724,7 @@ namespace bgfx
 						}
 
 						const bool hasFragColor   = !bx::strFind(input, "gl_FragColor").isEmpty();
-						const bool hasFragCoord   = !bx::strFind(input, "gl_FragCoord").isEmpty() || profile->id > 2;
+						const bool hasFragCoord   = !bx::strFind(input, "gl_FragCoord").isEmpty() || profile->id >= 400;
 						const bool hasFragDepth   = !bx::strFind(input, "gl_FragDepth").isEmpty();
 						const bool hasFrontFacing = !bx::strFind(input, "gl_FrontFacing").isEmpty();
 						const bool hasPrimitiveId = !bx::strFind(input, "gl_PrimitiveID").isEmpty();
@@ -1749,10 +1748,10 @@ namespace bgfx
 							// If it has gl_FragData or gl_FragColor, color target at
 							// index 0 exists, otherwise shader is not modifying color
 							// targets.
-							hasFragData[0] |= hasFragColor || profile->id < 3;
+							hasFragData[0] |= hasFragColor || profile->id < 400;
 
 							if (!insert.isEmpty()
-							&&  profile->id < 3
+							&&  profile->id < 400
 							&&  !hasFragColor)
 							{
 								insert = strInsert(const_cast<char*>(insert.getPtr()+1), "\ngl_FragColor = bgfx_VoidFrag;\n");
@@ -1786,7 +1785,7 @@ namespace bgfx
 							}
 						}
 
-						const uint32_t maxRT = profile->id > 2 ? BX_COUNTOF(hasFragData) : 4;
+						const uint32_t maxRT = profile->id >= 400 ? BX_COUNTOF(hasFragData) : 4;
 
 						for (uint32_t ii = 0; ii < BX_COUNTOF(hasFragData); ++ii)
 						{
@@ -1813,7 +1812,7 @@ namespace bgfx
 
 						if (hasFrontFacing)
 						{
-							if (profile->id < 3)
+							if (profile->id < 400)
 							{
 								preprocessor.writef(
 									" \\\n\t%sfloat __vface : VFACE"
@@ -1831,7 +1830,7 @@ namespace bgfx
 
 						if (hasPrimitiveId)
 						{
-							if (profile->id > 2)
+							if (profile->id >= 400)
 							{
 								preprocessor.writef(
 									" \\\n\t%suint gl_PrimitiveID : SV_PrimitiveID"
@@ -1851,7 +1850,7 @@ namespace bgfx
 
 						if (hasFrontFacing)
 						{
-							if (profile->id == 2)
+							if (profile->id < 400)
 							{
 								preprocessor.writef(
 									"#define gl_FrontFacing (__vface >= 0.0)\n"
@@ -1961,7 +1960,7 @@ namespace bgfx
 
 						if (hasVertexId)
 						{
-							if (profile->id > 2)
+							if (profile->id >= 400)
 							{
 								preprocessor.writef(
 									" \\\n\t%suint gl_VertexID : SV_VertexID"
@@ -1977,7 +1976,7 @@ namespace bgfx
 
 						if (hasInstanceId)
 						{
-							if (profile->id > 2)
+							if (profile->id >= 400)
 							{
 								preprocessor.writef(
 									" \\\n\t%suint gl_InstanceID : SV_InstanceID"

--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -62,16 +62,6 @@ namespace bgfx { namespace glsl
 		const char* optimizedShader = glslopt_get_output(shader);
 
 		std::string out;
-		// Preserver #version preamble
-		if('#' == *optimizedShader)
-		{
-			bx::StringView preamble(optimizedShader, bx::strFindNl(optimizedShader).getPtr());
-			if(bx::strCmp(preamble, "#version", 8) == 0)
-			{
-				out.append(preamble.getPtr(), preamble.getLength());
-			}
-		}
-
 		// Trim all directives.
 		while ('#' == *optimizedShader)
 		{
@@ -111,10 +101,6 @@ namespace bgfx { namespace glsl
 		if (target != kGlslTargetMetal)
 		{
 			bx::StringView parse(optimizedShader);
-
-			if(bx::strCmp(parse, "#version", 8) == 0) {
-				parse.set(bx::strFindNl(parse).getPtr(), parse.getTerm());
-			}
 
 			while (!parse.isEmpty() )
 			{

--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -16,23 +16,15 @@ namespace bgfx { namespace glsl
 			: (ch == 'c' ? kGlslOptShaderCompute : kGlslOptShaderVertex);
 
 		glslopt_target target = kGlslTargetOpenGL;
-		switch (_version)
+		if(_version == BX_MAKEFOURCC('M', 'T', 'L', 0))
 		{
-		case BX_MAKEFOURCC('M', 'T', 'L', 0):
 			target = kGlslTargetMetal;
-			break;
-
-		case 2:
-			target = kGlslTargetOpenGLES20;
-			break;
-
-		case 3:
-			target = kGlslTargetOpenGLES30;
-			break;
-
-		default:
+		} else if(_version < 0x80000000) {
 			target = kGlslTargetOpenGL;
-			break;
+		}
+		else {
+			_version &= ~0x80000000;
+			target = (_version >= 300) ? kGlslTargetOpenGLES30 : kGlslTargetOpenGLES20;
 		}
 
 		glslopt_ctx* ctx = glslopt_initialize(target);
@@ -70,10 +62,10 @@ namespace bgfx { namespace glsl
 		const char* optimizedShader = glslopt_get_output(shader);
 
 		// Trim all directives.
-		while ('#' == *optimizedShader)
-		{
-			optimizedShader = bx::strFindNl(optimizedShader).getPtr();
-		}
+		//while ('#' == *optimizedShader)
+		//{
+		//	optimizedShader = bx::strFindNl(optimizedShader).getPtr();												// [todo] no!
+		//}
 
 		{
 			char* code = const_cast<char*>(optimizedShader);

--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -663,7 +663,7 @@ namespace bgfx { namespace hlsl
 		uint16_t attrs[bgfx::Attrib::Count];
 		uint16_t size = 0;
 
-		if (_version <= 2)
+		if (_version < 400)
 		{
 			if (!getReflectionDataD3D9(code, uniforms) )
 			{
@@ -782,7 +782,7 @@ namespace bgfx { namespace hlsl
 			bx::write(_writer, nul);
 		}
 
-		if (_version > 2)
+		if (_version >= 400)
 		{
 			bx::write(_writer, numAttrs);
 			bx::write(_writer, attrs, numAttrs*sizeof(uint16_t) );

--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -663,7 +663,7 @@ namespace bgfx { namespace hlsl
 		uint16_t attrs[bgfx::Attrib::Count];
 		uint16_t size = 0;
 
-		if (_version == 9)
+		if (_version <= 2)
 		{
 			if (!getReflectionDataD3D9(code, uniforms) )
 			{
@@ -782,7 +782,7 @@ namespace bgfx { namespace hlsl
 			bx::write(_writer, nul);
 		}
 
-		if (_version > 9)
+		if (_version > 2)
 		{
 			bx::write(_writer, numAttrs);
 			bx::write(_writer, attrs, numAttrs*sizeof(uint16_t) );


### PR DESCRIPTION
This pull request fixes #2308 by adding a version preamble to the generated glsl shaders.
It also adds profiles for ESSL targets and limits the set of GLSL profiles.
A side effect is that now shaderc help command now lists all the supported profiles.

Some of the ESSL/GLSL profiles added to the cli are not currently supported by glsl-optimizer.