### PR TITLE
add newline at end of error

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -2735,7 +2735,7 @@ namespace bgfx
 
 			if (!bx::open(writer, outFilePath) )
 			{
-				bx::printf("Unable to open output file '%s'.", outFilePath);
+				bx::printf("Unable to open output file '%s'.\n", outFilePath);
 				return bx::kExitFailure;
 			}
 


### PR DESCRIPTION
Probably a really petty change, but it's a little confusing for a couple seconds when what looks like one error is actually two.