### PR TITLE
Make shaderc output independent of backend enums

### DIFF
--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -635,7 +635,7 @@ project "shaderc"
 		path.join(BGFX_DIR, "tools/shaderc/**.cpp"),
 		path.join(BGFX_DIR, "tools/shaderc/**.h"),
 		path.join(BGFX_DIR, "src/vertexlayout.**"),
-		path.join(BGFX_DIR, "src/shader_spirv.**"),
+		path.join(BGFX_DIR, "src/shader**"),
 	}
 
 	configuration { "mingw-*" }

--- a/src/amalgamated.cpp
+++ b/src/amalgamated.cpp
@@ -20,6 +20,7 @@
 #include "renderer_nvn.cpp"
 #include "renderer_vk.cpp"
 #include "renderer_webgpu.cpp"
+#include "shader.cpp"
 #include "shader_dx9bc.cpp"
 #include "shader_dxbc.cpp"
 #include "shader_spirv.cpp"

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -5067,9 +5067,10 @@ VK_DESTROY
 				uint16_t regCount;
 				bx::read(&reader, regCount);
 
-				uint8_t texComponent = textureComponentTypeToId(TextureComponentType::Undefined);
-				uint8_t texDimension = textureDimensionToId(TextureDimension::Undefined);
-				if (!isShaderVerLess(magic, 8) )
+				const bool hasTexData = !isShaderVerLess(magic, 8);
+				uint8_t texComponent = 0;
+				uint8_t texDimension = 0;
+				if (hasTexData)
 				{
 					bx::read(&reader, texComponent);
 					bx::read(&reader, texDimension);

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -5067,12 +5067,18 @@ VK_DESTROY
 				uint16_t regCount;
 				bx::read(&reader, regCount);
 
+				uint8_t texComponent = textureComponentTypeToId(TextureComponentType::Undefined);
+				uint8_t texDimension = textureDimensionToId(TextureDimension::Undefined);
 				if (!isShaderVerLess(magic, 8) )
 				{
-					uint16_t texInfo = 0;
-					bx::read(&reader, texInfo);
+					bx::read(&reader, texComponent);
+					bx::read(&reader, texDimension);
 				}
+
 				const char* kind = "invalid";
+
+				BX_UNUSED(num);
+				BX_UNUSED(texComponent);
 
 				if (UINT16_MAX != regIndex)
 				{
@@ -5088,7 +5094,7 @@ VK_DESTROY
 					else if (UniformType::End == (~kUniformMask & type) )
 					{
 						// regCount is used for descriptor type
-						const bool  isBuffer = regCount == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+						const bool isBuffer = idToDescriptorType(regCount) == DescriptorType::StorageBuffer;
 						const uint16_t stage = regIndex - (isBuffer ? 16 : 32) - (fragment ? 48 : 0);  // regIndex is used for buffer binding index
 
 						m_bindInfo[stage].type = isBuffer ? BindType::Buffer : BindType::Image;
@@ -5129,13 +5135,14 @@ VK_DESTROY
 					}
 				}
 
-				BX_TRACE("\t%s: %s (%s), num %2d, r.index %3d, r.count %2d"
+				BX_TRACE("\t%s: %s (%s), r.index %3d, r.count %2d, r.texComponent %1d, r.texDimension %1d"
 					, kind
 					, name
 					, getUniformTypeName(UniformType::Enum(type&~kUniformMask) )
-					, num
 					, regIndex
 					, regCount
+					, texComponent
+					, texDimension
 					);
 				BX_UNUSED(kind);
 			}

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -21,9 +21,8 @@ namespace bgfx
 		// NOTICE:
 		// DescriptorType must be in order how it appears in DescriptorType::Enum! id is
 		// unique and should not be changed if new DescriptorTypes are added.
-		{ DescriptorType::Undefined,     0xFFFF },
-		{ DescriptorType::StorageBuffer, 0x0007 }, // VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
-		{ DescriptorType::StorageImage,  0x0003 }, // VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+		{ DescriptorType::StorageBuffer, 0x0007 },
+		{ DescriptorType::StorageImage,  0x0003 },
 	};
 	BX_STATIC_ASSERT(BX_COUNTOF(s_descriptorTypeToId) == DescriptorType::Count);
 
@@ -37,7 +36,7 @@ namespace bgfx
 			}
 		}
 
-		return DescriptorType::Undefined;
+		return DescriptorType::Count;
 	}
 
 	uint16_t descriptorTypeToId(DescriptorType::Enum _type)
@@ -54,10 +53,9 @@ namespace bgfx
 	static TextureComponentTypeToId s_textureComponentTypeToId[] =
 	{
 		// see comment in s_descriptorTypeToId
-		{ TextureComponentType::Undefined, 0xFF },
-		{ TextureComponentType::Float,     0x00 }, // wgpu::TextureComponentType::Float
-		{ TextureComponentType::Int,       0x01 }, // wgpu::TextureComponentType::Sint
-		{ TextureComponentType::Uint,      0x02 }, // wgpu::TextureComponentType::Uint
+		{ TextureComponentType::Float,     0x00 },
+		{ TextureComponentType::Int,       0x01 },
+		{ TextureComponentType::Uint,      0x02 },
 	};
 	BX_STATIC_ASSERT(BX_COUNTOF(s_textureComponentTypeToId) == TextureComponentType::Count);
 
@@ -71,7 +69,7 @@ namespace bgfx
 			}
 		}
 
-		return TextureComponentType::Undefined;
+		return TextureComponentType::Count;
 	}
 
 	uint8_t textureComponentTypeToId(TextureComponentType::Enum _type)
@@ -88,13 +86,12 @@ namespace bgfx
 	static TextureDimensionToId s_textureDimensionToId[] =
 	{
 		// see comment in s_descriptorTypeToId
-		{ TextureDimension::Undefined,          0x00 }, // wgpu::TextureViewDimension::Undefined
-		{ TextureDimension::Dimension1D,        0x01 }, // wgpu::TextureViewDimension::e1D
-		{ TextureDimension::Dimension2D,        0x02 }, // wgpu::TextureComponentType::e2D
-		{ TextureDimension::Dimension2DArray,   0x03 }, // wgpu::TextureComponentType::e2DArray
-		{ TextureDimension::DimensionCube,      0x04 }, // wgpu::TextureComponentType::Cube
-		{ TextureDimension::DimensionCubeArray, 0x05 }, // wgpu::TextureComponentType::CubeArray
-		{ TextureDimension::Dimension3D,        0x06 }, // wgpu::TextureComponentType::e3D
+		{ TextureDimension::Dimension1D,        0x01 },
+		{ TextureDimension::Dimension2D,        0x02 },
+		{ TextureDimension::Dimension2DArray,   0x03 },
+		{ TextureDimension::DimensionCube,      0x04 },
+		{ TextureDimension::DimensionCubeArray, 0x05 },
+		{ TextureDimension::Dimension3D,        0x06 },
 	};
 	BX_STATIC_ASSERT(BX_COUNTOF(s_textureDimensionToId) == TextureDimension::Count);
 
@@ -108,7 +105,7 @@ namespace bgfx
 			}
 		}
 
-		return TextureDimension::Undefined;
+		return TextureDimension::Count;
 	}
 
 	uint8_t textureDimensionToId(TextureDimension::Enum _dim)

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -10,6 +10,112 @@
 
 namespace bgfx
 {
+	struct DescriptorTypeToId
+	{
+		DescriptorType::Enum type;
+		uint16_t id;
+	};
+
+	static DescriptorTypeToId s_descriptorTypeToId[] =
+	{
+		// NOTICE:
+		// DescriptorType must be in order how it appears in DescriptorType::Enum! id is
+		// unique and should not be changed if new DescriptorTypes are added.
+		{ DescriptorType::Undefined,     0xFFFF },
+		{ DescriptorType::StorageBuffer, 0x0007 }, // VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
+		{ DescriptorType::StorageImage,  0x0003 }, // VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+	};
+	BX_STATIC_ASSERT(BX_COUNTOF(s_descriptorTypeToId) == DescriptorType::Count);
+
+	DescriptorType::Enum idToDescriptorType(uint16_t _id)
+	{
+		for (uint32_t ii = 0; ii < BX_COUNTOF(s_descriptorTypeToId); ++ii)
+		{
+			if (s_descriptorTypeToId[ii].id == _id)
+			{
+				return s_descriptorTypeToId[ii].type;
+			}
+		}
+
+		return DescriptorType::Undefined;
+	}
+
+	uint16_t descriptorTypeToId(DescriptorType::Enum _type)
+	{
+		return s_descriptorTypeToId[_type].id;
+	}
+
+	struct TextureComponentTypeToId
+	{
+		TextureComponentType::Enum type;
+		uint8_t id;
+	};
+
+	static TextureComponentTypeToId s_textureComponentTypeToId[] =
+	{
+		// see comment in s_descriptorTypeToId
+		{ TextureComponentType::Undefined, 0xFF },
+		{ TextureComponentType::Float,     0x00 }, // wgpu::TextureComponentType::Float
+		{ TextureComponentType::Int,       0x01 }, // wgpu::TextureComponentType::Sint
+		{ TextureComponentType::Uint,      0x02 }, // wgpu::TextureComponentType::Uint
+	};
+	BX_STATIC_ASSERT(BX_COUNTOF(s_textureComponentTypeToId) == TextureComponentType::Count);
+
+	TextureComponentType::Enum idToTextureComponentType(uint8_t _id)
+	{
+		for (uint32_t ii = 0; ii < BX_COUNTOF(s_textureComponentTypeToId); ++ii)
+		{
+			if (s_textureComponentTypeToId[ii].id == _id)
+			{
+				return s_textureComponentTypeToId[ii].type;
+			}
+		}
+
+		return TextureComponentType::Undefined;
+	}
+
+	uint8_t textureComponentTypeToId(TextureComponentType::Enum _type)
+	{
+		return s_textureComponentTypeToId[_type].id;
+	}
+
+	struct TextureDimensionToId
+	{
+		TextureDimension::Enum dimension;
+		uint8_t id;
+	};
+
+	static TextureDimensionToId s_textureDimensionToId[] =
+	{
+		// see comment in s_descriptorTypeToId
+		{ TextureDimension::Undefined,          0x00 }, // wgpu::TextureViewDimension::Undefined
+		{ TextureDimension::Dimension1D,        0x01 }, // wgpu::TextureViewDimension::e1D
+		{ TextureDimension::Dimension2D,        0x02 }, // wgpu::TextureComponentType::e2D
+		{ TextureDimension::Dimension2DArray,   0x03 }, // wgpu::TextureComponentType::e2DArray
+		{ TextureDimension::DimensionCube,      0x04 }, // wgpu::TextureComponentType::Cube
+		{ TextureDimension::DimensionCubeArray, 0x05 }, // wgpu::TextureComponentType::CubeArray
+		{ TextureDimension::Dimension3D,        0x06 }, // wgpu::TextureComponentType::e3D
+	};
+	BX_STATIC_ASSERT(BX_COUNTOF(s_textureDimensionToId) == TextureDimension::Count);
+
+	TextureDimension::Enum idToTextureDimension(uint8_t _id)
+	{
+		for (uint32_t ii = 0; ii < BX_COUNTOF(s_textureDimensionToId); ++ii)
+		{
+			if (s_textureDimensionToId[ii].id == _id)
+			{
+				return s_textureDimensionToId[ii].dimension;
+			}
+		}
+
+		return TextureDimension::Undefined;
+	}
+
+	uint8_t textureDimensionToId(TextureDimension::Enum _dim)
+	{
+		return s_textureDimensionToId[_dim].id;
+	}
+
 	static bool printAsm(uint32_t _offset, const DxbcInstruction& _instruction, void* _userData)
 	{
 		BX_UNUSED(_offset);

--- a/src/shader.h
+++ b/src/shader.h
@@ -10,6 +10,56 @@
 
 namespace bgfx
 {
+	struct DescriptorType
+	{
+		enum Enum
+		{
+			Undefined,
+			StorageBuffer,
+			StorageImage,
+
+			Count
+		};
+	};
+
+	DescriptorType::Enum idToDescriptorType(uint16_t _id);
+	uint16_t descriptorTypeToId(DescriptorType::Enum _type);
+
+	struct TextureComponentType
+	{
+		enum Enum
+		{
+			Undefined,
+			Float,
+			Int,
+			Uint,
+
+			Count
+		};
+	};
+
+	TextureComponentType::Enum idToTextureComponentType(uint8_t _id);
+	uint8_t textureComponentTypeToId(TextureComponentType::Enum _type);
+
+	struct TextureDimension
+	{
+		enum Enum
+		{
+			Undefined,
+			Dimension1D,
+			Dimension2D,
+			Dimension2DArray,
+			DimensionCube,
+			DimensionCubeArray,
+			Dimension3D,
+
+			Count
+		};
+	};
+
+	TextureDimension::Enum idToTextureDimension(uint8_t _id);
+	uint8_t textureDimensionToId(TextureDimension::Enum _dim);
+
 	///
 	void disassemble(bx::WriterI* _writer, bx::ReaderSeekerI* _reader, bx::Error* _err = NULL);
 

--- a/src/shader.h
+++ b/src/shader.h
@@ -14,7 +14,6 @@ namespace bgfx
 	{
 		enum Enum
 		{
-			Undefined,
 			StorageBuffer,
 			StorageImage,
 
@@ -29,7 +28,6 @@ namespace bgfx
 	{
 		enum Enum
 		{
-			Undefined,
 			Float,
 			Int,
 			Uint,
@@ -45,7 +43,6 @@ namespace bgfx
 	{
 		enum Enum
 		{
-			Undefined,
 			Dimension1D,
 			Dimension2D,
 			Dimension2DArray,

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -104,7 +104,7 @@ namespace bgfx
 		{  ShadingLang::HLSL,  500,    "s_5_0"      },
 		{  ShadingLang::Metal, 1000,   "metal"      },
 		{  ShadingLang::PSSL,  1000,   "pssl"       },
-		{  ShadingLang::SpirV, 1331,   "spirv13-11" },
+		{  ShadingLang::SpirV, 1311,   "spirv13-11" },
 		{  ShadingLang::SpirV, 1411,   "spirv14-11" },
 		{  ShadingLang::SpirV, 1512,   "spirv15-12" },
 		{  ShadingLang::SpirV, 1010,   "spirv10-10" },

--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -214,7 +214,8 @@ namespace bgfx { namespace spirv
 				: bgfx::TextureDimension::DimensionCube
 				;
 		default:
-			return bgfx::TextureDimension::Undefined;
+			BX_ASSERT(false, "Unknown texture dimension %d", _dim);
+			return bgfx::TextureDimension::Dimension2D;
 		}
 	}
 

--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -56,6 +56,7 @@ namespace bgfx
 #include <tinystl/vector.h>
 namespace stl = tinystl;
 
+#include "../../src/shader.h"
 #include "../../src/shader_spirv.h"
 #include "../../3rdparty/khronos/vulkan-local/vulkan.h"
 
@@ -179,39 +180,41 @@ namespace bgfx { namespace spirv
 		return true;
 	}
 
-	wgpu::TextureComponentType SpirvCrossBaseTypeToFormatType(spirv_cross::SPIRType::BaseType spirvBaseType)
+	bgfx::TextureComponentType::Enum SpirvCrossBaseTypeToFormatType(spirv_cross::SPIRType::BaseType _type)
 	{
-		switch (spirvBaseType)
+		switch (_type)
 		{
 		case spirv_cross::SPIRType::Float:
-			return wgpu::TextureComponentType::Float;
+			return bgfx::TextureComponentType::Float;
 		case spirv_cross::SPIRType::Int:
-			return wgpu::TextureComponentType::Sint;
+			return bgfx::TextureComponentType::Int;
 		case spirv_cross::SPIRType::UInt:
-			return wgpu::TextureComponentType::Uint;
+			return bgfx::TextureComponentType::Uint;
 		default:
-		    return wgpu::TextureComponentType::Float;
+		    return bgfx::TextureComponentType::Float;
 		}
 	}
 
-	wgpu::TextureViewDimension SpirvDimToTextureViewDimension(spv::Dim dim, bool arrayed)
+	bgfx::TextureDimension::Enum SpirvDimToTextureViewDimension(spv::Dim _dim, bool _arrayed)
 	{
-		switch (dim)
+		switch (_dim)
 		{
 		case spv::Dim::Dim1D:
-			return wgpu::TextureViewDimension::e1D;
+			return bgfx::TextureDimension::Dimension1D;
 		case spv::Dim::Dim2D:
-			return arrayed
-				? wgpu::TextureViewDimension::e2DArray
-				: wgpu::TextureViewDimension::e2D;
+			return _arrayed
+				? bgfx::TextureDimension::Dimension2DArray
+				: bgfx::TextureDimension::Dimension2D
+				;
 		case spv::Dim::Dim3D:
-			return wgpu::TextureViewDimension::e3D;
+			return bgfx::TextureDimension::Dimension3D;
 		case spv::Dim::DimCube:
-			return arrayed
-				? wgpu::TextureViewDimension::CubeArray
-				: wgpu::TextureViewDimension::Cube;
+			return _arrayed
+				? bgfx::TextureDimension::DimensionCubeArray
+				: bgfx::TextureDimension::DimensionCube
+				;
 		default:
-			return wgpu::TextureViewDimension::Undefined;
+			return bgfx::TextureDimension::Undefined;
 		}
 	}
 
@@ -1077,8 +1080,8 @@ namespace bgfx { namespace spirv
 									| (isCompareSampler ? kUniformCompareBit : 0)
 									);
 
-							un.texComponent = uint8_t(SpirvCrossBaseTypeToFormatType(componentType) );
-							un.texDimension = uint8_t(SpirvDimToTextureViewDimension(imageType.dim, imageType.arrayed) );
+							un.texComponent = textureComponentTypeToId(SpirvCrossBaseTypeToFormatType(componentType) );
+							un.texDimension = textureDimensionToId(SpirvDimToTextureViewDimension(imageType.dim, imageType.arrayed) );
 
 							un.regIndex = binding_index;
 							un.regCount = 0; // unused
@@ -1110,11 +1113,11 @@ namespace bgfx { namespace spirv
 							un.name = uniform_name;
 							un.type = type;
 
-							un.texComponent = uint8_t(SpirvCrossBaseTypeToFormatType(componentType) );
-							un.texDimension = uint8_t(SpirvDimToTextureViewDimension(imageType.dim, imageType.arrayed) );
+							un.texComponent = textureComponentTypeToId(SpirvCrossBaseTypeToFormatType(componentType) );
+							un.texDimension = textureDimensionToId(SpirvDimToTextureViewDimension(imageType.dim, imageType.arrayed) );
 
 							un.regIndex = binding_index;
-							un.regCount = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;	// for descriptor type
+							un.regCount = descriptorTypeToId(DescriptorType::StorageImage);
 
 							uniforms.push_back(un);
 						}
@@ -1138,7 +1141,7 @@ namespace bgfx { namespace spirv
 								uniform.name = name;
 								uniform.type = type;
 								uniform.regIndex = binding_index;
-								uniform.regCount = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+								uniform.regCount = descriptorTypeToId(DescriptorType::StorageBuffer);
 								break;
 							}
 						}


### PR DESCRIPTION
This change makes the `texComponent` and `texDimension` shaderc output not depend on or require using Vulkan and WebGPU enums. The new enums are stored in src/shader.h along with conversion functions in src/shader.cpp, which required changes to the amalgamated file as well as shaderc's source files.

I'm not too sure about the names of the enums, or if they should maybe be behind an additional `shader` namespace to clarify what they do.

⚠️ Disclaimer: The WebGPU changes are **untested** (read: uncompiled, because getting WebGPU to compile is too much for a saturday). Definitely need feedback from @hugoam before merging this.