### PR TITLE
Fix crash when hitting max draw call limit

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1237,7 +1237,7 @@ namespace bgfx
 		}
 
 		const uint32_t renderItemIdx = bx::atomicFetchAndAddsat<uint32_t>(&m_frame->m_numRenderItems, 1, BGFX_CONFIG_MAX_DRAW_CALLS);
-		if (BGFX_CONFIG_MAX_DRAW_CALLS-1 <= renderItemIdx)
+		if (BGFX_CONFIG_MAX_DRAW_CALLS <= renderItemIdx)
 		{
 			discard(_flags);
 			++m_numDropped;


### PR DESCRIPTION
This expands the instancing demo to have a non-instanced path, and a slider for adjusting the number of cubes drawn.  When instancing is turned off and the slider is put at 256 or higher with default configs, a crash occurs without the off by one fix.