### PR TITLE
Fix: retain submit_index32 flag across draw states

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -1643,9 +1643,12 @@ namespace bgfx
 				m_startIndex      = 0;
 				m_numIndices      = UINT32_MAX;
 				m_indexBuffer.idx = kInvalidHandle;
+				m_submitFlags   = 0;
+			} else {
+				// if index buffer retained track its size in submit flags.
+				m_submitFlags = isIndex16() ? 0 : BGFX_SUBMIT_INTERNAL_INDEX32;
 			}
 
-			m_submitFlags   = 0;
 			m_startIndirect = 0;
 			m_numIndirect   = UINT16_MAX;
 			m_indirectBuffer.idx = kInvalidHandle;


### PR DESCRIPTION
If you do 
```
bgfx::setIndexBuffer()
bgfx::submit(BGFX_DISCARD_NONE)
bgfx::submit()
```

then the second submit will be broken because even though it still uses the correct index buffer it will lose the BGFX_SUBMIT_INTERNAL_INDEX32 state.
Basically all multi-pass calls involving a 32index buffer are broken currently in bgfx master. 
This fixes bug introduced by https://github.com/bkaradzic/bgfx/commit/5c304dad3b98cfa895a531527881347f3c52aeea

Feel free to change if better idea but the idea is sound.