### PR TITLE
blit handle num layers of 2d texture array

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -3910,9 +3910,10 @@ namespace bgfx
 		uint32_t srcHeight = bx::max<uint32_t>(1, src.m_height >> _srcMip);
 		uint32_t dstWidth  = bx::max<uint32_t>(1, dst.m_width  >> _dstMip);
 		uint32_t dstHeight = bx::max<uint32_t>(1, dst.m_height >> _dstMip);
-
-		uint32_t srcDepth  = src.isCubeMap() ? 6 : bx::max<uint32_t>(1, src.m_depth >> _srcMip);
-		uint32_t dstDepth  = dst.isCubeMap() ? 6 : bx::max<uint32_t>(1, dst.m_depth >> _dstMip);
+		
+		// support cube map, texture array layers, or 3d texture depth.
+		uint32_t srcDepth  = src.isCubeMap() ? 6 : bx::max<uint32_t>(src.m_numLayers, src.m_depth >> _srcMip);
+		uint32_t dstDepth  = dst.isCubeMap() ? 6 : bx::max<uint32_t>(dst.m_numLayers, dst.m_depth >> _dstMip);
 
 		BX_ASSERT(_srcX < srcWidth && _srcY < srcHeight && _srcZ < srcDepth
 			, "Blit src coordinates out of range (%d, %d, %d) >= (%d, %d, %d)"


### PR DESCRIPTION
confirmed to work on gl_renderer.cpp glCopyImageSubData

This should allow for users to blit all slices of a texture array. (still need to blit each mip individually)