### PR TITLE
DX11: Fix draw vertex count not updating

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -6215,7 +6215,7 @@ namespace bgfx { namespace d3d11
 
 				if (0 != currentState.m_streamMask)
 				{
-					uint32_t numVertices       = currentState.m_numVertices;
+					uint32_t numVertices       = draw.m_numVertices;
 					uint32_t numIndices        = 0;
 					uint32_t numPrimsSubmitted = 0;
 					uint32_t numInstances      = 0;


### PR DESCRIPTION
If everyting else stays same but vertex count changes then numVertices uses the "currentState.m_numVertices" which might differ from "draw.m_numVertices". Thus change numVertices to be polled from "draw".