### PR TITLE
Print error messages when shader doesn't compile.

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6484,7 +6484,6 @@ namespace bgfx { namespace gl
 				GLsizei len;
 				char log[1024];
 				GL_CHECK(glGetShaderInfoLog(m_id, sizeof(log), &len, log) );
-				BX_TRACE("Failed to compile shader. %d: %s", compiled, log);
 
 				GL_CHECK(glDeleteShader(m_id) );
 				m_id = 0;

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6488,7 +6488,7 @@ namespace bgfx { namespace gl
 
 				GL_CHECK(glDeleteShader(m_id) );
 				m_id = 0;
-				BGFX_FATAL(false, bgfx::Fatal::InvalidShader, "Failed to compile shader.");
+				BGFX_FATAL(false, bgfx::Fatal::InvalidShader, "Failed to compile shader. %d: %s", compiled, log);
 			}
 			else if (BX_ENABLED(BGFX_CONFIG_DEBUG)
 				 &&  s_extension[Extension::ANGLE_translated_shader_source].m_supported


### PR DESCRIPTION
Move the error printout into the BGFX_FATAL, and remove the (now redundant) BX_TRACE.