### PR TITLE
Various Vulkan fixes

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3717,7 +3717,7 @@ VK_IMPORT_DEVICE
 			sci.addressModeU     = s_textureAddress[(_samplerFlags&BGFX_SAMPLER_U_MASK)>>BGFX_SAMPLER_U_SHIFT];
 			sci.addressModeV     = s_textureAddress[(_samplerFlags&BGFX_SAMPLER_V_MASK)>>BGFX_SAMPLER_V_SHIFT];
 			sci.addressModeW     = s_textureAddress[(_samplerFlags&BGFX_SAMPLER_W_MASK)>>BGFX_SAMPLER_W_SHIFT];
-			sci.mipLodBias       = 0.0f;
+			sci.mipLodBias       = float(BGFX_CONFIG_MIP_LOD_BIAS);
 			sci.anisotropyEnable = VK_FALSE;
 			sci.maxAnisotropy    = m_maxAnisotropy;
 			sci.compareEnable    = 0 != cmpFunc;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -1595,6 +1595,7 @@ VK_IMPORT_INSTANCE
 					goto error;
 				}
 
+				VkPhysicalDevice fallbackPhysicalDevice = VK_NULL_HANDLE;
 				m_physicalDevice = VK_NULL_HANDLE;
 
 				for (uint32_t ii = 0; ii < numPhysicalDevices; ++ii)
@@ -1620,7 +1621,14 @@ VK_IMPORT_INSTANCE
 					&&   (BGFX_PCI_ID_NONE == g_caps.vendorId || pdp.vendorID == g_caps.vendorId)
 					&&   (0 == g_caps.deviceId                || pdp.deviceID == g_caps.deviceId) )
 					{
-						m_physicalDevice = physicalDevices[ii];
+						if (BX_ENABLED(BGFX_CONFIG_PREFER_DISCRETE_GPU) && (pdp.deviceType != VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) )
+						{
+							fallbackPhysicalDevice = physicalDevices[ii];
+						}
+						else
+						{
+							m_physicalDevice = physicalDevices[ii];
+						}
 					}
 
 					VkPhysicalDeviceMemoryProperties pdmp;
@@ -1653,7 +1661,10 @@ VK_IMPORT_INSTANCE
 
 				if (VK_NULL_HANDLE == m_physicalDevice)
 				{
-					m_physicalDevice = physicalDevices[0];
+					m_physicalDevice = VK_NULL_HANDLE == fallbackPhysicalDevice
+						? physicalDevices[0]
+						: fallbackPhysicalDevice
+						;
 				}
 
 				vkGetPhysicalDeviceProperties(m_physicalDevice, &m_deviceProperties);

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3414,6 +3414,15 @@ VK_IMPORT_DEVICE
 			m_rtMsaa = _msaa;
 		}
 
+		void setDebugWireframe(bool _wireframe)
+		{
+			if (m_wireframe != _wireframe)
+			{
+				m_wireframe = _wireframe;
+				m_pipelineStateCache.invalidate();
+			}
+		}
+
 		void setBlendState(VkPipelineColorBlendStateCreateInfo& _desc, uint64_t _state, uint32_t _rgba = 0)
 		{
 			VkPipelineColorBlendAttachmentState* bas = const_cast<VkPipelineColorBlendAttachmentState*>(_desc.pAttachments);
@@ -3955,7 +3964,7 @@ VK_IMPORT_DEVICE
 			inputAssemblyState.primitiveRestartEnable = VK_FALSE;
 
 			VkPipelineRasterizationStateCreateInfo rasterizationState;
-			setRasterizerState(rasterizationState, _state);
+			setRasterizerState(rasterizationState, _state, m_wireframe);
 
 			VkPipelineDepthStencilStateCreateInfo depthStencilState;
 			setDepthStencilState(depthStencilState, _state, _stencil);
@@ -6631,8 +6640,8 @@ VK_DESTROY
 		static ViewState viewState;
 		viewState.reset(_render);
 
-// 		bool wireframe = !!(_render->m_debug&BGFX_DEBUG_WIREFRAME);
-// 		setDebugWireframe(wireframe);
+		bool wireframe = !!(_render->m_debug&BGFX_DEBUG_WIREFRAME);
+		setDebugWireframe(wireframe);
 
 		uint16_t currentSamplerStateIdx = kInvalidHandle;
 		ProgramHandle currentProgram    = BGFX_INVALID_HANDLE;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -667,8 +667,7 @@ VK_IMPORT_DEVICE
 			if (VK_SUCCESS == result
 			&&  0 < numExtensionProperties)
 			{
-				VkExtensionProperties extensionProperties[64];
-				numExtensionProperties = bx::min<uint32_t>(numExtensionProperties, BX_COUNTOF(extensionProperties) );
+				VkExtensionProperties* extensionProperties = (VkExtensionProperties*)BX_ALLOC(g_allocator, numExtensionProperties * sizeof(VkExtensionProperties) );
 				result = enumerateExtensionProperties(_physicalDevice
 					, NULL
 					, &numExtensionProperties
@@ -695,6 +694,8 @@ VK_IMPORT_DEVICE
 
 					BX_UNUSED(supported);
 				}
+
+				BX_FREE(g_allocator, extensionProperties);
 			}
 		}
 
@@ -705,8 +706,7 @@ VK_IMPORT_DEVICE
 		if (VK_SUCCESS == result
 		&&  0 < numLayerProperties)
 		{
-			VkLayerProperties layerProperties[64];
-			numLayerProperties = bx::min<uint32_t>(numLayerProperties, BX_COUNTOF(layerProperties) );
+			VkLayerProperties* layerProperties = (VkLayerProperties*)BX_ALLOC(g_allocator, numLayerProperties * sizeof(VkLayerProperties) );
 			result = enumerateLayerProperties(_physicalDevice, &numLayerProperties, layerProperties);
 
 			char indent = VK_NULL_HANDLE == _physicalDevice ? '\0' : '\t';
@@ -741,8 +741,7 @@ VK_IMPORT_DEVICE
 				if (VK_SUCCESS == result
 				&&  0 < numExtensionProperties)
 				{
-					VkExtensionProperties extensionProperties[64];
-					numExtensionProperties = bx::min<uint32_t>(numExtensionProperties, BX_COUNTOF(extensionProperties) );
+					VkExtensionProperties* extensionProperties = (VkExtensionProperties*)BX_ALLOC(g_allocator, numExtensionProperties * sizeof(VkExtensionProperties) );
 					result = enumerateExtensionProperties(_physicalDevice
 						, layerProperties[layer].layerName
 						, &numExtensionProperties
@@ -766,8 +765,12 @@ VK_IMPORT_DEVICE
 
 						BX_UNUSED(supported);
 					}
+
+					BX_FREE(g_allocator, extensionProperties);
 				}
 			}
+
+			BX_FREE(g_allocator, layerProperties);
 		}
 	}
 

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -1005,7 +1005,7 @@ VK_IMPORT_DEVICE
 			: m_allocatorCb(NULL)
 			, m_renderDocDll(NULL)
 			, m_vulkan1Dll(NULL)
-			, m_maxAnisotropy(1)
+			, m_maxAnisotropy(1.0f)
 			, m_depthClamp(false)
 			, m_wireframe(false)
 			, m_rtMsaa(false)
@@ -3134,13 +3134,16 @@ VK_IMPORT_DEVICE
 
 		bool updateResolution(const Resolution& _resolution)
 		{
+			float maxAnisotropy = 1.0f;
 			if (!!(_resolution.reset & BGFX_RESET_MAXANISOTROPY) )
 			{
-				m_maxAnisotropy = UINT32_MAX;
+				maxAnisotropy = m_deviceProperties.limits.maxSamplerAnisotropy;
 			}
-			else
+
+			if (m_maxAnisotropy != maxAnisotropy)
 			{
-				m_maxAnisotropy = 1;
+				m_maxAnisotropy = maxAnisotropy;
+				m_samplerCache.invalidate();
 			}
 
 			bool depthClamp = !!(_resolution.reset & BGFX_RESET_DEPTH_CLAMP);
@@ -3716,7 +3719,7 @@ VK_IMPORT_DEVICE
 			sci.addressModeW     = s_textureAddress[(_samplerFlags&BGFX_SAMPLER_W_MASK)>>BGFX_SAMPLER_W_SHIFT];
 			sci.mipLodBias       = 0.0f;
 			sci.anisotropyEnable = VK_FALSE;
-			sci.maxAnisotropy    = 4.0f;
+			sci.maxAnisotropy    = m_maxAnisotropy;
 			sci.compareEnable    = 0 != cmpFunc;
 			sci.compareOp        = s_cmpFunc[cmpFunc];
 			sci.minLod           = 0.0f;
@@ -4608,7 +4611,7 @@ VK_IMPORT_DEVICE
 		StateCacheT<VkSampler> m_samplerCache;
 
 		Resolution m_resolution;
-		uint32_t m_maxAnisotropy;
+		float m_maxAnisotropy;
 		bool m_depthClamp;
 		bool m_wireframe;
 		bool m_rtMsaa;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -317,6 +317,7 @@ VK_IMPORT_DEVICE
 			EXT_debug_report,
 			EXT_memory_budget,
 			KHR_get_physical_device_properties2,
+			EXT_shader_viewport_index_layer,
 
 			Count
 		};
@@ -337,6 +338,7 @@ VK_IMPORT_DEVICE
 		{ "VK_EXT_debug_report",                    1, false, false, BGFX_CONFIG_DEBUG            , Layer::Count },
 		{ "VK_EXT_memory_budget",                   1, false, false, true                         , Layer::Count },
 		{ "VK_KHR_get_physical_device_properties2", 1, false, false, true                         , Layer::Count },
+		{ "VK_EXT_shader_viewport_index_layer",     1, false, false, true                         , Layer::Count }
 	};
 	BX_STATIC_ASSERT(Extension::Count == BX_COUNTOF(s_extension) );
 
@@ -1693,6 +1695,10 @@ VK_IMPORT_INSTANCE
 					| BGFX_CAPS_VERTEX_ID
 					| BGFX_CAPS_IMAGE_RW
 					);
+
+				g_caps.supported |= 0
+					| (s_extension[Extension::EXT_shader_viewport_index_layer].m_supported ? BGFX_CAPS_VIEWPORT_LAYER_ARRAY : 0)
+					;
 
 				g_caps.limits.maxTextureSize     = m_deviceProperties.limits.maxImageDimension2D;
 				g_caps.limits.maxTextureLayers   = m_deviceProperties.limits.maxImageArrayLayers;
@@ -4426,6 +4432,7 @@ VK_IMPORT_DEVICE
 			{
 				const FrameBufferVK& fb = m_frameBuffers[fbh.idx];
 				numMrt = fb.m_num;
+				rect[0].layerCount = fb.m_attachment[0].numLayers;
 			}
 
 			VkClearAttachment attachments[BGFX_CONFIG_MAX_FRAME_BUFFERS];

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -667,6 +667,7 @@ VK_DESTROY
 			, m_denseIdx(kInvalidHandle)
 			, m_num(0)
 			, m_numTh(0)
+			, m_needRecreate(false)
 			, m_framebuffer(VK_NULL_HANDLE)
 		{
 		}
@@ -683,6 +684,7 @@ VK_DESTROY
 		uint8_t m_num;
 		uint8_t m_numTh;
 		uint8_t m_numAttachment;
+		bool m_needRecreate;
 		Attachment m_attachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 		VkFramebuffer m_framebuffer;
 		VkRenderPass m_renderPass;

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -389,23 +389,6 @@ VK_DESTROY
 		uint32_t m_maxDescriptors;
 	};
 
-	struct ImageVK
-	{
-		ImageVK()
-			: m_memory(VK_NULL_HANDLE)
-			, m_image(VK_NULL_HANDLE)
-			, m_imageView(VK_NULL_HANDLE)
-		{
-		}
-
-		VkResult create(VkFormat _format, const VkExtent3D& _extent);
-		void destroy();
-
-		VkDeviceMemory m_memory;
-		VkImage        m_image;
-		VkImageView    m_imageView;
-	};
-
 	struct BufferVK
 	{
 		BufferVK()
@@ -610,7 +593,6 @@ VK_DESTROY
 			, m_textureDeviceMem(VK_NULL_HANDLE)
 			, m_textureImageView(VK_NULL_HANDLE)
 			, m_textureImageDepthView(VK_NULL_HANDLE)
-			, m_textureImageStorageView(VK_NULL_HANDLE)
 			, m_currentImageLayout(VK_IMAGE_LAYOUT_UNDEFINED)
 			, m_singleMsaaImage(VK_NULL_HANDLE)
 			, m_singleMsaaDeviceMem(VK_NULL_HANDLE)
@@ -625,6 +607,8 @@ VK_DESTROY
 
 		void copyBufferToTexture(VkCommandBuffer _commandBuffer, VkBuffer _stagingBuffer, uint32_t _bufferImageCopyCount, VkBufferImageCopy* _bufferImageCopy);
 		void setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout);
+
+		VkImageView createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips) const;
 
 		void*    m_directAccessPtr;
 		uint64_t m_flags;
@@ -648,7 +632,6 @@ VK_DESTROY
 		VkDeviceMemory m_textureDeviceMem;
 		VkImageView    m_textureImageView;
 		VkImageView    m_textureImageDepthView;
-		VkImageView    m_textureImageStorageView;
 		VkImageLayout  m_currentImageLayout;
 
 		VkImage        m_singleMsaaImage;
@@ -683,9 +666,10 @@ VK_DESTROY
 		uint16_t m_denseIdx;
 		uint8_t m_num;
 		uint8_t m_numTh;
-		uint8_t m_numAttachment;
 		bool m_needRecreate;
 		Attachment m_attachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
+
+		VkImageView m_textureImageViews[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 		VkFramebuffer m_framebuffer;
 		VkRenderPass m_renderPass;
 	};


### PR DESCRIPTION
Miscellaneous fixes for the Vulkan backend, mostly involving textures:

- resize textures that are based on backbuffer ratio (fixes example 09-hdr when resizing)
- support for indirect draw (fixes example 41-tess)
- support for texture array framebuffers (fixes example 08-update [framebuffer cube] and 21-deferred, just some minor validation errors left)
    - related: support for VPRT (see https://github.com/bkaradzic/bgfx/issues/2320)
- `BGFX_CONFIG_PREFER_DISCRETE_GPU` is used for device selection (`NvOptimusEnablement`/`AmdPowerXpressRequestHighPerformance` are not enough since they only make the discrete GPU visible)
- use `BGFX_CONFIG_MIP_LOD_BIAS`
- support for `BGFX_DEBUG_WIREFRAME`