### PR TITLE
Additional condition in the after-usage of setPlatformData

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -344,9 +344,10 @@ namespace bgfx
 		{
 			BGFX_FATAL(true
 				&& g_platformData.ndt     == _data.ndt
+				&& g_platformData.nwh     == _data.nwh
 				&& g_platformData.context == _data.context
 				, Fatal::UnableToInitialize
-				, "Only backbuffer pointer and native window handle can be changed after initialization!"
+				, "Only backbuffer pointer can be changed after initialization!"
 				);
 		}
 		bx::memCopy(&g_platformData, &_data, sizeof(PlatformData) );

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -344,7 +344,10 @@ namespace bgfx
 		{
 			BGFX_FATAL(true
 				&& g_platformData.ndt     == _data.ndt
+#if !BX_PLATFORM_ANDROID
+				// Changing window handle on Android is actually possible:
 				&& g_platformData.nwh     == _data.nwh
+#endif
 				&& g_platformData.context == _data.context
 				, Fatal::UnableToInitialize
 				, "Only backbuffer pointer can be changed after initialization!"


### PR DESCRIPTION
I've narrowed down the setPlatformData usage, since reset doesn't actually accomodate for nwh changes. The documentation for this method should still correct the warning to something else, since this method doesn't prohibit its usage before the init, but only a *certain* usage.

Thank you.