### PR TITLE
Don't skip reset if platform data has changed

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2997,7 +2997,8 @@ namespace bgfx
 		{
 			const TextureFormat::Enum format = TextureFormat::Count != _format ? _format : m_init.resolution.format;
 
-			if (m_init.resolution.format == format
+			if (!g_platformDataChangedSinceReset
+			&&  m_init.resolution.format == format
 			&&  m_init.resolution.width  == _width
 			&&  m_init.resolution.height == _height
 			&&  m_init.resolution.reset  == _flags)


### PR DESCRIPTION
In commit [475fea23bc1061461168fd99de41ebc8ee321b3b](https://github.com/bkaradzic/bgfx/commit/475fea23bc1061461168fd99de41ebc8ee321b3b) an optimization was added to skip reset if nothing changes, however this was not honoring the g_platformDataChangedSinceReset flag. This meant that if the windowptr changes between reset calls but the resolution stays the same then we would not properly regenerate and resize textures during reset.

This change just adds a check for g_platformDataChangedSinceReset to rectify this behavior.