### PR TITLE
Reset s_renderFrameCalled on bgfx::shutdown

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -3563,9 +3563,10 @@ namespace bgfx
 			s_allocatorStub = NULL;
 		}
 
-		s_threadIndex = 0;
-		g_callback    = NULL;
-		g_allocator   = NULL;
+		s_threadIndex       = 0;
+		s_renderFrameCalled = false;
+		g_callback          = NULL;
+		g_allocator         = NULL;
 	}
 
 	void reset(uint32_t _width, uint32_t _height, uint32_t _flags, TextureFormat::Enum _format)


### PR DESCRIPTION
Without this, `m_singleThreaded` will never be set with the next `bgfx::init` call. `bgfx::renderFrame` must be called again after `bgfx::shutdown`.