### PR TITLE
GLFW: no need to weak up glfw when polling event from queue

### DIFF
--- a/examples/common/entry/entry_glfw.cpp
+++ b/examples/common/entry/entry_glfw.cpp
@@ -799,13 +799,11 @@ namespace entry
 
 	const Event* poll()
 	{
-		glfwPostEmptyEvent();
 		return s_ctx.m_eventQueue.poll();
 	}
 
 	const Event* poll(WindowHandle _handle)
 	{
-		glfwPostEmptyEvent();
 		return s_ctx.m_eventQueue.poll(_handle);
 	}
 


### PR DESCRIPTION
When we do nothing in `AppI::update()` function. The application will run very very fast, thus call `processEvents()` frequently and thus call `poll()` many many times, which make a lot of `glfwPostEmptyEvent()` call. Then, this may blocking glfw event system.