### PR TITLE
Vulkan: alias texture types in shaders + misc fixes

### DIFF
--- a/src/renderer.h
+++ b/src/renderer.h
@@ -7,6 +7,7 @@
 #define BGFX_RENDERER_H_HEADER_GUARD
 
 #include "bgfx_p.h"
+#include <memory>
 
 namespace bgfx
 {
@@ -312,7 +313,7 @@ namespace bgfx
 			data.m_parent = _parent;
 			m_hashMap.insert(stl::make_pair(_key, handle) );
 
-			return &m_data[handle].m_value;
+			return std::addressof(m_data[handle].m_value);
 		}
 
 		Ty* find(uint64_t _key)
@@ -322,7 +323,7 @@ namespace bgfx
 			{
 				uint16_t handle = it->second;
 				m_alloc.touch(handle);
-				return &m_data[handle].m_value;
+				return std::addressof(m_data[handle].m_value);
 			}
 
 			return NULL;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -6941,19 +6941,19 @@ VK_DESTROY
 			blitInfo.dstOffsets[1].y = blit.m_dstY + blit.m_height;
 			blitInfo.dstOffsets[1].z = 1;
 
-			if (VK_IMAGE_VIEW_TYPE_CUBE == src.m_type)
-			{
-				blitInfo.srcSubresource.baseArrayLayer = blit.m_srcZ;
-				blitInfo.dstSubresource.baseArrayLayer = blit.m_dstZ;
-				blitInfo.srcSubresource.layerCount = blit.m_depth;
-				blitInfo.dstSubresource.layerCount = blit.m_depth;
-			}
-			else if (VK_IMAGE_VIEW_TYPE_3D == src.m_type)
+			if (VK_IMAGE_VIEW_TYPE_3D == src.m_type)
 			{
 				blitInfo.srcOffsets[0].z = blit.m_srcZ;
 				blitInfo.dstOffsets[0].z = blit.m_dstZ;
 				blitInfo.srcOffsets[1].z = blit.m_srcZ + blit.m_depth;
 				blitInfo.dstOffsets[1].z = blit.m_dstZ + blit.m_depth;
+			}
+			else
+			{
+				blitInfo.srcSubresource.baseArrayLayer = blit.m_srcZ;
+				blitInfo.dstSubresource.baseArrayLayer = blit.m_dstZ;
+				blitInfo.srcSubresource.layerCount = bx::max<uint32_t>(1, blit.m_depth);
+				blitInfo.dstSubresource.layerCount = bx::max<uint32_t>(1, blit.m_depth);
 			}
 
 			const VkFilter filter = bimg::isDepth(bimg::TextureFormat::Enum(src.m_textureFormat) )

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -348,28 +348,30 @@ VK_IMPORT_DEVICE
 
 	bool updateExtension(const char* _name, uint32_t _version, bool _instanceExt, Extension _extensions[Extension::Count])
 	{
-		const bx::StringView ext(_name);
-
 		bool supported = false;
-		for (uint32_t ii = 0; ii < Extension::Count; ++ii)
+		if (BX_ENABLED(BGFX_CONFIG_RENDERER_USE_EXTENSIONS) )
 		{
-			Extension& extension = _extensions[ii];
-			LayerInfo& layerInfo = _instanceExt
-				? s_layer[extension.m_layer].m_instance
-				: s_layer[extension.m_layer].m_device
-				;
-
-			if (!extension.m_supported
-			&&   extension.m_initialize
-			&&  (extension.m_layer == Layer::Count || layerInfo.m_supported) )
+			const bx::StringView ext(_name);
+			for (uint32_t ii = 0; ii < Extension::Count; ++ii)
 			{
-				if (       0 == bx::strCmp(ext, extension.m_name)
-				&&  _version >= extension.m_minVersion)
+				Extension& extension = _extensions[ii];
+				LayerInfo& layerInfo = _instanceExt
+					? s_layer[extension.m_layer].m_instance
+					: s_layer[extension.m_layer].m_device
+					;
+
+				if (!extension.m_supported
+				&&   extension.m_initialize
+				&&  (extension.m_layer == Layer::Count || layerInfo.m_supported) )
 				{
-					extension.m_supported   = true;
-					extension.m_instanceExt = _instanceExt;
-					supported = true;
-					break;
+					if (       0 == bx::strCmp(ext, extension.m_name)
+					&&  _version >= extension.m_minVersion)
+					{
+						extension.m_supported   = true;
+						extension.m_instanceExt = _instanceExt;
+						supported = true;
+						break;
+					}
 				}
 			}
 		}

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -5817,7 +5817,10 @@ VK_DESTROY
 
 			if (imageContainer.m_cubeMap)
 			{
-				m_type = VK_IMAGE_VIEW_TYPE_CUBE;
+				m_type = imageContainer.m_numLayers > 1
+					? VK_IMAGE_VIEW_TYPE_CUBE_ARRAY
+					: VK_IMAGE_VIEW_TYPE_CUBE
+					;
 			}
 			else if (imageContainer.m_depth > 1)
 			{

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -6618,7 +6618,7 @@ VK_DESTROY
 		VkCommandPoolCreateInfo cpci;
 		cpci.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
 		cpci.pNext = NULL;
-		cpci.flags = 0;
+		cpci.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
 		cpci.queueFamilyIndex = m_queueFamily;
 
 		VkCommandBufferAllocateInfo cbai;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -5002,26 +5002,28 @@ VK_IMPORT_DEVICE
 		s_renderVK = NULL;
 	}
 
-#define VK_DESTROY_FUNC(_name)                                                       \
-	void vkDestroy(::Vk##_name _obj)                                                 \
-	{                                                                                \
-		if (VK_NULL_HANDLE != _obj)                                                  \
-		{                                                                            \
-			vkDestroy##_name(s_renderVK->m_device, _obj, s_renderVK->m_allocatorCb); \
-		}                                                                            \
-	}                                                                                \
-	void release(Vk##_name& _obj)                                                    \
-	{                                                                                \
-		s_renderVK->release(_obj);                                                   \
+#define VK_DESTROY_FUNC(_name)                                                          \
+	void vkDestroy(Vk##_name& _obj)                                                     \
+	{                                                                                   \
+		if (VK_NULL_HANDLE != _obj)                                                     \
+		{                                                                               \
+			vkDestroy##_name(s_renderVK->m_device, _obj.vk, s_renderVK->m_allocatorCb); \
+			_obj = VK_NULL_HANDLE;                                                      \
+		}                                                                               \
+	}                                                                                   \
+	void release(Vk##_name& _obj)                                                       \
+	{                                                                                   \
+		s_renderVK->release(_obj);                                                      \
 	}
 VK_DESTROY
 #undef VK_DESTROY_FUNC
 
-	void vkDestroy(::VkDeviceMemory _obj)
+	void vkDestroy(VkDeviceMemory& _obj)
 	{
 		if (VK_NULL_HANDLE != _obj)
 		{
-			vkFreeMemory(s_renderVK->m_device, _obj, s_renderVK->m_allocatorCb);
+			vkFreeMemory(s_renderVK->m_device, _obj.vk, s_renderVK->m_allocatorCb);
+			_obj = VK_NULL_HANDLE;
 		}
 	}
 
@@ -6864,16 +6866,16 @@ VK_DESTROY
 		{
 			switch (resource.m_type)
 			{
-			case VK_OBJECT_TYPE_BUFFER:                vkDestroy(::VkBuffer(resource.m_handle) );              break;
-			case VK_OBJECT_TYPE_IMAGE_VIEW:            vkDestroy(::VkImageView(resource.m_handle) );           break;
-			case VK_OBJECT_TYPE_IMAGE:                 vkDestroy(::VkImage(resource.m_handle) );               break;
-			case VK_OBJECT_TYPE_FRAMEBUFFER:           vkDestroy(::VkFramebuffer(resource.m_handle) );         break;
-			case VK_OBJECT_TYPE_PIPELINE_LAYOUT:       vkDestroy(::VkPipelineLayout(resource.m_handle) );      break;
-			case VK_OBJECT_TYPE_PIPELINE:              vkDestroy(::VkPipeline(resource.m_handle) );            break;
-			case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT: vkDestroy(::VkDescriptorSetLayout(resource.m_handle) ); break;
-			case VK_OBJECT_TYPE_RENDER_PASS:           vkDestroy(::VkRenderPass(resource.m_handle) );          break;
-			case VK_OBJECT_TYPE_SAMPLER:               vkDestroy(::VkSampler(resource.m_handle) );             break;
-			case VK_OBJECT_TYPE_DEVICE_MEMORY:         vkDestroy(::VkDeviceMemory(resource.m_handle) );        break;
+			case VK_OBJECT_TYPE_BUFFER:                destroy<VkBuffer             >(resource.m_handle); break;
+			case VK_OBJECT_TYPE_IMAGE_VIEW:            destroy<VkImageView          >(resource.m_handle); break;
+			case VK_OBJECT_TYPE_IMAGE:                 destroy<VkImage              >(resource.m_handle); break;
+			case VK_OBJECT_TYPE_FRAMEBUFFER:           destroy<VkFramebuffer        >(resource.m_handle); break;
+			case VK_OBJECT_TYPE_PIPELINE_LAYOUT:       destroy<VkPipelineLayout     >(resource.m_handle); break;
+			case VK_OBJECT_TYPE_PIPELINE:              destroy<VkPipeline           >(resource.m_handle); break;
+			case VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT: destroy<VkDescriptorSetLayout>(resource.m_handle); break;
+			case VK_OBJECT_TYPE_RENDER_PASS:           destroy<VkRenderPass         >(resource.m_handle); break;
+			case VK_OBJECT_TYPE_SAMPLER:               destroy<VkSampler            >(resource.m_handle); break;
+			case VK_OBJECT_TYPE_DEVICE_MEMORY:         destroy<VkDeviceMemory       >(resource.m_handle); break;
 
 			default:
 				BX_ASSERT(false, "Invalid resource type: %d", resource.m_type);

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -46,15 +46,6 @@ namespace bgfx { namespace vk
 	};
 	BX_STATIC_ASSERT(Topology::Count == BX_COUNTOF(s_primInfo)-1);
 
-	static const uint32_t s_checkMsaa[] =
-	{
-		0,
-		2,
-		4,
-		8,
-		16,
-	};
-
 	static MsaaSamplerVK s_msaa[] =
 	{
 		{  1, VK_SAMPLE_COUNT_1_BIT },
@@ -1490,8 +1481,6 @@ VK_IMPORT_DEVICE
 
 		bool init(const Init& _init)
 		{
-			BX_UNUSED(s_checkMsaa, s_textureAddress);
-
 			struct ErrorState
 			{
 				enum Enum
@@ -3823,22 +3812,17 @@ VK_IMPORT_DEVICE
 			hash.begin(0);
 			for (uint8_t ii = 0; ii < _num; ++ii)
 			{
-				hash.add(attachments[ii].access);
-				hash.add(attachments[ii].layer);
-				hash.add(attachments[ii].mip);
-				hash.add(attachments[ii].resolve);
-
 				TextureVK& texture = m_textures[attachments[ii].handle.idx];
 				hash.add(texture.m_textureFormat);
+				hash.add(texture.m_sampler.Sample);
 			}
 			return hash.end();
 		}
 
 		VkRenderPass getRenderPass(uint8_t _num, const Attachment* _attachments)
 		{
-			VkRenderPass renderPass = VK_NULL_HANDLE;
 			uint32_t hashKey = getRenderPassHashkey(_num, _attachments);
-			renderPass = (VkRenderPass)m_renderPassCache.find(hashKey);
+			VkRenderPass renderPass = m_renderPassCache.find(hashKey);
 
 			if (VK_NULL_HANDLE != renderPass)
 			{

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -451,6 +451,12 @@ VK_DESTROY_FUNC(DeviceMemory);
 		BindType::Enum type;
 		uint32_t binding;
 		uint32_t samplerBinding;
+		uint32_t index;
+	};
+
+	struct TextureBindInfo
+	{
+		VkImageViewType type;
 	};
 
 	struct ShaderVK
@@ -485,6 +491,10 @@ VK_DESTROY_FUNC(DeviceMemory);
 		uint8_t m_numAttrs;
 
 		BindInfo m_bindInfo[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
+
+		TextureBindInfo m_textures[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
+		uint8_t m_numTextures;
+
 		uint32_t m_uniformBinding;
 		uint16_t m_numBindings;
 		VkDescriptorSetLayoutBinding m_bindings[32];
@@ -507,6 +517,9 @@ VK_DESTROY_FUNC(DeviceMemory);
 		const ShaderVK* m_fsh;
 
 		BindInfo m_bindInfo[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
+
+		TextureBindInfo m_textures[BGFX_CONFIG_MAX_TEXTURE_SAMPLERS];
+		uint8_t m_numTextures;
 
 		PredefinedUniform m_predefined[PredefinedUniform::Count * 2];
 		uint8_t m_numPredefined;
@@ -599,12 +612,9 @@ VK_DESTROY_FUNC(DeviceMemory);
 			, m_format(VK_FORMAT_UNDEFINED)
 			, m_textureImage(VK_NULL_HANDLE)
 			, m_textureDeviceMem(VK_NULL_HANDLE)
-			, m_textureImageView(VK_NULL_HANDLE)
-			, m_textureImageDepthView(VK_NULL_HANDLE)
 			, m_currentImageLayout(VK_IMAGE_LAYOUT_UNDEFINED)
 			, m_singleMsaaImage(VK_NULL_HANDLE)
 			, m_singleMsaaDeviceMem(VK_NULL_HANDLE)
-			, m_singleMsaaImageView(VK_NULL_HANDLE)
 		{
 		}
 
@@ -616,7 +626,7 @@ VK_DESTROY_FUNC(DeviceMemory);
 		void copyBufferToTexture(VkCommandBuffer _commandBuffer, VkBuffer _stagingBuffer, uint32_t _bufferImageCopyCount, VkBufferImageCopy* _bufferImageCopy);
 		void setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout);
 
-		VkImageView createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, bool _asArray = false) const;
+		VkImageView createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, VkImageViewType _type, bool _renderTarget) const;
 
 		void*    m_directAccessPtr;
 		uint64_t m_flags;
@@ -638,13 +648,10 @@ VK_DESTROY_FUNC(DeviceMemory);
 
 		VkImage        m_textureImage;
 		VkDeviceMemory m_textureDeviceMem;
-		VkImageView    m_textureImageView;
-		VkImageView    m_textureImageDepthView;
 		VkImageLayout  m_currentImageLayout;
 
 		VkImage        m_singleMsaaImage;
 		VkDeviceMemory m_singleMsaaDeviceMem;
-		VkImageView    m_singleMsaaImageView;
 
 		ReadbackVK m_readback;
 	};

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -73,7 +73,7 @@
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceProperties);             \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFormatProperties);       \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFeatures);               \
-			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFeatures2KHR);           \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceFeatures2KHR);           \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceImageFormatProperties);  \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceMemoryProperties);       \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceMemoryProperties2KHR);   \

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -289,12 +289,7 @@ namespace bgfx { namespace vk
 		const ::Vk##_name* operator &() const { return &vk; }    \
 	};                                                           \
 	BX_STATIC_ASSERT(sizeof(::Vk##_name) == sizeof(Vk##_name) ); \
-	void vkDestroy(::Vk##_name);                                 \
-	void vkDestroy(Vk##_name& _obj)                              \
-	{                                                            \
-		vkDestroy(_obj.vk);                                      \
-		_obj = VK_NULL_HANDLE;                                   \
-	}                                                            \
+	void vkDestroy(Vk##_name&);                                  \
 	void release(Vk##_name&)
 VK_DESTROY
 VK_DESTROY_FUNC(DeviceMemory);
@@ -731,6 +726,15 @@ VK_DESTROY_FUNC(DeviceMemory);
 
 		typedef stl::vector<Resource> ResourceArray;
 		ResourceArray m_release[BGFX_CONFIG_MAX_FRAME_LATENCY];
+
+	private:
+		template<typename Ty>
+		void destroy(uint64_t _handle)
+		{
+			typedef decltype(Ty::vk) vk_t;
+			Ty obj = vk_t(_handle);
+			vkDestroy(obj);
+		}
 	};
 
 } /* namespace bgfx */ } // namespace vk

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -289,8 +289,15 @@ namespace bgfx { namespace vk
 		const ::Vk##_name* operator &() const { return &vk; }    \
 	};                                                           \
 	BX_STATIC_ASSERT(sizeof(::Vk##_name) == sizeof(Vk##_name) ); \
-	void vkDestroy(Vk##_name&)
+	void vkDestroy(::Vk##_name);                                 \
+	void vkDestroy(Vk##_name& _obj)                              \
+	{                                                            \
+		vkDestroy(_obj.vk);                                      \
+		_obj = VK_NULL_HANDLE;                                   \
+	}                                                            \
+	void release(Vk##_name&)
 VK_DESTROY
+VK_DESTROY_FUNC(DeviceMemory);
 #undef VK_DESTROY_FUNC
 
 	struct DslBinding
@@ -332,7 +339,7 @@ VK_DESTROY
 			typename HashMap::iterator it = m_hashMap.find(_key);
 			if (it != m_hashMap.end() )
 			{
-				destroy(it->second);
+				release(it->second);
 				m_hashMap.erase(it);
 			}
 		}
@@ -341,7 +348,7 @@ VK_DESTROY
 		{
 			for (typename HashMap::iterator it = m_hashMap.begin(), itEnd = m_hashMap.end(); it != itEnd; ++it)
 			{
-				destroy(it->second);
+				release(it->second);
 			}
 
 			m_hashMap.clear();
@@ -353,8 +360,6 @@ VK_DESTROY
 		}
 
 	private:
-		void destroy(Ty handle);
-
 		typedef stl::unordered_map<uint64_t, Ty> HashMap;
 		HashMap m_hashMap;
 	};

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -611,7 +611,7 @@ VK_DESTROY
 		void copyBufferToTexture(VkCommandBuffer _commandBuffer, VkBuffer _stagingBuffer, uint32_t _bufferImageCopyCount, VkBufferImageCopy* _bufferImageCopy);
 		void setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout);
 
-		VkImageView createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips) const;
+		VkImageView createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, bool _asArray = false) const;
 
 		void*    m_directAccessPtr;
 		uint64_t m_flags;


### PR DESCRIPTION
This PR mainly adds support for aliasing textures to different types in the shader, enabling a few use cases that currently end in validation errors/device lost:
- array textures can be bound to a SAMPLER2D, using the first layer
- non-array 2D textures can be bound to a SAMPLER2DARRAY with 1 layer
- 3D and cube textures can be bound to a SAMPLER2DARRAY

For this to take effect, shaders need to be compiled with shaderc producing binary version 8 or higher (added with the WebGPU backend: https://github.com/bkaradzic/bgfx/pull/2132). With older shaders, the sampler type is always assumed to match the texture type (this is equal to the current behaviour).

The only example relying on this fix is 21-deferred with texture array frame buffer. The shaders don't need recompilation, they recently got updated (https://github.com/bkaradzic/bgfx/commit/c2b7ffe2e7eb0f407b950939bc0cae4386e42e8f).

I've tested this with all other examples with both old and new shaders and I get identical output to before this change, but would appreciate another eye :eyes:

Some small additional changes that didn't really warrant extra PRs:
- check `BGFX_CONFIG_RENDERER_USE_EXTENSIONS` when loading extensions
- fixed renderpass caching for multisample framebuffers
- depth slices of 3D textures can be used as framebuffer attachments
