### PR TITLE
Support dynamic SwapChainPanel changes for DirectX11 UWP scenarios

### DIFF
--- a/src/dxgi.cpp
+++ b/src/dxgi.cpp
@@ -573,7 +573,7 @@ namespace bgfx
 	}
 
 #if BX_PLATFORM_WINRT
-	HRESULT Dxgi::releaseSwapChain(const SwapChainDesc& _scd, SwapChainI** _swapChain)
+	HRESULT Dxgi::removeSwapChain(const SwapChainDesc& _scd, SwapChainI** _swapChain)
 	{
 		IInspectable *nativeWindow = reinterpret_cast<IInspectable*>(_scd.nwh);
 		ISwapChainPanelNative* swapChainPanelNative;

--- a/src/dxgi.cpp
+++ b/src/dxgi.cpp
@@ -572,6 +572,66 @@ namespace bgfx
 		return S_OK;
 	}
 
+#if BX_PLATFORM_WINRT
+	HRESULT Dxgi::releaseSwapChain(const SwapChainDesc& _scd, SwapChainI** _swapChain)
+	{
+		IInspectable *nativeWindow = reinterpret_cast<IInspectable*>(_scd.nwh);
+		ISwapChainPanelNative* swapChainPanelNative;
+
+		HRESULT hr = nativeWindow->QueryInterface(
+			  __uuidof(ISwapChainPanelNative)
+			, (void**)&swapChainPanelNative
+			);
+
+		if (SUCCEEDED(hr))
+		{
+			// Swap Chain Panel
+			if (NULL != swapChainPanelNative)
+			{
+				hr = swapChainPanelNative->SetSwapChain(nullptr);
+
+				if (FAILED(hr))
+				{
+					DX_RELEASE(swapChainPanelNative, 0);
+					BX_TRACE("Failed to SetSwapChain, hr %x.");
+					return hr;
+				}
+
+				DX_RELEASE_I(swapChainPanelNative);
+			}
+		}
+		else
+		{
+			// Swap Chain Background Panel
+			ISwapChainBackgroundPanelNative* swapChainBackgroundPanelNative = NULL;
+
+			hr = nativeWindow->QueryInterface(
+				__uuidof(ISwapChainBackgroundPanelNative)
+				, (void**)&swapChainBackgroundPanelNative
+			);
+
+			if (FAILED(hr))
+			{
+				return hr;
+			}
+
+			if (NULL != swapChainBackgroundPanelNative)
+			{
+				hr = swapChainBackgroundPanelNative->SetSwapChain(nullptr);
+
+				if (FAILED(hr))
+				{
+					DX_RELEASE(swapChainBackgroundPanelNative, 0);
+					BX_TRACE("Failed to SetSwapChain, hr %x.");
+					return hr;
+				}
+
+				DX_RELEASE_I(swapChainBackgroundPanelNative);
+			}
+		}
+	}
+#endif
+
 	void Dxgi::updateHdr10(SwapChainI* _swapChain, const SwapChainDesc& _scd)
 	{
 #if BX_PLATFORM_WINDOWS

--- a/src/dxgi.cpp
+++ b/src/dxgi.cpp
@@ -588,6 +588,7 @@ namespace bgfx
 			// Swap Chain Panel
 			if (NULL != swapChainPanelNative)
 			{
+				// Remove swap chain
 				hr = swapChainPanelNative->SetSwapChain(nullptr);
 
 				if (FAILED(hr))
@@ -617,6 +618,7 @@ namespace bgfx
 
 			if (NULL != swapChainBackgroundPanelNative)
 			{
+				// Remove swap chain
 				hr = swapChainBackgroundPanelNative->SetSwapChain(nullptr);
 
 				if (FAILED(hr))

--- a/src/dxgi.cpp
+++ b/src/dxgi.cpp
@@ -589,7 +589,7 @@ namespace bgfx
 			if (NULL != swapChainPanelNative)
 			{
 				// Remove swap chain
-				hr = swapChainPanelNative->SetSwapChain(nullptr);
+				hr = swapChainPanelNative->SetSwapChain(NULL);
 
 				if (FAILED(hr))
 				{
@@ -619,7 +619,7 @@ namespace bgfx
 			if (NULL != swapChainBackgroundPanelNative)
 			{
 				// Remove swap chain
-				hr = swapChainBackgroundPanelNative->SetSwapChain(nullptr);
+				hr = swapChainBackgroundPanelNative->SetSwapChain(NULL);
 
 				if (FAILED(hr))
 				{

--- a/src/dxgi.h
+++ b/src/dxgi.h
@@ -87,7 +87,7 @@ namespace bgfx
 
 #if BX_PLATFORM_WINRT
 		///
-		HRESULT releaseSwapChain(const SwapChainDesc& _scd, SwapChainI** _swapChain);
+		HRESULT removeSwapChain(const SwapChainDesc& _scd, SwapChainI** _swapChain);
 #endif
 
 		///

--- a/src/dxgi.h
+++ b/src/dxgi.h
@@ -85,6 +85,11 @@ namespace bgfx
 		///
 		HRESULT createSwapChain(IUnknown* _device, const SwapChainDesc& _scd, SwapChainI** _swapChain);
 
+#if BX_PLATFORM_WINRT
+		///
+		HRESULT releaseSwapChain(const SwapChainDesc& _scd, SwapChainI** _swapChain);
+#endif
+
 		///
 		void updateHdr10(SwapChainI* _swapChain, const SwapChainDesc& _scd);
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1681,11 +1681,9 @@ namespace bgfx { namespace d3d11
 			DX_RELEASE(m_annotation, 1);
 			DX_RELEASE_W(m_infoQueue, 0);
 			DX_RELEASE(m_msaaRt, 0);
-
 #if BX_PLATFORM_WINRT
-			m_dxgi.releaseSwapChain(m_scd, &m_swapChain);
+			m_dxgi.removeSwapChain(m_scd, &m_swapChain);
 #endif
-
 			DX_RELEASE(m_swapChain, 0);
 			DX_RELEASE(m_deviceCtx, 0);
 			DX_RELEASE(m_device, 0);
@@ -2462,9 +2460,8 @@ namespace bgfx { namespace d3d11
 						m_scd.sampleDesc = s_msaa[(m_resolution.reset&BGFX_RESET_MSAA_MASK)>>BGFX_RESET_MSAA_SHIFT];
 
 #if BX_PLATFORM_WINRT
-						m_dxgi.releaseSwapChain(m_scd, &m_swapChain);
+						m_dxgi.removeSwapChain(m_scd, &m_swapChain);
 #endif
-
 						DX_RELEASE(m_swapChain, 0);
 
 						HRESULT hr = m_dxgi.createSwapChain(m_device

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -2430,8 +2430,7 @@ namespace bgfx { namespace d3d11
 				m_scd.width  = _resolution.width;
 				m_scd.height = _resolution.height;
 				// see comment in init() about why we don't worry about BGFX_RESET_SRGB_BACKBUFFER here
-				m_scd.format = s_textureFormat[_resolution.format].m_fmt
-					;
+				m_scd.format = s_textureFormat[_resolution.format].m_fmt;
 
 				preReset();
 
@@ -2461,9 +2460,12 @@ namespace bgfx { namespace d3d11
 
 #if BX_PLATFORM_WINRT
 						m_dxgi.removeSwapChain(m_scd, &m_swapChain);
+						// Avoid updating the native window handler prior to removing preexisting swap chains.
+						// Then, ensure the native window handler is up to date prior to creating swap chains.
+						m_scd.nwh = g_platformData.nwh;
+						m_scd.ndt = g_platformData.ndt;
 #endif
 						DX_RELEASE(m_swapChain, 0);
-
 						HRESULT hr = m_dxgi.createSwapChain(m_device
 							, m_scd
 							, &m_swapChain

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1681,6 +1681,11 @@ namespace bgfx { namespace d3d11
 			DX_RELEASE(m_annotation, 1);
 			DX_RELEASE_W(m_infoQueue, 0);
 			DX_RELEASE(m_msaaRt, 0);
+
+#if BX_PLATFORM_WINRT
+			m_dxgi.releaseSwapChain(m_scd, &m_swapChain);
+#endif
+
 			DX_RELEASE(m_swapChain, 0);
 			DX_RELEASE(m_deviceCtx, 0);
 			DX_RELEASE(m_device, 0);
@@ -2455,6 +2460,10 @@ namespace bgfx { namespace d3d11
 					{
 						updateMsaa(m_scd.format);
 						m_scd.sampleDesc = s_msaa[(m_resolution.reset&BGFX_RESET_MSAA_MASK)>>BGFX_RESET_MSAA_SHIFT];
+
+#if BX_PLATFORM_WINRT
+						m_dxgi.releaseSwapChain(m_scd, &m_swapChain);
+#endif
 
 						DX_RELEASE(m_swapChain, 0);
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -2362,8 +2362,9 @@ namespace bgfx { namespace d3d11
 		void updateNativeWindow()
 		{
 #if BX_PLATFORM_WINRT
-			if (m_scd.nwh != g_platformData.nwh
-				|| m_scd.ndt != g_platformData.ndt)
+			// SwapChainPanels can be dynamically updated
+			if (m_scd.ndt == reinterpret_cast<void*>(2)
+				&& (m_scd.nwh != g_platformData.nwh || m_scd.ndt != g_platformData.ndt))
 			{
 				// Remove swap chain from SwapChainPanel (nwh) if applicable
 				m_dxgi.removeSwapChain(m_scd, &m_swapChain);

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1594,6 +1594,10 @@ namespace bgfx { namespace d3d11
 				DX_RELEASE(m_annotation, 1);
 				DX_RELEASE_W(m_infoQueue, 0);
 				DX_RELEASE(m_msaaRt, 0);
+#if BX_PLATFORM_WINRT
+				// Remove swap chain from SwapChainPanel (nwh) if applicable
+				m_dxgi.removeSwapChain(m_scd, &m_swapChain);
+#endif
 				DX_RELEASE(m_swapChain, 0);
 				DX_RELEASE(m_deviceCtx, 0);
 				DX_RELEASE(m_device, 0);
@@ -1682,6 +1686,7 @@ namespace bgfx { namespace d3d11
 			DX_RELEASE_W(m_infoQueue, 0);
 			DX_RELEASE(m_msaaRt, 0);
 #if BX_PLATFORM_WINRT
+			// Remove swap chain from SwapChainPanel (nwh) if applicable
 			m_dxgi.removeSwapChain(m_scd, &m_swapChain);
 #endif
 			DX_RELEASE(m_swapChain, 0);
@@ -2354,6 +2359,21 @@ namespace bgfx { namespace d3d11
 			}
 		}
 
+		void updateNativeWindow()
+		{
+#if BX_PLATFORM_WINRT
+			if (m_scd.nwh != g_platformData.nwh
+				|| m_scd.ndt != g_platformData.ndt)
+			{
+				// Remove swap chain from SwapChainPanel (nwh) if applicable
+				m_dxgi.removeSwapChain(m_scd, &m_swapChain);
+				// Update nwh after removing swap chain
+				m_scd.nwh = g_platformData.nwh;
+				m_scd.ndt = g_platformData.ndt;
+			}
+#endif
+		}
+
 		bool updateResolution(const Resolution& _resolution)
 		{
 			const bool suspended    = !!( _resolution.reset & BGFX_RESET_SUSPEND);
@@ -2459,11 +2479,8 @@ namespace bgfx { namespace d3d11
 						m_scd.sampleDesc = s_msaa[(m_resolution.reset&BGFX_RESET_MSAA_MASK)>>BGFX_RESET_MSAA_SHIFT];
 
 #if BX_PLATFORM_WINRT
+						// Remove swap chain from SwapChainPanel (nwh) if applicable
 						m_dxgi.removeSwapChain(m_scd, &m_swapChain);
-						// Avoid updating the native window handler prior to removing preexisting swap chains.
-						// Then, ensure the native window handler is up to date prior to creating swap chains.
-						m_scd.nwh = g_platformData.nwh;
-						m_scd.ndt = g_platformData.ndt;
 #endif
 						DX_RELEASE(m_swapChain, 0);
 						HRESULT hr = m_dxgi.createSwapChain(m_device
@@ -5491,8 +5508,13 @@ namespace bgfx { namespace d3d11
 
 	void RendererContextD3D11::submit(Frame* _render, ClearQuad& _clearQuad, TextVideoMemBlitter& _textVideoMemBlitter)
 	{
-		if (m_lost
-		||  updateResolution(_render->m_resolution) )
+		if (m_lost)
+		{
+			return;
+		}
+
+		updateNativeWindow();
+		if (updateResolution(_render->m_resolution) )
 		{
 			return;
 		}

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -2451,7 +2451,8 @@ namespace bgfx { namespace d3d11
 				m_scd.width  = _resolution.width;
 				m_scd.height = _resolution.height;
 				// see comment in init() about why we don't worry about BGFX_RESET_SRGB_BACKBUFFER here
-				m_scd.format = s_textureFormat[_resolution.format].m_fmt;
+				m_scd.format = s_textureFormat[_resolution.format].m_fmt
+					;
 
 				preReset();
 


### PR DESCRIPTION
Right now there are two issues addressed in this PR

1. renderer_d3d11 does not remove swap chains from their associated swap chain panel when releasing. This causes crashes in debug images when changing or resizing SwapChainPanels. We now clean up swap chain panels through dxgi prior to releasing when the swap chain is associated with a SwapChainPanel
1. renderer_d3d11 does not assess changes to the native window handle once created. SwapChainPanels can be dynamically updated, which we now observe/support