### PR TITLE
Misc. Vulkan features and fixes

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4070,6 +4070,7 @@ VK_IMPORT_DEVICE
 
 			murmur.add(layout.m_attributes, sizeof(layout.m_attributes) );
 			murmur.add(m_fbh.idx);
+			murmur.add(isValid(m_fbh) ? 0 : m_sci.imageFormat);
 			murmur.add(_numInstanceData);
 			const uint32_t hash = murmur.end();
 

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -73,6 +73,7 @@
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceProperties);             \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFormatProperties);       \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFeatures);               \
+			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFeatures2KHR);           \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceImageFormatProperties);  \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceMemoryProperties);       \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceMemoryProperties2KHR);   \

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -517,8 +517,9 @@ VK_DESTROY
 		{
 		}
 
-		void init()
+		VkResult init()
 		{
+			return VK_SUCCESS;
 		}
 
 		void shutdown()
@@ -678,10 +679,10 @@ VK_DESTROY
 
 	struct CommandQueueVK
 	{
-		void init(uint32_t _queueFamily, VkQueue _queue, uint32_t _numFramesInFlight);
-		void reset();
+		VkResult init(uint32_t _queueFamily, VkQueue _queue, uint32_t _numFramesInFlight);
+		VkResult reset();
 		void shutdown();
-		VkCommandBuffer alloc();
+		VkResult alloc(VkCommandBuffer* _commandBuffer);
 		void kick(VkSemaphore _waitSemaphore = VK_NULL_HANDLE, VkSemaphore _signalSemaphore = VK_NULL_HANDLE, bool _wait = false);
 		void finish(bool _finishAll = false);
 		void release(uint64_t _handle, VkObjectType _type);


### PR DESCRIPTION
This PR

- adds support for `BGFX_STATE_CONSERVATIVE_RASTER`, `BGFX_STATE_LINEAA`, `BGFX_RESET_SUSPEND`
- reports GPU memory in `Stats`
- fixes bugs related to swapchain recreation
- removes all hard asserts during `init()`
