### PR TITLE
Vulkan: fix scratch buffer size calculation

### DIFF
--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -369,9 +369,10 @@ VK_DESTROY
 		{
 		}
 
-		void create(uint32_t _size, uint32_t _maxDescriptors);
+		void create(uint32_t _size, uint32_t _count, uint32_t _maxDescriptors);
 		void destroy();
 		void reset();
+		uint32_t write(const void* _data, uint32_t _size);
 		void flush();
 
 		VkDescriptorSet& getCurrentDS()


### PR DESCRIPTION
The scratchbuffer was running out of space because the size was calculated with a different alignment than was used to advance entries. Only an issue at high amount of draw calls, more specifically it crashed example 17-drawstress.

Next step, actually outperform GL in draw call performance 👀 