### PR TITLE
Update entry_android.cpp

### DIFF
--- a/examples/common/entry/entry_android.cpp
+++ b/examples/common/entry/entry_android.cpp
@@ -154,7 +154,7 @@ namespace entry
 			{
 				if (0 == AAsset_getRemainingLength(m_file) )
 				{
-					BX_ERROR_SET(_err, bx::kErrorRederWriterEof, "FileReader: EOF.");
+					BX_ERROR_SET(_err, bx::kErrorReaderWriterEof, "FileReader: EOF.");
 				}
 
 				return size >= 0 ? size : 0;


### PR DESCRIPTION
- Fix Android Building
- "entry_android.cpp:157:29: error: no member named 'kErrorRederWriterEof' in namespace 'bx'; did you mean 'kErrorReaderWriterEof'?"