### PR TITLE
Vulkan sync rewrite

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -811,6 +811,8 @@ VK_IMPORT_DEVICE
 	VkObjectType getType();
 
 	template<> VkObjectType getType<VkBuffer      >() { return VK_OBJECT_TYPE_BUFFER;        }
+	template<> VkObjectType getType<VkImage       >() { return VK_OBJECT_TYPE_IMAGE;         }
+	template<> VkObjectType getType<VkImageView   >() { return VK_OBJECT_TYPE_IMAGE_VIEW;    }
 	template<> VkObjectType getType<VkShaderModule>() { return VK_OBJECT_TYPE_SHADER_MODULE; }
 
 	template<typename Ty>
@@ -3054,7 +3056,19 @@ VK_IMPORT_DEVICE
 				break;
 
 			case Handle::Texture:
-//				setDebugObjectName(m_device, m_textures[_handle.idx].m_ptr, "%.*s", _len, _name);
+				setDebugObjectName(m_device, m_textures[_handle.idx].m_textureImage, "%.*s", _len, _name);
+				if (m_textures[_handle.idx].m_textureImageView != VK_NULL_HANDLE)
+				{
+					setDebugObjectName(m_device, m_textures[_handle.idx].m_textureImageView, "%.*s", _len, _name);
+				}
+				if (m_textures[_handle.idx].m_textureImageStorageView != VK_NULL_HANDLE)
+				{
+					setDebugObjectName(m_device, m_textures[_handle.idx].m_textureImageStorageView, "%.*s", _len, _name);
+				}
+				if (m_textures[_handle.idx].m_textureImageDepthView != VK_NULL_HANDLE)
+				{
+					setDebugObjectName(m_device, m_textures[_handle.idx].m_textureImageDepthView, "%.*s", _len, _name);
+				}
 				break;
 
 			case Handle::VertexBuffer:

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -814,6 +814,7 @@ VK_IMPORT_DEVICE
 	template<> VkObjectType getType<VkImage       >() { return VK_OBJECT_TYPE_IMAGE;         }
 	template<> VkObjectType getType<VkImageView   >() { return VK_OBJECT_TYPE_IMAGE_VIEW;    }
 	template<> VkObjectType getType<VkShaderModule>() { return VK_OBJECT_TYPE_SHADER_MODULE; }
+	template<> VkObjectType getType<VkFramebuffer >() { return VK_OBJECT_TYPE_FRAMEBUFFER;   }
 	template<> VkObjectType getType<VkDeviceMemory>() { return VK_OBJECT_TYPE_DEVICE_MEMORY; }
 
 	template<typename Ty>
@@ -6162,7 +6163,8 @@ VK_DESTROY
 
 	void FrameBufferVK::destroy()
 	{
-		vkDestroy(m_framebuffer);
+		s_renderVK->releaseDeferred(m_framebuffer);
+		m_framebuffer = VK_NULL_HANDLE;
 	}
 
 	void CommandQueueVK::init(uint32_t _queueFamily, VkQueue _queue, uint32_t _numFramesInFlight)
@@ -6370,6 +6372,9 @@ VK_DESTROY
 				break;
 			case VK_OBJECT_TYPE_IMAGE:
 				vkDestroyImage(device, ::VkImage(resource.m_handle), allocatorCb);
+				break;
+			case VK_OBJECT_TYPE_FRAMEBUFFER:
+				vkDestroyFramebuffer(device, ::VkFramebuffer(resource.m_handle), allocatorCb);
 				break;
 			case VK_OBJECT_TYPE_DEVICE_MEMORY:
 				vkFreeMemory(device, ::VkDeviceMemory(resource.m_handle), allocatorCb);

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4006,25 +4006,14 @@ VK_IMPORT_DEVICE
 							wds[wdsCount].pTexelBufferView = NULL;
 
 							TextureVK& texture = m_textures[bind.m_idx];
-							VkSampler sampler = getSampler(
-								(0 == (BGFX_SAMPLER_INTERNAL_DEFAULT & bind.m_samplerFlags)
-									? bind.m_samplerFlags
-									: (uint32_t)texture.m_flags
-								) & (BGFX_SAMPLER_BITS_MASK | BGFX_SAMPLER_BORDER_COLOR_MASK)
-								, (uint32_t)texture.m_numMips);
-
-							if (VK_IMAGE_LAYOUT_GENERAL != texture.m_currentImageLayout
-							&&  VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL != texture.m_currentImageLayout)
-							{
-								texture.setImageMemoryBarrier(m_commandBuffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-							}
+							texture.setImageMemoryBarrier(m_commandBuffer, VK_IMAGE_LAYOUT_GENERAL);
 
 							imageInfo[imageCount].imageLayout = texture.m_currentImageLayout;
 							imageInfo[imageCount].imageView   = VK_NULL_HANDLE != texture.m_textureImageStorageView
 								? texture.m_textureImageStorageView
 								: texture.m_textureImageView
 								;
-							imageInfo[imageCount].sampler     = sampler;
+							imageInfo[imageCount].sampler     = VK_NULL_HANDLE;
 							wds[wdsCount].pImageInfo = &imageInfo[imageCount];
 							++imageCount;
 
@@ -4068,8 +4057,7 @@ VK_IMPORT_DEVICE
 								, (uint32_t)texture.m_numMips
 								);
 
-							if (VK_IMAGE_LAYOUT_GENERAL != texture.m_currentImageLayout
-							&&  VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL != texture.m_currentImageLayout)
+							if (VK_IMAGE_LAYOUT_GENERAL != texture.m_currentImageLayout)
 							{
 								texture.setImageMemoryBarrier(m_commandBuffer, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 							}

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -6555,7 +6555,21 @@ VK_DESTROY
 		uint32_t statsNumIndices = 0;
 		uint32_t statsKeyType[2] = {};
 
-		bool needAcquire = true;
+		bool needAcquire = !!(_render->m_debug & (BGFX_DEBUG_STATS|BGFX_DEBUG_TEXT) );
+		if (!needAcquire)
+		{
+			for (uint32_t ii = 0; ii < _render->m_numRenderItems; ++ii)
+			{
+				const ViewId decodedView = SortKey::decodeView(_render->m_sortKeys[ii]);
+				const ViewId remappedView = _render->m_viewRemap[decodedView];
+				if (!isValid(_render->m_view[remappedView].m_fbh) )
+				{
+					needAcquire = true;
+					break;
+				}
+			}
+		}
+
 		if (needAcquire)
 		{
 			if (!acquireImage() )

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -6688,9 +6688,6 @@ VK_DESTROY
 
 					if (!isCompute && !beginRenderPass)
 					{
-						vkCmdBeginRenderPass(m_commandBuffer, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
-						beginRenderPass = true;
-
 						VkViewport vp;
 						vp.x        =  float(rect.m_x);
 						vp.y        =  float(rect.m_y + rect.m_height);
@@ -6712,14 +6709,21 @@ VK_DESTROY
 						Clear& clr = _render->m_view[view].m_clear;
 						if (BGFX_CLEAR_NONE != clr.m_flags)
 						{
+							vkCmdBeginRenderPass(m_commandBuffer, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+
 							Rect clearRect = rect;
 							clearRect.setIntersect(rect, viewScissorRect);
 							clearQuad(clearRect, clr, _render->m_colorPalette);
+
+							vkCmdEndRenderPass(m_commandBuffer);
 						}
 
 						prim = s_primInfo[Topology::Count]; // Force primitive type update.
 
 						submitBlit(bs, view);
+
+						vkCmdBeginRenderPass(m_commandBuffer, &rpbi, VK_SUBPASS_CONTENTS_INLINE);
+						beginRenderPass = true;
 					}
 				}
 

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -331,7 +331,7 @@ VK_DESTROY
 			typename HashMap::iterator it = m_hashMap.find(_key);
 			if (it != m_hashMap.end() )
 			{
-				vkDestroy(it->second);
+				destroy(it->second);
 				m_hashMap.erase(it);
 			}
 		}
@@ -340,7 +340,7 @@ VK_DESTROY
 		{
 			for (typename HashMap::iterator it = m_hashMap.begin(), itEnd = m_hashMap.end(); it != itEnd; ++it)
 			{
-				vkDestroy(it->second);
+				destroy(it->second);
 			}
 
 			m_hashMap.clear();
@@ -352,6 +352,8 @@ VK_DESTROY
 		}
 
 	private:
+		void destroy(Ty handle);
+
 		typedef stl::unordered_map<uint64_t, Ty> HashMap;
 		HashMap m_hashMap;
 	};

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -370,6 +370,7 @@ VK_DESTROY
 		void create(uint32_t _size, uint32_t _maxDescriptors);
 		void destroy();
 		void reset();
+		void flush();
 
 		VkDescriptorSet& getCurrentDS()
 		{
@@ -592,16 +593,13 @@ VK_DESTROY
 			VkDeviceSize m_offset;
 			uint8_t m_mip;
 			void* m_data;
-			// screenshot only
-			bool m_swizzleBgra8;
-			const char* m_filePath;
 		};
 
 		void create(VkImage _image, uint32_t _width, uint32_t _height, bimg::TextureFormat::Enum _format);
 		void destroy() {}
 		uint32_t pitch(uint8_t _mip = 0) const;
+		void copyImageToBuffer(VkCommandBuffer _commandBuffer, VkBuffer _buffer, VkImageLayout _layout, VkImageAspectFlags _aspect, uint8_t _mip = 0) const;
 		void readback(const Data& _data) const;
-		void screenshot(const Data& _data) const;
 
 		VkImage m_image;
 		uint32_t m_width;
@@ -609,7 +607,6 @@ VK_DESTROY
 		bimg::TextureFormat::Enum m_format;
 
 		static void copyCallback(void* _data);
-		static void screenshotCallback(void* _data);
 	};
 
 	struct TextureVK
@@ -689,7 +686,6 @@ VK_DESTROY
 
 		TextureHandle m_texture[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 		TextureHandle m_depth;
-//		IDXGISwapChain* m_swapChain;
 		uint32_t m_width;
 		uint32_t m_height;
 		uint16_t m_denseIdx;
@@ -709,7 +705,7 @@ VK_DESTROY
 		void reset();
 		void shutdown();
 		VkCommandBuffer alloc();
-		void kick(VkSemaphore _wait = VK_NULL_HANDLE);
+		void kick(VkSemaphore _waitSemaphore = VK_NULL_HANDLE, VkSemaphore _signalSemaphore = VK_NULL_HANDLE, bool _wait = false);
 		void finish(bool _finishAll = false);
 		void release(uint64_t _handle, VkObjectType _type);
 		void run(Callback _func, void* _data = NULL);

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -586,27 +586,16 @@ VK_DESTROY
 
 	struct ReadbackVK
 	{
-		struct Data
-		{
-			ReadbackVK* m_readback;
-			VkDeviceMemory m_memory;
-			VkDeviceSize m_offset;
-			uint8_t m_mip;
-			void* m_data;
-		};
-
 		void create(VkImage _image, uint32_t _width, uint32_t _height, bimg::TextureFormat::Enum _format);
 		void destroy();
 		uint32_t pitch(uint8_t _mip = 0) const;
 		void copyImageToBuffer(VkCommandBuffer _commandBuffer, VkBuffer _buffer, VkImageLayout _layout, VkImageAspectFlags _aspect, uint8_t _mip = 0) const;
-		void readback(const Data& _data) const;
+		void readback(VkDeviceMemory _memory, VkDeviceSize _offset, void* _data, uint8_t _mip = 0) const;
 
 		VkImage m_image;
 		uint32_t m_width;
 		uint32_t m_height;
 		bimg::TextureFormat::Enum m_format;
-
-		static void copyCallback(void* _data);
 	};
 
 	struct TextureVK
@@ -699,8 +688,6 @@ VK_DESTROY
 
 	struct CommandQueueVK
 	{
-		typedef void (*Callback)(void*);
-
 		void init(uint32_t _queueFamily, VkQueue _queue, uint32_t _numFramesInFlight);
 		void reset();
 		void shutdown();
@@ -708,7 +695,6 @@ VK_DESTROY
 		void kick(VkSemaphore _waitSemaphore = VK_NULL_HANDLE, VkSemaphore _signalSemaphore = VK_NULL_HANDLE, bool _wait = false);
 		void finish(bool _finishAll = false);
 		void release(uint64_t _handle, VkObjectType _type);
-		void run(Callback _func, void* _data = NULL);
 		void consume();
 
 		uint32_t m_queueFamily;
@@ -742,15 +728,6 @@ VK_DESTROY
 
 		typedef stl::vector<Resource> ResourceArray;
 		ResourceArray m_release[BGFX_CONFIG_MAX_FRAME_LATENCY];
-
-		struct RunData
-		{
-			Callback m_func;
-			void* m_data;
-		};
-
-		typedef stl::vector<RunData> RunDataArray;
-		RunDataArray m_run[BGFX_CONFIG_MAX_FRAME_LATENCY];
 	};
 
 } /* namespace bgfx */ } // namespace vk

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -596,7 +596,7 @@ VK_DESTROY
 		};
 
 		void create(VkImage _image, uint32_t _width, uint32_t _height, bimg::TextureFormat::Enum _format);
-		void destroy() {}
+		void destroy();
 		uint32_t pitch(uint8_t _mip = 0) const;
 		void copyImageToBuffer(VkCommandBuffer _commandBuffer, VkBuffer _buffer, VkImageLayout _layout, VkImageAspectFlags _aspect, uint8_t _mip = 0) const;
 		void readback(const Data& _data) const;


### PR DESCRIPTION
This PR reworks the synchronization in the Vulkan backend to allow pushing render commands ahead of the GPU, similarly to the existing backends.

Currently there's a CPU stall after every compute shader, texture/buffer transfer and render pass (all draw calls of one view). This results in high CPU frame time not only because of the stall (CPU does nothing while GPU is busy) but also because of the non-negligible cost of submitting command buffers. For some examples this easily wastes > 1ms of CPU time.

The frame latency can be controlled with [`Init::Resolution::maxFrameLatency`](https://bkaradzic.github.io/bgfx/bgfx.html#_CPPv4N4bgfx10Resolution15maxFrameLatencyE), from 1 to 3. Using 0 there defaults to 3, similar to the D3D11/12 backends. Current behaviour is similar to a fixed latency of 1, only ever allowing 1 frame to be encoded or executed at the same time. A latency of 2 allows one frame to be encoded on the CPU while another frame is rendering on the GPU, etc.

I would appreciate if anyone could test this with systems I have no access to. The only environment I could test on was an Nvidia card on Windows 10. While the validation layers are happy, there might be subtle bugs in the swapchain interaction that just didn't surface for me.

Sorry for the huge changelist, but this touched just about every part of the code. Looking at single commits might make the changes easier to follow.

### Numbers

Some measurements with example 09-hdr (Release, Nvidia GTX 1070, Win 10):

#### Old code:

| Function | # of calls | combined CPU time |
| --- |---:| ---:|
| `vkQueueSubmit` | 17 | 0.4ms |
| `vkQueueWaitIdle` | 17 | 1.2ms |
| `vkWaitForFences` | 0 | -- |
| Total | -- | 1.6ms |

#### New code, frame latency 3 (default):

Note: there are two submissions because the example uses texture readback.

| Function | # of calls | combined CPU time |
| --- |---:| ---:|
| `vkQueueSubmit` | 2 | 0.1ms |
| `vkQueueWaitIdle` | 0 | -- |
| `vkWaitForFences` | 4 | 0.03ms |
| Total | -- | 0.2ms |

#### New code, frame latency 1:

| Function | # of calls | acc. CPU time |
| --- |---:| ---:|
| `vkQueueSubmit` | 2 | 0.1ms |
| `vkQueueWaitIdle` | 0 | -- |
| `vkWaitForFences` | 4 | 0.3ms |
| Total | -- | 0.4ms |

### Extra fixes

Because I was already working on it:

- Swapchain images are not acquired if no view in the frame renders to the backbuffer. Potentially fixes https://github.com/bkaradzic/bgfx/issues/1936
- Textures can be assigned a debug name now
- Cubemap blitting from and to faces > 0 was fixed

### Related Todo

Possible future fixes:

- Rework swapchain recreation to retire all swapchain-related items and release them deferred, instead of stalling the GPU. This should make resizing a lot smoother.

### Details

Some more info for anyone curious:

Frames are encoded in a ring buffer of command buffers (in `CommandQueueVK`). An entire frame is recorded to a single command buffer, so there's only ever one `vkQueueSubmit` per frame (with the exception of texture/screenshot readback). Frames are serialized by making each submission wait on the previous submission's semaphore. This has the useful side effect of introducing a full memory barrier between consecutive frames.

Before rendering the frame a single memory barrier makes sure that all transfer operations (texture and buffer creation/updates) are finished and visible. Render passes are synchronized to other render passes and compute dispatches via external subpass dependencies (roughly `ALL_COMMANDS` -> `GRAPHICS` -> `ALL_COMMANDS`). Since subpass dependencies don't cover compute dispatches, we need to serialize those with another memory barrier between them.

The barriers and dependencies could, in a future change, be made more fine-grained, depending on things like framebuffer attachment flags, etc.

