### PR TITLE
Fix building with wayland

### DIFF
--- a/scripts/geometryv.lua
+++ b/scripts/geometryv.lua
@@ -30,6 +30,13 @@ project ("geometryv")
 		defines { "ENTRY_CONFIG_USE_SDL=1" }
 		links   { "SDL2" }
 
+		configuration { "linux or freebsd" }
+			if _OPTIONS["with-wayland"]  then
+				links {
+					"wayland-egl",
+				}
+			end
+
 		configuration { "x32", "windows" }
 			libdirs { "$(SDL2_DIR)/lib/x86" }
 

--- a/scripts/texturev.lua
+++ b/scripts/texturev.lua
@@ -30,6 +30,13 @@ project ("texturev")
 		defines { "ENTRY_CONFIG_USE_SDL=1" }
 		links   { "SDL2" }
 
+		configuration { "linux or freebsd" }
+			if _OPTIONS["with-wayland"]  then
+				links {
+					"wayland-egl",
+				}
+			end
+
 		configuration { "x32", "windows" }
 			libdirs { "$(SDL2_DIR)/lib/x86" }
 


### PR DESCRIPTION
Without these changes linking texturev and geometryv fails due to undefined references.