### PR TITLE
fixed shutdown dx11

### DIFF
--- a/src/renderer_d3d.h
+++ b/src/renderer_d3d.h
@@ -248,6 +248,11 @@ namespace bgfx
 			{
 				return &_ref->_ptr;
 			}
+
+			operator void** () const throw()
+			{
+				return reinterpret_cast<void**>(&_ref->_ptr);
+			}
 		};
 
 	public:

--- a/src/renderer_d3d.h
+++ b/src/renderer_d3d.h
@@ -219,6 +219,67 @@ namespace bgfx
 		DX_RELEASE(_ptr, 0);
 	}
 
+	template<typename InterfaceType>
+	class Ptr
+	{
+	private:
+		ULONG _expected;
+		InterfaceType* _ptr;
+
+	public:
+		class Ref
+		{
+		private:
+			Ptr<InterfaceType>* _ref;
+
+		public:
+			Ref(Ptr* ref)
+				: _ref(ref)
+			{}
+
+			~Ref()
+			{
+				_ref->_expected = getRefCount(_ref->_ptr) - 1;
+			}
+
+			operator InterfaceType** () const throw()
+			{
+				return (InterfaceType**)&(_ref->_ptr);
+			}
+		};
+
+	public:
+		Ptr(InterfaceType* ptr)
+			: _expected(ptr ? (getRefCount(ptr) - 1) : 0)
+			, _ptr(ptr)
+		{}
+
+		inline InterfaceType* operator->() const throw()
+		{
+			return _ptr;
+		}
+
+		void operator=(InterfaceType* ptr)
+		{
+			_expected = ptr ? (getRefCount(ptr) - 1) : 0;
+			_ptr = ptr;
+		}
+
+		operator InterfaceType* () { return _ptr; }
+		operator InterfaceType* () const { return _ptr; }
+
+		Ptr::Ref operator&() throw()
+		{
+			return Ptr::Ref(this);
+		}
+
+		InterfaceType* get() { return _ptr; }
+
+		inline ULONG expected()
+		{
+			return _expected;
+		}
+	};
 } // namespace bgfx
 
 #endif // BGFX_RENDERER_D3D_H_HEADER_GUARD

--- a/src/renderer_d3d.h
+++ b/src/renderer_d3d.h
@@ -219,61 +219,63 @@ namespace bgfx
 		DX_RELEASE(_ptr, 0);
 	}
 
-	template<typename InterfaceType>
-	class Ptr
+	template<typename Interface>
+	class DxPtr
 	{
 	private:
 		ULONG _expected;
-		InterfaceType* _ptr;
+		Interface* _ptr;
 
 	public:
 		class Ref
 		{
 		private:
-			Ptr<InterfaceType>* _ref;
+			DxPtr<Interface>* _ref;
 
 		public:
-			Ref(Ptr* ref)
+			Ref(DxPtr* ref)
 				: _ref(ref)
 			{}
 
 			~Ref()
 			{
-				_ref->_expected = getRefCount(_ref->_ptr) - 1;
+				Interface* ptr = _ref->_ptr;
+				if( NULL != ptr )
+					_ref->_expected = getRefCount(ptr) - 1;
 			}
 
-			operator InterfaceType** () const throw()
+			operator Interface** () const throw()
 			{
-				return (InterfaceType**)&(_ref->_ptr);
+				return &_ref->_ptr;
 			}
 		};
 
 	public:
-		Ptr(InterfaceType* ptr)
+		DxPtr(Interface* ptr)
 			: _expected(ptr ? (getRefCount(ptr) - 1) : 0)
 			, _ptr(ptr)
 		{}
 
-		inline InterfaceType* operator->() const throw()
+		inline Interface* operator->() const throw()
 		{
 			return _ptr;
 		}
 
-		void operator=(InterfaceType* ptr)
+		void operator=(Interface* ptr)
 		{
 			_expected = ptr ? (getRefCount(ptr) - 1) : 0;
 			_ptr = ptr;
 		}
 
-		operator InterfaceType* () { return _ptr; }
-		operator InterfaceType* () const { return _ptr; }
+		operator Interface*() { return _ptr; }
+		operator Interface*() const { return _ptr; }
 
-		Ptr::Ref operator&() throw()
+		DxPtr::Ref operator&() throw()
 		{
-			return Ptr::Ref(this);
+			return DxPtr::Ref(this);
 		}
 
-		InterfaceType* get() { return _ptr; }
+		Interface* get() { return _ptr; }
 
 		inline ULONG expected()
 		{

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1689,9 +1689,13 @@ namespace bgfx { namespace d3d11
 			// Remove swap chain from SwapChainPanel (nwh) if applicable
 			m_dxgi.removeSwapChain(m_scd, &m_swapChain);
 #endif
-			DX_RELEASE(m_swapChain, 0);
-			DX_RELEASE(m_deviceCtx, 0);
-			DX_RELEASE(m_device, 0);
+			DX_RELEASE(m_swapChain, m_swapChain.expected());
+			DX_RELEASE(m_deviceCtx, m_deviceCtx.expected());
+			if (NULL == g_platformData.context)
+			{
+				// -1 due to reference in m_deviceCtx on initial creation
+				DX_RELEASE(m_device, m_device.expected() - 1);
+			}
 
 			m_nvapi.shutdown();
 			m_dxgi.shutdown();
@@ -2484,7 +2488,7 @@ namespace bgfx { namespace d3d11
 						// Remove swap chain from SwapChainPanel (nwh) if applicable
 						m_dxgi.removeSwapChain(m_scd, &m_swapChain);
 #endif
-						DX_RELEASE(m_swapChain, 0);
+						DX_RELEASE(m_swapChain, m_swapChain.expected());
 						HRESULT hr = m_dxgi.createSwapChain(m_device
 							, m_scd
 							, &m_swapChain
@@ -2943,7 +2947,7 @@ namespace bgfx { namespace d3d11
 						: D3D11_CONSERVATIVE_RASTERIZATION_MODE_OFF
 						;
 
-					ID3D11Device3* device3 = reinterpret_cast<ID3D11Device3*>(m_device);
+					ID3D11Device3* device3 = reinterpret_cast<ID3D11Device3*>(m_device.get());
 					DX_CHECK(device3->CreateRasterizerState2(&desc, reinterpret_cast<ID3D11RasterizerState2**>(&rs) ) );
 				}
 				else
@@ -3550,7 +3554,7 @@ namespace bgfx { namespace d3d11
 
 		D3D_FEATURE_LEVEL m_featureLevel;
 
-		Dxgi::SwapChainI* m_swapChain;
+		Ptr<Dxgi::SwapChainI> m_swapChain;
 		ID3D11Texture2D*  m_msaaRt;
 
 		bool m_needPresent;
@@ -3558,8 +3562,8 @@ namespace bgfx { namespace d3d11
 		uint16_t m_numWindows;
 		FrameBufferHandle m_windows[BGFX_CONFIG_MAX_FRAME_BUFFERS];
 
-		ID3D11Device*              m_device;
-		ID3D11DeviceContext*       m_deviceCtx;
+		Ptr<ID3D11Device>          m_device;
+		Ptr<ID3D11DeviceContext>   m_deviceCtx;
 		ID3DUserDefinedAnnotation* m_annotation;
 		ID3D11InfoQueue*           m_infoQueue;
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -3554,7 +3554,7 @@ namespace bgfx { namespace d3d11
 
 		D3D_FEATURE_LEVEL m_featureLevel;
 
-		Ptr<Dxgi::SwapChainI> m_swapChain;
+		DxPtr<Dxgi::SwapChainI> m_swapChain;
 		ID3D11Texture2D*  m_msaaRt;
 
 		bool m_needPresent;
@@ -3562,8 +3562,8 @@ namespace bgfx { namespace d3d11
 		uint16_t m_numWindows;
 		FrameBufferHandle m_windows[BGFX_CONFIG_MAX_FRAME_BUFFERS];
 
-		Ptr<ID3D11Device>          m_device;
-		Ptr<ID3D11DeviceContext>   m_deviceCtx;
+		DxPtr<ID3D11Device>        m_device;
+		DxPtr<ID3D11DeviceContext> m_deviceCtx;
 		ID3DUserDefinedAnnotation* m_annotation;
 		ID3D11InfoQueue*           m_infoQueue;
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1690,12 +1690,8 @@ namespace bgfx { namespace d3d11
 			m_dxgi.removeSwapChain(m_scd, &m_swapChain);
 #endif
 			DX_RELEASE(m_swapChain, m_swapChain.expected());
+			DX_RELEASE(m_device, m_device.expected());
 			DX_RELEASE(m_deviceCtx, m_deviceCtx.expected());
-			if (NULL == g_platformData.context)
-			{
-				// -1 due to reference in m_deviceCtx on initial creation
-				DX_RELEASE(m_device, m_device.expected() - 1);
-			}
 
 			m_nvapi.shutdown();
 			m_dxgi.shutdown();

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -654,6 +654,7 @@ namespace bgfx { namespace d3d12
 			, m_winPixEvent(NULL)
 			, m_featureLevel(D3D_FEATURE_LEVEL(0) )
 			, m_swapChain(NULL)
+			, m_device(NULL)
 			, m_wireframe(false)
 			, m_lost(false)
 			, m_maxAnisotropy(1)
@@ -1460,12 +1461,12 @@ namespace bgfx { namespace d3d12
 
 			DX_RELEASE(m_rootSignature, 0);
 			DX_RELEASE(m_msaaRt, 0);
-			DX_RELEASE(m_swapChain, 0);
+			DX_RELEASE(m_swapChain, m_swapChain.expected());
 
 			m_device->SetPrivateDataInterface(IID_ID3D12CommandQueue, NULL);
 			m_cmd.shutdown();
 
-			DX_RELEASE(m_device, 0);
+			DX_RELEASE(m_device, m_device.expected());
 
 			m_nvapi.shutdown();
 			m_dxgi.shutdown();
@@ -2297,7 +2298,7 @@ namespace bgfx { namespace d3d12
 						updateMsaa(m_scd.format);
 						m_scd.sampleDesc = s_msaa[(m_resolution.reset&BGFX_RESET_MSAA_MASK)>>BGFX_RESET_MSAA_SHIFT];
 
-						DX_RELEASE(m_swapChain, 0);
+						DX_RELEASE(m_swapChain, m_swapChain.expected());
 
 						HRESULT hr;
 						hr = m_dxgi.createSwapChain(
@@ -3348,7 +3349,7 @@ namespace bgfx { namespace d3d12
 		D3D12_FEATURE_DATA_ARCHITECTURE m_architecture;
 		D3D12_FEATURE_DATA_D3D12_OPTIONS m_options;
 
-		Dxgi::SwapChainI* m_swapChain;
+		DxPtr<Dxgi::SwapChainI> m_swapChain;
 		ID3D12Resource*   m_msaaRt;
 
 #if BX_PLATFORM_WINDOWS
@@ -3359,7 +3360,7 @@ namespace bgfx { namespace d3d12
 		uint16_t m_numWindows;
 		FrameBufferHandle m_windows[BGFX_CONFIG_MAX_FRAME_BUFFERS];
 
-		ID3D12Device*       m_device;
+		DxPtr<ID3D12Device> m_device;
 		TimerQueryD3D12     m_gpuTimer;
 		OcclusionQueryD3D12 m_occlusionQuery;
 


### PR DESCRIPTION
In many environments using bgfx, device, context, and swapchain may have non-zero expected release counts when shutting down.

This pull request saves the expected release count when the device, context and swapchain is created inside bgfx and uses it during shutdown to solve the problem.