### PR TITLE
Add TransientIndexType

### DIFF
--- a/examples/03-raymarch/raymarch.cpp
+++ b/examples/03-raymarch/raymarch.cpp
@@ -83,7 +83,7 @@ void renderScreenSpaceQuad(uint8_t _view, bgfx::ProgramHandle _program, float _x
 		vertex[3].m_u = minu;
 		vertex[3].m_v = maxv;
 
-		uint16_t* indices = (uint16_t*)tib.data;
+		bgfx::TransientIndexType* indices = (bgfx::TransientIndexType*)tib.data;
 
 		indices[0] = 0;
 		indices[1] = 2;

--- a/examples/06-bump/bump.cpp
+++ b/examples/06-bump/bump.cpp
@@ -64,7 +64,7 @@ static PosNormalTangentTexcoordVertex s_cubeVertices[24] =
 	{-1.0f,  1.0f, -1.0f, encodeNormalRgba8(-1.0f,  0.0f,  0.0f), 0, 0x7fff, 0x7fff },
 };
 
-static const uint16_t s_cubeIndices[36] =
+static const bgfx::TransientIndexType s_cubeIndices[36] =
 {
 	 0,  2,  1,
 	 1,  2,  3,

--- a/examples/21-deferred/deferred.cpp
+++ b/examples/21-deferred/deferred.cpp
@@ -252,6 +252,7 @@ public:
 				, PosNormalTangentTexcoordVertex::ms_layout
 				, s_cubeIndices
 				, BX_COUNTOF(s_cubeIndices)
+				, false
 				);
 
 		// Create static vertex buffer.
@@ -756,7 +757,7 @@ public:
 								vertex->m_z = 0.0f;
 								vertex->m_abgr = abgr;
 
-								uint16_t* indices = (uint16_t*)tib.data;
+								bgfx::TransientIndexType* indices = (bgfx::TransientIndexType*)tib.data;
 								*indices++ = 0;
 								*indices++ = 1;
 								*indices++ = 1;

--- a/examples/29-debugdraw/debugdraw.cpp
+++ b/examples/29-debugdraw/debugdraw.cpp
@@ -168,7 +168,7 @@ static DdVertex s_bunnyVertices[] =
 	{   6.19167f,    34.497f,   -17.965f },
 };
 
-static const uint16_t s_bunnyTriList[] =
+static const bgfx::TransientIndexType s_bunnyTriList[] =
 {
 	 80,   2,  52,
 	  0, 143,  92,
@@ -812,6 +812,7 @@ public:
 			, s_bunnyVertices
 			, BX_COUNTOF(s_bunnyTriList)
 			, s_bunnyTriList
+			, sizeof(bgfx::TransientIndexType) == sizeof(uint32_t)
 			);
 
 		imguiCreate();

--- a/examples/common/bgfx_utils.cpp
+++ b/examples/common/bgfx_utils.cpp
@@ -259,7 +259,7 @@ bimg::ImageContainer* imageLoad(const char* _filePath, bgfx::TextureFormat::Enum
 	return bimg::imageParse(entry::getAllocator(), data, size, bimg::TextureFormat::Enum(_dstFormat) );
 }
 
-void calcTangents(void* _vertices, uint16_t _numVertices, bgfx::VertexLayout _layout, const uint16_t* _indices, uint32_t _numIndices)
+void calcTangents(void* _vertices, uint16_t _numVertices, bgfx::VertexLayout _layout, const bgfx::TransientIndexType* _indices, uint32_t _numIndices)
 {
 	struct PosTexcoord
 	{
@@ -282,7 +282,7 @@ void calcTangents(void* _vertices, uint16_t _numVertices, bgfx::VertexLayout _la
 
 	for (uint32_t ii = 0, num = _numIndices/3; ii < num; ++ii)
 	{
-		const uint16_t* indices = &_indices[ii*3];
+		const bgfx::TransientIndexType* indices = &_indices[ii*3];
 		uint32_t i0 = indices[0];
 		uint32_t i1 = indices[1];
 		uint32_t i2 = indices[2];
@@ -465,7 +465,7 @@ void Mesh::load(bx::ReaderSeekerI* _reader, bool _ramcopy)
 
 				if (_ramcopy)
 				{
-					group.m_indices = (uint16_t*)BX_ALLOC(allocator, group.m_numIndices*2);
+					group.m_indices = (bgfx::TransientIndexType*)BX_ALLOC(allocator, group.m_numIndices*2);
 					bx::memCopy(group.m_indices, mem->data, mem->size);
 				}
 
@@ -492,7 +492,7 @@ void Mesh::load(bx::ReaderSeekerI* _reader, bool _ramcopy)
 
 				if (_ramcopy)
 				{
-					group.m_indices = (uint16_t*)BX_ALLOC(allocator, group.m_numIndices*2);
+					group.m_indices = (bgfx::TransientIndexType*)BX_ALLOC(allocator, group.m_numIndices*2);
 					bx::memCopy(group.m_indices, mem->data, mem->size);
 				}
 

--- a/examples/common/bgfx_utils.h
+++ b/examples/common/bgfx_utils.h
@@ -35,7 +35,7 @@ bgfx::TextureHandle loadTexture(const char* _name, uint64_t _flags = BGFX_TEXTUR
 bimg::ImageContainer* imageLoad(const char* _filePath, bgfx::TextureFormat::Enum _dstFormat);
 
 ///
-void calcTangents(void* _vertices, uint16_t _numVertices, bgfx::VertexLayout _layout, const uint16_t* _indices, uint32_t _numIndices);
+void calcTangents(void* _vertices, uint16_t _numVertices, bgfx::VertexLayout _layout, const bgfx::TransientIndexType* _indices, uint32_t _numIndices);
 
 /// Returns true if both internal transient index and vertex buffer have
 /// enough space.
@@ -108,7 +108,7 @@ struct Group
 	uint16_t m_numVertices;
 	uint8_t* m_vertices;
 	uint32_t m_numIndices;
-	uint16_t* m_indices;
+	bgfx::TransientIndexType* m_indices;
 	Sphere m_sphere;
 	Aabb m_aabb;
 	Obb m_obb;

--- a/examples/common/bgfx_utils.h
+++ b/examples/common/bgfx_utils.h
@@ -35,7 +35,7 @@ bgfx::TextureHandle loadTexture(const char* _name, uint64_t _flags = BGFX_TEXTUR
 bimg::ImageContainer* imageLoad(const char* _filePath, bgfx::TextureFormat::Enum _dstFormat);
 
 ///
-void calcTangents(void* _vertices, uint16_t _numVertices, bgfx::VertexLayout _layout, const bgfx::TransientIndexType* _indices, uint32_t _numIndices);
+void calcTangents(void* _vertices, uint16_t _numVertices, bgfx::VertexLayout _layout, const void* _indices, uint32_t _numIndices, bool _index32);
 
 /// Returns true if both internal transient index and vertex buffer have
 /// enough space.

--- a/examples/common/debugdraw/debugdraw.cpp
+++ b/examples/common/debugdraw/debugdraw.cpp
@@ -1604,7 +1604,7 @@ struct DebugDrawEncoderImpl
 		m_encoder->submit(m_viewId, program);
 	}
 
-	void draw(bool _lineList, uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices, const uint16_t* _indices)
+	void draw(bool _lineList, uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices, const bgfx::TransientIndexType* _indices)
 	{
 		flush();
 
@@ -1631,23 +1631,23 @@ struct DebugDrawEncoderImpl
 						, 0
 						, _indices
 						, _numIndices
-						, false
+						, sizeof(bgfx::TransientIndexType) == sizeof(uint32_t)
 						);
 
 					bgfx::allocTransientIndexBuffer(&tib, numIndices);
 					bgfx::topologyConvert(
 						  bgfx::TopologyConvert::TriListToLineList
 						, tib.data
-						, numIndices * sizeof(uint16_t)
+						, numIndices * sizeof(bgfx::TransientIndexType)
 						, _indices
 						, _numIndices
-						, false
+						, sizeof(bgfx::TransientIndexType) == sizeof(uint32_t)
 					);
 				}
 				else
 				{
 					bgfx::allocTransientIndexBuffer(&tib, numIndices);
-					bx::memCopy(tib.data, _indices, numIndices * sizeof(uint16_t) );
+					bx::memCopy(tib.data, _indices, numIndices * sizeof(bgfx::TransientIndexType) );
 				}
 
 				m_encoder->setIndexBuffer(&tib);
@@ -2171,7 +2171,7 @@ struct DebugDrawEncoderImpl
 
 				bgfx::TransientIndexBuffer tib;
 				bgfx::allocTransientIndexBuffer(&tib, m_indexPos);
-				bx::memCopy(tib.data, m_indices, m_indexPos * sizeof(uint16_t) );
+				bx::memCopy(tib.data, m_indices, m_indexPos * sizeof(bgfx::TransientIndexType) );
 
 				const Attrib& attrib = m_attrib[m_stack];
 
@@ -2484,12 +2484,12 @@ void DebugDrawEncoder::draw(GeometryHandle _handle)
 	DEBUG_DRAW_ENCODER(draw(_handle) );
 }
 
-void DebugDrawEncoder::drawLineList(uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices, const uint16_t* _indices)
+void DebugDrawEncoder::drawLineList(uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices, const bgfx::TransientIndexType* _indices)
 {
 	DEBUG_DRAW_ENCODER(draw(true, _numVertices, _vertices, _numIndices, _indices) );
 }
 
-void DebugDrawEncoder::drawTriList(uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices, const uint16_t* _indices)
+void DebugDrawEncoder::drawTriList(uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices, const bgfx::TransientIndexType* _indices)
 {
 	DEBUG_DRAW_ENCODER(draw(false, _numVertices, _vertices, _numIndices, _indices) );
 }

--- a/examples/common/debugdraw/debugdraw.cpp
+++ b/examples/common/debugdraw/debugdraw.cpp
@@ -115,7 +115,7 @@ static DebugShapeVertex s_quadVertices[4] =
 
 };
 
-static const uint16_t s_quadIndices[6] =
+static const bgfx::TransientIndexType s_quadIndices[6] =
 {
 	0, 1, 2,
 	1, 3, 2,
@@ -133,7 +133,7 @@ static DebugShapeVertex s_cubeVertices[8] =
 	{ 1.0f, -1.0f, -1.0f, { 0, 0, 0, 0 } },
 };
 
-static const uint16_t s_cubeIndices[36] =
+static const bgfx::TransientIndexType s_cubeIndices[36] =
 {
 	0, 1, 2, // 0
 	1, 3, 2,
@@ -641,7 +641,7 @@ struct DebugDrawShared
 		m_texture  = bgfx::createTexture2D(SPRITE_TEXTURE_SIZE, SPRITE_TEXTURE_SIZE, false, 1, bgfx::TextureFormat::BGRA8);
 
 		void* vertices[DebugMesh::Count] = {};
-		uint16_t* indices[DebugMesh::Count] = {};
+		bgfx::TransientIndexType* indices[DebugMesh::Count] = {};
 		uint16_t stride = DebugShapeVertex::ms_layout.getStride();
 
 		uint32_t startVertex = 0;
@@ -659,10 +659,10 @@ struct DebugDrawShared
 			bx::memSet(vertices[id], 0, numVertices*stride);
 			genSphere(tess, vertices[id], stride);
 
-			uint16_t* trilist = (uint16_t*)BX_ALLOC(m_allocator, numIndices*sizeof(uint16_t) );
+			bgfx::TransientIndexType* trilist = (bgfx::TransientIndexType*)BX_ALLOC(m_allocator, numIndices*sizeof(bgfx::TransientIndexType) );
 			for (uint32_t ii = 0; ii < numIndices; ++ii)
 			{
-				trilist[ii] = uint16_t(ii);
+				trilist[ii] = bgfx::TransientIndexType(ii);
 			}
 
 			uint32_t numLineListIndices = bgfx::topologyConvert(
@@ -671,19 +671,19 @@ struct DebugDrawShared
 				, 0
 				, trilist
 				, numIndices
-				, false
+				, sizeof(bgfx::TransientIndexType) == sizeof(uint32_t)
 				);
-			indices[id] = (uint16_t*)BX_ALLOC(m_allocator, (numIndices + numLineListIndices)*sizeof(uint16_t) );
-			uint16_t* indicesOut = indices[id];
-			bx::memCopy(indicesOut, trilist, numIndices*sizeof(uint16_t) );
+			indices[id] = (bgfx::TransientIndexType*)BX_ALLOC(m_allocator, (numIndices + numLineListIndices)*sizeof(bgfx::TransientIndexType) );
+			bgfx::TransientIndexType* indicesOut = indices[id];
+			bx::memCopy(indicesOut, trilist, numIndices*sizeof(bgfx::TransientIndexType) );
 
 			bgfx::topologyConvert(
 				  bgfx::TopologyConvert::TriListToLineList
 				, &indicesOut[numIndices]
-				, numLineListIndices*sizeof(uint16_t)
+				, numLineListIndices*sizeof(bgfx::TransientIndexType)
 				, trilist
 				, numIndices
-				, false
+				, sizeof(bgfx::TransientIndexType) == sizeof(uint32_t)
 				);
 
 			m_mesh[id].m_startVertex = startVertex;
@@ -711,11 +711,11 @@ struct DebugDrawShared
 			const uint32_t numLineListIndices = num*4;
 
 			vertices[id] = BX_ALLOC(m_allocator, numVertices*stride);
-			indices[id]  = (uint16_t*)BX_ALLOC(m_allocator, (numIndices + numLineListIndices)*sizeof(uint16_t) );
-			bx::memSet(indices[id], 0, (numIndices + numLineListIndices)*sizeof(uint16_t) );
+			indices[id]  = (bgfx::TransientIndexType*)BX_ALLOC(m_allocator, (numIndices + numLineListIndices)*sizeof(bgfx::TransientIndexType) );
+			bx::memSet(indices[id], 0, (numIndices + numLineListIndices)*sizeof(bgfx::TransientIndexType) );
 
 			DebugShapeVertex* vertex = (DebugShapeVertex*)vertices[id];
-			uint16_t* index = indices[id];
+			bgfx::TransientIndexType* index = indices[id];
 
 			vertex[num].m_x = 0.0f;
 			vertex[num].m_y = 0.0f;
@@ -734,19 +734,19 @@ struct DebugDrawShared
 				vertex[ii].m_z = xy[0];
 				vertex[ii].m_indices[0] = 0;
 
-				index[ii*3+0] = uint16_t(num);
-				index[ii*3+1] = uint16_t( (ii+1)%num);
-				index[ii*3+2] = uint16_t(ii);
+				index[ii*3+0] = bgfx::TransientIndexType(num);
+				index[ii*3+1] = bgfx::TransientIndexType( (ii+1)%num);
+				index[ii*3+2] = bgfx::TransientIndexType(ii);
 
 				index[num*3+ii*3+0] = 0;
-				index[num*3+ii*3+1] = uint16_t(ii);
-				index[num*3+ii*3+2] = uint16_t( (ii+1)%num);
+				index[num*3+ii*3+1] = bgfx::TransientIndexType(ii);
+				index[num*3+ii*3+2] = bgfx::TransientIndexType( (ii+1)%num);
 
-				index[numIndices+ii*2+0] = uint16_t(ii);
-				index[numIndices+ii*2+1] = uint16_t(num);
+				index[numIndices+ii*2+0] = bgfx::TransientIndexType(ii);
+				index[numIndices+ii*2+1] = bgfx::TransientIndexType(num);
 
-				index[numIndices+num*2+ii*2+0] = uint16_t(ii);
-				index[numIndices+num*2+ii*2+1] = uint16_t( (ii+1)%num);
+				index[numIndices+num*2+ii*2+0] = bgfx::TransientIndexType(ii);
+				index[numIndices+num*2+ii*2+1] = bgfx::TransientIndexType( (ii+1)%num);
 			}
 
 			m_mesh[id].m_startVertex = startVertex;
@@ -772,11 +772,11 @@ struct DebugDrawShared
 			const uint32_t numLineListIndices = num*6;
 
 			vertices[id] = BX_ALLOC(m_allocator, numVertices*stride);
-			indices[id]  = (uint16_t*)BX_ALLOC(m_allocator, (numIndices + numLineListIndices)*sizeof(uint16_t) );
-			bx::memSet(indices[id], 0, (numIndices + numLineListIndices)*sizeof(uint16_t) );
+			indices[id]  = (bgfx::TransientIndexType*)BX_ALLOC(m_allocator, (numIndices + numLineListIndices)*sizeof(bgfx::TransientIndexType) );
+			bx::memSet(indices[id], 0, (numIndices + numLineListIndices)*sizeof(bgfx::TransientIndexType) );
 
 			DebugShapeVertex* vertex = (DebugShapeVertex*)vertices[id];
-			uint16_t* index = indices[id];
+			bgfx::TransientIndexType* index = indices[id];
 
 			for (uint32_t ii = 0; ii < num; ++ii)
 			{
@@ -795,28 +795,28 @@ struct DebugDrawShared
 				vertex[ii+num].m_z = xy[0];
 				vertex[ii+num].m_indices[0] = 1;
 
-				index[ii*6+0] = uint16_t(ii+num);
-				index[ii*6+1] = uint16_t( (ii+1)%num);
-				index[ii*6+2] = uint16_t(ii);
-				index[ii*6+3] = uint16_t(ii+num);
-				index[ii*6+4] = uint16_t( (ii+1)%num+num);
-				index[ii*6+5] = uint16_t( (ii+1)%num);
+				index[ii*6+0] = bgfx::TransientIndexType(ii+num);
+				index[ii*6+1] = bgfx::TransientIndexType( (ii+1)%num);
+				index[ii*6+2] = bgfx::TransientIndexType(ii);
+				index[ii*6+3] = bgfx::TransientIndexType(ii+num);
+				index[ii*6+4] = bgfx::TransientIndexType( (ii+1)%num+num);
+				index[ii*6+5] = bgfx::TransientIndexType( (ii+1)%num);
 
-				index[num*6+ii*6+0] = uint16_t(0);
-				index[num*6+ii*6+1] = uint16_t(ii);
-				index[num*6+ii*6+2] = uint16_t( (ii+1)%num);
-				index[num*6+ii*6+3] = uint16_t(num);
-				index[num*6+ii*6+4] = uint16_t( (ii+1)%num+num);
-				index[num*6+ii*6+5] = uint16_t(ii+num);
+				index[num*6+ii*6+0] = bgfx::TransientIndexType(0);
+				index[num*6+ii*6+1] = bgfx::TransientIndexType(ii);
+				index[num*6+ii*6+2] = bgfx::TransientIndexType( (ii+1)%num);
+				index[num*6+ii*6+3] = bgfx::TransientIndexType(num);
+				index[num*6+ii*6+4] = bgfx::TransientIndexType( (ii+1)%num+num);
+				index[num*6+ii*6+5] = bgfx::TransientIndexType(ii+num);
 
-				index[numIndices+ii*2+0] = uint16_t(ii);
-				index[numIndices+ii*2+1] = uint16_t(ii+num);
+				index[numIndices+ii*2+0] = bgfx::TransientIndexType(ii);
+				index[numIndices+ii*2+1] = bgfx::TransientIndexType(ii+num);
 
-				index[numIndices+num*2+ii*2+0] = uint16_t(ii);
-				index[numIndices+num*2+ii*2+1] = uint16_t( (ii+1)%num);
+				index[numIndices+num*2+ii*2+0] = bgfx::TransientIndexType(ii);
+				index[numIndices+num*2+ii*2+1] = bgfx::TransientIndexType( (ii+1)%num);
 
-				index[numIndices+num*4+ii*2+0] = uint16_t(num + ii);
-				index[numIndices+num*4+ii*2+1] = uint16_t(num + (ii+1)%num);
+				index[numIndices+num*4+ii*2+0] = bgfx::TransientIndexType(num + ii);
+				index[numIndices+num*4+ii*2+1] = bgfx::TransientIndexType(num + (ii+1)%num);
 			}
 
 			m_mesh[id].m_startVertex = startVertex;
@@ -842,11 +842,11 @@ struct DebugDrawShared
 			const uint32_t numLineListIndices = num*6;
 
 			vertices[id] = BX_ALLOC(m_allocator, numVertices*stride);
-			indices[id]  = (uint16_t*)BX_ALLOC(m_allocator, (numIndices + numLineListIndices)*sizeof(uint16_t) );
-			bx::memSet(indices[id], 0, (numIndices + numLineListIndices)*sizeof(uint16_t) );
+			indices[id]  = (bgfx::TransientIndexType*)BX_ALLOC(m_allocator, (numIndices + numLineListIndices)*sizeof(bgfx::TransientIndexType) );
+			bx::memSet(indices[id], 0, (numIndices + numLineListIndices)*sizeof(bgfx::TransientIndexType) );
 
 			DebugShapeVertex* vertex = (DebugShapeVertex*)vertices[id];
-			uint16_t* index = indices[id];
+			bgfx::TransientIndexType* index = indices[id];
 
 			for (uint32_t ii = 0; ii < num; ++ii)
 			{
@@ -865,28 +865,28 @@ struct DebugDrawShared
 				vertex[ii+num].m_z = xy[0];
 				vertex[ii+num].m_indices[0] = 1;
 
-				index[ii*6+0] = uint16_t(ii+num);
-				index[ii*6+1] = uint16_t( (ii+1)%num);
-				index[ii*6+2] = uint16_t(ii);
-				index[ii*6+3] = uint16_t(ii+num);
-				index[ii*6+4] = uint16_t( (ii+1)%num+num);
-				index[ii*6+5] = uint16_t( (ii+1)%num);
+				index[ii*6+0] = bgfx::TransientIndexType(ii+num);
+				index[ii*6+1] = bgfx::TransientIndexType( (ii+1)%num);
+				index[ii*6+2] = bgfx::TransientIndexType(ii);
+				index[ii*6+3] = bgfx::TransientIndexType(ii+num);
+				index[ii*6+4] = bgfx::TransientIndexType( (ii+1)%num+num);
+				index[ii*6+5] = bgfx::TransientIndexType( (ii+1)%num);
 
-//				index[num*6+ii*6+0] = uint16_t(0);
-//				index[num*6+ii*6+1] = uint16_t(ii);
-//				index[num*6+ii*6+2] = uint16_t( (ii+1)%num);
-//				index[num*6+ii*6+3] = uint16_t(num);
-//				index[num*6+ii*6+4] = uint16_t( (ii+1)%num+num);
-//				index[num*6+ii*6+5] = uint16_t(ii+num);
+//				index[num*6+ii*6+0] = bgfx::TransientIndexType(0);
+//				index[num*6+ii*6+1] = bgfx::TransientIndexType(ii);
+//				index[num*6+ii*6+2] = bgfx::TransientIndexType( (ii+1)%num);
+//				index[num*6+ii*6+3] = bgfx::TransientIndexType(num);
+//				index[num*6+ii*6+4] = bgfx::TransientIndexType( (ii+1)%num+num);
+//				index[num*6+ii*6+5] = bgfx::TransientIndexType(ii+num);
 
-				index[numIndices+ii*2+0] = uint16_t(ii);
-				index[numIndices+ii*2+1] = uint16_t(ii+num);
+				index[numIndices+ii*2+0] = bgfx::TransientIndexType(ii);
+				index[numIndices+ii*2+1] = bgfx::TransientIndexType(ii+num);
 
-				index[numIndices+num*2+ii*2+0] = uint16_t(ii);
-				index[numIndices+num*2+ii*2+1] = uint16_t( (ii+1)%num);
+				index[numIndices+num*2+ii*2+0] = bgfx::TransientIndexType(ii);
+				index[numIndices+num*2+ii*2+1] = bgfx::TransientIndexType( (ii+1)%num);
 
-				index[numIndices+num*4+ii*2+0] = uint16_t(num + ii);
-				index[numIndices+num*4+ii*2+1] = uint16_t(num + (ii+1)%num);
+				index[numIndices+num*4+ii*2+0] = bgfx::TransientIndexType(num + ii);
+				index[numIndices+num*4+ii*2+1] = bgfx::TransientIndexType(num + (ii+1)%num);
 			}
 
 			m_mesh[id].m_startVertex = startVertex;
@@ -919,7 +919,7 @@ struct DebugDrawShared
 		startIndex  += m_mesh[DebugMesh::Cube].m_numIndices[0];
 
 		const bgfx::Memory* vb = bgfx::alloc(startVertex*stride);
-		const bgfx::Memory* ib = bgfx::alloc(startIndex*sizeof(uint16_t) );
+		const bgfx::Memory* ib = bgfx::alloc(startIndex*sizeof(bgfx::TransientIndexType) );
 
 		for (uint32_t mesh = DebugMesh::Sphere0; mesh < DebugMesh::Quad; ++mesh)
 		{
@@ -929,9 +929,9 @@ struct DebugDrawShared
 				 , m_mesh[id].m_numVertices*stride
 				 );
 
-			bx::memCopy(&ib->data[m_mesh[id].m_startIndex[0] * sizeof(uint16_t)]
+			bx::memCopy(&ib->data[m_mesh[id].m_startIndex[0] * sizeof(bgfx::TransientIndexType)]
 				 , indices[id]
-				 , (m_mesh[id].m_numIndices[0]+m_mesh[id].m_numIndices[1])*sizeof(uint16_t)
+				 , (m_mesh[id].m_numIndices[0]+m_mesh[id].m_numIndices[1])*sizeof(bgfx::TransientIndexType)
 				 );
 
 			BX_FREE(m_allocator, vertices[id]);
@@ -943,7 +943,7 @@ struct DebugDrawShared
 			, sizeof(s_quadVertices)
 			);
 
-		bx::memCopy(&ib->data[m_mesh[DebugMesh::Quad].m_startIndex[0] * sizeof(uint16_t)]
+		bx::memCopy(&ib->data[m_mesh[DebugMesh::Quad].m_startIndex[0] * sizeof(bgfx::TransientIndexType)]
 			, s_quadIndices
 			, sizeof(s_quadIndices)
 			);
@@ -953,13 +953,13 @@ struct DebugDrawShared
 			, sizeof(s_cubeVertices)
 			);
 
-		bx::memCopy(&ib->data[m_mesh[DebugMesh::Cube].m_startIndex[0] * sizeof(uint16_t)]
+		bx::memCopy(&ib->data[m_mesh[DebugMesh::Cube].m_startIndex[0] * sizeof(bgfx::TransientIndexType)]
 			, s_cubeIndices
 			, sizeof(s_cubeIndices)
 			);
 
 		m_vbh = bgfx::createVertexBuffer(vb, DebugShapeVertex::ms_layout);
-		m_ibh = bgfx::createIndexBuffer(ib);
+		m_ibh = bgfx::createIndexBuffer(ib, sizeof(bgfx::TransientIndexType) == sizeof(uint32_t) ? BGFX_BUFFER_INDEX32 : BGFX_BUFFER_NONE);
 	}
 
 	void shutdown()
@@ -2209,10 +2209,10 @@ struct DebugDrawEncoderImpl
 
 				bgfx::TransientIndexBuffer tib;
 				bgfx::allocTransientIndexBuffer(&tib, numIndices);
-				uint16_t* indices = (uint16_t*)tib.data;
-				for (uint16_t ii = 0, num = m_posQuad/4; ii < num; ++ii)
+				bgfx::TransientIndexType* indices = (bgfx::TransientIndexType*)tib.data;
+				for (bgfx::TransientIndexType ii = 0, num = m_posQuad/4; ii < num; ++ii)
 				{
-					uint16_t startVertex = ii*4;
+					bgfx::TransientIndexType startVertex = ii*4;
 					indices[0] = startVertex+0;
 					indices[1] = startVertex+1;
 					indices[2] = startVertex+2;
@@ -2257,7 +2257,7 @@ struct DebugDrawEncoderImpl
 
 	DebugVertex   m_cache[kCacheSize+1];
 	DebugUvVertex m_cacheQuad[kCacheQuadSize];
-	uint16_t m_indices[kCacheSize*2];
+	bgfx::TransientIndexType m_indices[kCacheSize*2];
 	uint16_t m_pos;
 	uint16_t m_posQuad;
 	uint16_t m_indexPos;

--- a/examples/common/debugdraw/debugdraw.h
+++ b/examples/common/debugdraw/debugdraw.h
@@ -148,10 +148,10 @@ struct DebugDrawEncoder
 	void draw(GeometryHandle _handle);
 
 	///
-	void drawLineList(uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices = 0, const uint16_t* _indices = NULL);
+	void drawLineList(uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices = 0, const bgfx::TransientIndexType* _indices = NULL);
 
 	///
-	void drawTriList(uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices = 0, const uint16_t* _indices = NULL);
+	void drawTriList(uint32_t _numVertices, const DdVertex* _vertices, uint32_t _numIndices = 0, const bgfx::TransientIndexType* _indices = NULL);
 
 	///
 	void drawFrustum(const void* _viewProj);

--- a/examples/common/debugdraw/debugdraw.h
+++ b/examples/common/debugdraw/debugdraw.h
@@ -195,7 +195,7 @@ struct DebugDrawEncoder
 	///
 	void drawOrb(float _x, float _y, float _z, float _radius, Axis::Enum _highlight = Axis::Count);
 
-	BX_ALIGN_DECL_CACHE_LINE(uint8_t) m_internal[50<<10];
+	BX_ALIGN_DECL_CACHE_LINE(uint8_t) m_internal[(50<<10)+(BGFX_CONFIG_TRANSIENT_INDEX32*4096)];
 };
 
 ///

--- a/examples/common/font/text_buffer_manager.cpp
+++ b/examples/common/font/text_buffer_manager.cpp
@@ -114,7 +114,7 @@ public:
 	}
 
 	/// get a pointer to the index buffer to submit it to the graphic
-	const uint16_t* getIndexBuffer() const
+	const bgfx::TransientIndexType* getIndexBuffer() const
 	{
 		return m_indexBuffer;
 	}
@@ -128,7 +128,7 @@ public:
 	/// Size in bytes of an index.
 	uint32_t getIndexSize() const
 	{
-		return sizeof(uint16_t);
+		return sizeof(bgfx::TransientIndexType);
 	}
 
 	uint32_t getTextColor() const
@@ -194,7 +194,7 @@ private:
 	};
 
 	TextVertex* m_vertexBuffer;
-	uint16_t* m_indexBuffer;
+	bgfx::TransientIndexType* m_indexBuffer;
 	uint8_t* m_styleBuffer;
 
 	uint32_t m_indexCount;
@@ -218,7 +218,7 @@ TextBuffer::TextBuffer(FontManager* _fontManager)
 	, m_lineGap(0)
 	, m_fontManager(_fontManager)
 	, m_vertexBuffer(new TextVertex[MAX_BUFFERED_CHARACTERS * 4])
-	, m_indexBuffer(new uint16_t[MAX_BUFFERED_CHARACTERS * 6])
+	, m_indexBuffer(new bgfx::TransientIndexType[MAX_BUFFERED_CHARACTERS * 6])
 	, m_styleBuffer(new uint8_t[MAX_BUFFERED_CHARACTERS * 4])
 	, m_indexCount(0)
 	, m_lineStartIndex(0)

--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -101,8 +101,37 @@ struct OcornutImguiContext
 			ImDrawVert* verts = (ImDrawVert*)tvb.data;
 			bx::memCopy(verts, drawList->VtxBuffer.begin(), numVertices * sizeof(ImDrawVert) );
 
-			ImDrawIdx* indices = (ImDrawIdx*)tib.data;
-			bx::memCopy(indices, drawList->IdxBuffer.begin(), numIndices * sizeof(ImDrawIdx) );
+			bgfx::TransientIndexType* indices = (bgfx::TransientIndexType*)tib.data;
+			size_t u16Size = sizeof(ImU16);
+			if (sizeof(ImDrawIdx) == u16Size)
+			{
+				if (sizeof(bgfx::TransientIndexType) == u16Size)
+				{
+					bx::memCopy(indices, drawList->IdxBuffer.begin(), numIndices * sizeof(ImDrawIdx) );
+				}
+				else
+				{
+					for (uint32_t index = 0; index < numIndices; ++index)
+					{
+						indices[index] = (bgfx::TransientIndexType)drawList->IdxBuffer[index];
+					}
+				}
+			}
+			else
+			{
+				size_t u32Size = sizeof(uint32_t);
+				if (sizeof(bgfx::TransientIndexType) == u32Size)
+				{
+					bx::memCopy(indices, drawList->IdxBuffer.begin(), numIndices * sizeof(ImDrawIdx) );
+				}
+				else
+				{
+					for (uint32_t index = 0; index < numIndices; ++index)
+					{
+						indices[index] = (bgfx::TransientIndexType)drawList->IdxBuffer[index];
+					}
+				}
+			}
 
 			uint32_t offset = 0;
 			for (const ImDrawCmd* cmd = drawList->CmdBuffer.begin(), *cmdEnd = drawList->CmdBuffer.end(); cmd != cmdEnd; ++cmd)

--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -571,7 +571,7 @@ namespace
 		uint32_t numTris = _count-2;
 		bgfx::TransientIndexBuffer tib;
 		bgfx::allocTransientIndexBuffer(&tib, numTris*3);
-		uint16_t* data = (uint16_t*)tib.data;
+		bgfx::TransientIndexType* data = (bgfx::TransientIndexType*)tib.data;
 		for (uint32_t ii = 0; ii < numTris; ++ii)
 		{
 			data[ii*3+0] = _start;

--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -813,6 +813,15 @@ namespace bgfx
 		uint16_t formats[TextureFormat::Count];
 	};
 
+#if !defined(BGFX_CONFIG_TRANSIENT_INDEX32)
+#define BGFX_CONFIG_TRANSIENT_INDEX32 0
+#endif // !defined(BGFX_CONFIG_TRANSIENT_INDEX32)
+#if BGFX_CONFIG_TRANSIENT_INDEX32
+	typedef uint32_t TransientIndexType;
+#else
+	typedef uint16_t TransientIndexType;
+#endif // BGFX_CONFIG_TRANSIENT_INDEX32
+
 	/// Transient index buffer.
 	///
 	/// @attention C99 equivalent is `bgfx_transient_index_buffer_t`.
@@ -2442,7 +2451,8 @@ namespace bgfx
 	/// @param[in] _num Number of indices to allocate.
 	///
 	/// @remarks
-	///   Only 16-bit index buffer is supported.
+	///   Defaults to 16-bit index buffers.
+	///   For 32-bit index buffers: #define BGFX_CONFIG_TRANSIENT_INDEX32 1
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transient_index_buffer`.
 	///
@@ -2472,7 +2482,8 @@ namespace bgfx
 	/// true.
 	///
 	/// @remarks
-	///   Only 16-bit index buffer is supported.
+	///   Defaults to 16-bit index buffers.
+	///   For 32-bit index buffers: #define BGFX_CONFIG_TRANSIENT_INDEX32 1
 	///
 	/// @attention C99 equivalent is `bgfx_alloc_transient_buffers`.
 	///

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -785,7 +785,7 @@ namespace bgfx
 		for (;yy < _mem.m_height;)
 		{
 			Vertex* vertex = (Vertex*)_blitter.m_vb->data;
-			uint16_t* indices = (uint16_t*)_blitter.m_ib->data;
+			TransientIndexType* indices = (TransientIndexType*)_blitter.m_ib->data;
 			uint32_t startVertex = 0;
 			uint32_t numIndices = 0;
 
@@ -821,12 +821,12 @@ namespace bgfx
 						bx::memCopy(vertex, vert, sizeof(vert) );
 						vertex += 4;
 
-						indices[0] = uint16_t(startVertex+0);
-						indices[1] = uint16_t(startVertex+1);
-						indices[2] = uint16_t(startVertex+2);
-						indices[3] = uint16_t(startVertex+2);
-						indices[4] = uint16_t(startVertex+3);
-						indices[5] = uint16_t(startVertex+0);
+						indices[0] = TransientIndexType(startVertex+0);
+						indices[1] = TransientIndexType(startVertex+1);
+						indices[2] = TransientIndexType(startVertex+2);
+						indices[3] = TransientIndexType(startVertex+2);
+						indices[4] = TransientIndexType(startVertex+3);
+						indices[5] = TransientIndexType(startVertex+0);
 
 						startVertex += 4;
 						indices += 6;
@@ -4162,11 +4162,11 @@ namespace bgfx
 		BX_ASSERT(NULL != _tib, "_tib can't be NULL");
 		BX_ASSERT(0 < _num, "Requesting 0 indices.");
 		s_ctx->allocTransientIndexBuffer(_tib, _num);
-		BX_ASSERT(_num == _tib->size/2
+		BX_ASSERT(_num == _tib->size/sizeof(TransientIndexType)
 			, "Failed to allocate transient index buffer (requested %d, available %d). "
 			  "Use bgfx::getAvailTransient* functions to ensure availability."
 			, _num
-			, _tib->size/2
+			, _tib->size/sizeof(TransientIndexType)
 			);
 	}
 

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2090,18 +2090,18 @@ namespace bgfx
 
 		uint32_t getAvailTransientIndexBuffer(uint32_t _num)
 		{
-			uint32_t offset   = bx::strideAlign(m_iboffset, sizeof(uint16_t) );
-			uint32_t iboffset = offset + _num*sizeof(uint16_t);
+			uint32_t offset   = bx::strideAlign(m_iboffset, sizeof(TransientIndexType) );
+			uint32_t iboffset = offset + _num*sizeof(TransientIndexType);
 			iboffset = bx::min<uint32_t>(iboffset, g_caps.limits.transientIbSize);
-			uint32_t num = (iboffset-offset)/sizeof(uint16_t);
+			uint32_t num = (iboffset-offset)/sizeof(TransientIndexType);
 			return num;
 		}
 
 		uint32_t allocTransientIndexBuffer(uint32_t& _num)
 		{
-			uint32_t offset = bx::strideAlign(m_iboffset, sizeof(uint16_t) );
+			uint32_t offset = bx::strideAlign(m_iboffset, sizeof(TransientIndexType) );
 			uint32_t num    = getAvailTransientIndexBuffer(_num);
-			m_iboffset = offset + num*sizeof(uint16_t);
+			m_iboffset = offset + num*sizeof(TransientIndexType);
 			_num = num;
 
 			return offset;
@@ -2437,7 +2437,7 @@ namespace bgfx
 		void setIndexBuffer(const TransientIndexBuffer* _tib, uint32_t _firstIndex, uint32_t _numIndices)
 		{
 			BX_ASSERT(UINT8_MAX != m_draw.m_streamMask, "bgfx::setVertexCount was already called for this draw call.");
-			const uint32_t numIndices = bx::min(_numIndices, _tib->size/2);
+			const uint32_t numIndices = bx::min(_numIndices, (uint32_t)(_tib->size/sizeof(TransientIndexType)));
 			m_draw.m_indexBuffer = _tib->handle;
 			m_draw.m_startIndex  = _tib->startIndex + _firstIndex;
 			m_draw.m_numIndices  = numIndices;
@@ -3676,7 +3676,7 @@ namespace bgfx
 				CommandBuffer& cmdbuf = getCommandBuffer(CommandBuffer::CreateDynamicIndexBuffer);
 				cmdbuf.write(handle);
 				cmdbuf.write(_size);
-				uint16_t flags = BGFX_BUFFER_NONE;
+				uint16_t flags = sizeof(TransientIndexType) == sizeof(uint32_t) ? BGFX_BUFFER_INDEX32 : BGFX_BUFFER_NONE;
 				cmdbuf.write(flags);
 
 				const uint32_t size = 0
@@ -3712,9 +3712,9 @@ namespace bgfx
 			TransientIndexBuffer& tib = *m_submit->m_transientIb;
 
 			_tib->data       = &tib.data[offset];
-			_tib->size       = _num * 2;
+			_tib->size       = _num * sizeof(TransientIndexType);
 			_tib->handle     = tib.handle;
-			_tib->startIndex = bx::strideAlign(offset, 2)/2;
+			_tib->startIndex = bx::strideAlign(offset, sizeof(TransientIndexType))/sizeof(TransientIndexType);
 		}
 
 		TransientVertexBuffer* createTransientVertexBuffer(uint32_t _size, const VertexLayout* _layout = NULL)

--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -216,7 +216,7 @@ namespace bgfx
 				return topologyConvertTriStripToTriList(_dst, _dstSize, (const uint32_t*)_indices, _numIndices);
 			}
 
-			return topologyConvertTriStripToTriList(_dst, _dstSize, (const uint16_t*)_indices, _numIndices);
+			return topologyConvertTriStripToTriList(_dst, _dstSize, (const TransientIndexType*)_indices, _numIndices);
 
 		case TopologyConvert::TriListFlipWinding:
 			if (_index32)
@@ -224,7 +224,7 @@ namespace bgfx
 				return topologyConvertTriListFlipWinding(_dst, _dstSize, (const uint32_t*)_indices, _numIndices);
 			}
 
-			return topologyConvertTriListFlipWinding(_dst, _dstSize, (const uint16_t*)_indices, _numIndices);
+			return topologyConvertTriListFlipWinding(_dst, _dstSize, (const TransientIndexType*)_indices, _numIndices);
 
 		case TopologyConvert::TriStripFlipWinding:
 			if (_index32)
@@ -232,7 +232,7 @@ namespace bgfx
 				return topologyConvertTriStripFlipWinding(_dst, _dstSize, (const uint32_t*)_indices, _numIndices);
 			}
 
-			return topologyConvertTriStripFlipWinding(_dst, _dstSize, (const uint16_t*)_indices, _numIndices);
+			return topologyConvertTriStripFlipWinding(_dst, _dstSize, (const TransientIndexType*)_indices, _numIndices);
 
 		case TopologyConvert::TriListToLineList:
 			if (NULL == _allocator)
@@ -245,7 +245,7 @@ namespace bgfx
 				return topologyConvertTriListToLineList<uint32_t, uint64_t>(_dst, _dstSize, (const uint32_t*)_indices, _numIndices, _allocator);
 			}
 
-			return topologyConvertTriListToLineList<uint16_t, uint32_t>(_dst, _dstSize, (const uint16_t*)_indices, _numIndices, _allocator);
+			return topologyConvertTriListToLineList<TransientIndexType, uint32_t>(_dst, _dstSize, (const TransientIndexType*)_indices, _numIndices, _allocator);
 
 		case TopologyConvert::LineStripToLineList:
 			if (_index32)
@@ -253,7 +253,7 @@ namespace bgfx
 				return topologyConvertLineStripToLineList(_dst, _dstSize, (const uint32_t*)_indices, _numIndices);
 			}
 
-			return topologyConvertLineStripToLineList(_dst, _dstSize, (const uint16_t*)_indices, _numIndices);
+			return topologyConvertLineStripToLineList(_dst, _dstSize, (const TransientIndexType*)_indices, _numIndices);
 
 		default:
 			break;

--- a/tools/texturev/texturev.cpp
+++ b/tools/texturev/texturev.cpp
@@ -911,7 +911,7 @@ struct PosUvwColorVertex
 
 bgfx::VertexLayout PosUvwColorVertex::ms_layout;
 
-static uint32_t addQuad(uint16_t* _indices, uint16_t _idx0, uint16_t _idx1, uint16_t _idx2, uint16_t _idx3)
+static uint32_t addQuad(bgfx::TransientIndexType* _indices, uint16_t _idx0, uint16_t _idx1, uint16_t _idx2, uint16_t _idx3)
 {
 	_indices[0] = _idx0;
 	_indices[1] = _idx3;
@@ -980,7 +980,7 @@ void setGeometry(
 			bgfx::allocTransientIndexBuffer(&tib, numIndices);
 
 			PosUvwColorVertex* vertex = (PosUvwColorVertex*)tvb.data;
-			uint16_t* indices = (uint16_t*)tib.data;
+			bgfx::TransientIndexType* indices = (bgfx::TransientIndexType*)tib.data;
 
 			if (Geometry::Cross == _type)
 			{


### PR DESCRIPTION
This adds support for a user-overridable TransientIndexType at compile-time. It defaults to uint16_t, but it can be overridden to the 32-bit uint32_t by defining BGFX_CONFIG_TRANSIENT_INDEX32 to 1. Code currently using uint16_t directly for the transient index buffer should change to using TransientIndexType, although existing code will continue to work due to the default type of uint16_t.

Pathstorm (https://pathstorm.com/) uses NanoVG and NanoSVG to render geometry whose mesh size far exceeds the 16-bit index buffer. TransientIndexType for Pathstorm is a uint32_t.

Other source code files were updated to ensure the bgfx samples work, but most of these are not directly used in Pathstorm.