### PR TITLE
Vulkan shader compiler uniform size fix (>255).

### DIFF
--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -957,10 +957,10 @@ namespace bgfx { namespace spirv
 						Uniform un;
 						un.name = program->getUniformName(ii);
 
-						un.num = uint8_t(program->getUniformArraySize(ii) );
+						un.num = 0;
 						const uint32_t offset = program->getUniformBufferOffset(ii);
 						un.regIndex = uint16_t(offset);
-						un.regCount = un.num;
+						un.regCount = uint16_t(program->getUniformArraySize(ii));
 
 						switch (program->getUniformType(ii) )
 						{


### PR DESCRIPTION
In renderer_vk.cpp un.num is not used therefore we can just set the regCount.