### PR TITLE
fix loading opengl es3+ shaders with new shaderc changes

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6399,7 +6399,7 @@ namespace bgfx { namespace gl
 							bx::write(&writer, &err, "out vec4 bgfx_FragData[%d];\n", fragData);
 							bx::write(&writer, "#define gl_FragData bgfx_FragData\n");
 						}
-						else
+						else if (!bx::findIdentifierMatch(code, "gl_FragColor").isEmpty())
 						{
 							bx::write(&writer
 								, "out vec4 bgfx_FragColor;\n"


### PR DESCRIPTION
The changes introduced by #2317 completely broke OpenGL ES 3.0 new shaders at runtime.
(resulting in: `must explicitly specify all locations when using multiple fragment outputs`)
Not sure why was merged in such state, Anyway this PR attempts to hot fix the issue.

Basically the new shaderc changes inject at shader compile time their own logic to replace `gl_FragColor` already, with this check we make sure to remain backward compatible yet ignore newly processed shaders.

P.S.
The shaderc changes were extremely welcome tho, don't get me wrong :)