### PR TITLE
Fix 31-rsm Vulkan shaders

### DIFF
--- a/examples/06-bump/fs_bump.sc
+++ b/examples/06-bump/fs_bump.sc
@@ -53,19 +53,9 @@ vec3 calcLight(int _idx, mat3 _tbn, vec3 _wpos, vec3 _normal, vec3 _view)
 	return rgb;
 }
 
-mat3 mtx3FromCols(vec3 c0, vec3 c1, vec3 c2)
-{
-#if BGFX_SHADER_LANGUAGE_GLSL
-	return mat3(c0, c1, c2);
-#else
-	return transpose(mat3(c0, c1, c2));
-#endif
-}
-
-
 void main()
 {
-	mat3 tbn = mtx3FromCols(v_tangent, v_bitangent, v_normal);
+	mat3 tbn = mtxFromCols(v_tangent, v_bitangent, v_normal);
 
 	vec3 normal;
 	normal.xy = texture2D(s_texNormal, v_texcoord0).xy * 2.0 - 1.0;

--- a/examples/06-bump/vs_bump.sc
+++ b/examples/06-bump/vs_bump.sc
@@ -8,15 +8,6 @@ $output v_wpos, v_view, v_normal, v_tangent, v_bitangent, v_texcoord0
 
 #include "../common/common.sh"
 
-mat3 mtx3FromCols(vec3 c0, vec3 c1, vec3 c2)
-{
-#ifdef BGFX_SHADER_LANGUAGE_GLSL
-	return mat3(c0, c1, c2);
-#else
-	return transpose(mat3(c0, c1, c2));
-#endif
-}
-
 void main()
 {
 	vec3 wpos = mul(u_model[0], vec4(a_position, 1.0) ).xyz;
@@ -34,11 +25,11 @@ void main()
 	v_tangent = normalize(wtangent);
 	v_bitangent = cross(v_normal, v_tangent) * tangent.w;
 
-	mat3 tbn = mtx3FromCols(v_tangent, v_bitangent, v_normal);
+	mat3 tbn = mtxFromCols(v_tangent, v_bitangent, v_normal);
 
 	// eye position in world space
-	vec3 weyepos = mul(vec4(0.0, 0.0, 0.0, 1.0), u_view).xyz;	
+	vec3 weyepos = mul(vec4(0.0, 0.0, 0.0, 1.0), u_view).xyz;
 	// tangent space view dir
-	v_view = mul(weyepos - wpos, tbn);	
+	v_view = mul(weyepos - wpos, tbn);
 	v_texcoord0 = a_texcoord0;
 }

--- a/examples/21-deferred/common.sh
+++ b/examples/21-deferred/common.sh
@@ -44,19 +44,3 @@ vec3 calcLight(vec3 _wpos, vec3 _normal, vec3 _view, vec3 _lightPos, float _ligh
 	vec3 rgb = _lightRgb * saturate(lc.y) * attn;
 	return rgb;
 }
-
-float toClipSpaceDepth(float _depthTextureZ)
-{
-#if BGFX_SHADER_LANGUAGE_GLSL
-	return _depthTextureZ * 2.0 - 1.0;
-#else
-	return _depthTextureZ;
-#endif // BGFX_SHADER_LANGUAGE_GLSL
-}
-
-vec3 clipToWorld(mat4 _invViewProj, vec3 _clipPos)
-{
-	vec4 wpos = mul(_invViewProj, vec4(_clipPos, 1.0) );
-	return wpos.xyz / wpos.w;
-}
-

--- a/examples/31-rsm/fs_rsm_combine.sc
+++ b/examples/31-rsm/fs_rsm_combine.sc
@@ -65,22 +65,6 @@ float PCF(sampler2DShadow _sampler, vec4 _shadowCoord, float _bias, vec2 _texelS
 	return result / 16.0;
 }
 
-
-float toClipSpaceDepth(float _depthTextureZ)
-{
-#if BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
-	return _depthTextureZ;
-#else
-	return _depthTextureZ * 2.0 - 1.0;
-#endif // BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
-}
-
-vec3 clipToWorld(mat4 _invViewProj, vec3 _clipPos)
-{
-	vec4 wpos = mul(_invViewProj, vec4(_clipPos, 1.0) );
-	return wpos.xyz / wpos.w;
-}
-
 void main()
 {
 	vec3 n  = texture2D(s_normal, v_texcoord0).xyz;
@@ -97,18 +81,18 @@ void main()
 	float deviceDepth = texture2D(s_depth, texCoord).x;
 	float depth       = toClipSpaceDepth(deviceDepth);
 	vec3 clip = vec3(texCoord * 2.0 - 1.0, depth);
-#if BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
+#if !BGFX_SHADER_LANGUAGE_GLSL
 	clip.y = -clip.y;
-#endif // BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
+#endif // !BGFX_SHADER_LANGUAGE_GLSL
 	vec3 wpos = clipToWorld(u_invMvp, clip);
 
 	const float shadowMapOffset = 0.003;
 	vec3 posOffset = wpos + n.xyz * shadowMapOffset;
 	vec4 shadowCoord = mul(u_lightMtx, vec4(posOffset, 1.0) );
 
-#if BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_METAL
+#if !BGFX_SHADER_LANGUAGE_GLSL
 	shadowCoord.y *= -1.0;
-#endif // BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_METAL
+#endif // !BGFX_SHADER_LANGUAGE_GLSL
 
 	float shadowMapBias = 0.001;
 	vec2 texelSize = vec2_splat(u_shadowDimsInv.x);

--- a/examples/31-rsm/fs_rsm_lbuffer.sc
+++ b/examples/31-rsm/fs_rsm_lbuffer.sc
@@ -12,21 +12,6 @@ SAMPLER2D(s_depth,  1);  // Depth output from gbuffer
 
 uniform mat4 u_invMvp;
 
-float toClipSpaceDepth(float _depthTextureZ)
-{
-#if BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
-	return _depthTextureZ;
-#else
-	return _depthTextureZ * 2.0 - 1.0;
-#endif // BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
-}
-
-vec3 clipToWorld(mat4 _invViewProj, vec3 _clipPos)
-{
-	vec4 wpos = mul(_invViewProj, vec4(_clipPos, 1.0) );
-	return wpos.xyz / wpos.w;
-}
-
 void main()
 {
 #if BGFX_SHADER_LANGUAGE_HLSL && (BGFX_SHADER_LANGUAGE_HLSL < 400)
@@ -40,9 +25,9 @@ void main()
 	float depth       = toClipSpaceDepth(deviceDepth);
 
 	vec3 clip = vec3(texCoord * 2.0 - 1.0, depth);
-#if BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
+#if !BGFX_SHADER_LANGUAGE_GLSL
 	clip.y = -clip.y;
-#endif // BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
+#endif // !BGFX_SHADER_LANGUAGE_GLSL
 	vec3 wpos = clipToWorld(u_invMvp, clip);
 
 	// Get normal from its map, and decompress

--- a/examples/31-rsm/vs_rsm_lbuffer.sc
+++ b/examples/31-rsm/vs_rsm_lbuffer.sc
@@ -16,21 +16,6 @@ uniform mat4 u_invMvpShadow;
 SAMPLER2D(s_shadowMap, 2);  // Used to reconstruct 3d position for lights
 SAMPLER2D(s_rsm,       3);  // Reflective shadow map, used to scale/color light
 
-float toClipSpaceDepth(float _depthTextureZ)
-{
-#if BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
-	return _depthTextureZ;
-#else
-	return _depthTextureZ * 2.0 - 1.0;
-#endif // BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
-}
-
-vec3 clipToWorld(mat4 _invViewProj, vec3 _clipPos)
-{
-	vec4 wpos = mul(_invViewProj, vec4(_clipPos, 1.0) );
-	return wpos.xyz / wpos.w;
-}
-
 void main()
 {
 	// Calculate vertex position
@@ -41,9 +26,9 @@ void main()
 	float deviceDepth = texture2DLod(s_shadowMap, texCoord, 0).x;
 	float depth       = toClipSpaceDepth(deviceDepth);
 	vec3 clip = vec3(texCoord * 2.0 - 1.0, depth);
-#if BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
+#if !BGFX_SHADER_LANGUAGE_GLSL
 	clip.y = -clip.y;
-#endif // BGFX_SHADER_LANGUAGE_HLSL || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_METAL
+#endif // !BGFX_SHADER_LANGUAGE_GLSL
 	vec3 wPos = clipToWorld(u_invMvpShadow, clip);
 	wPos.y -= 0.001;  // Would be much better to perturb in normal direction, but I didn't do that.
 

--- a/examples/common/shaderlib.sh
+++ b/examples/common/shaderlib.sh
@@ -413,4 +413,19 @@ mat3 cofactor(mat4 _m)
 		);
 }
 
+float toClipSpaceDepth(float _depthTextureZ)
+{
+#if BGFX_SHADER_LANGUAGE_GLSL
+	return _depthTextureZ * 2.0 - 1.0;
+#else
+	return _depthTextureZ;
+#endif // BGFX_SHADER_LANGUAGE_GLSL
+}
+
+vec3 clipToWorld(mat4 _invViewProj, vec3 _clipPos)
+{
+	vec4 wpos = mul(_invViewProj, vec4(_clipPos, 1.0) );
+	return wpos.xyz / wpos.w;
+}
+
 #endif // __SHADERLIB_SH__


### PR DESCRIPTION
Shaders were checking for everything that isn't `BGFX_SHADER_LANGUAGE_GLSL` but forgot `_SPIRV`. 

While I was checking for other wrong shader language ifdefs I also moved `toClipSpaceDepth` and `clipToWorld` to shaderlib.sh since they're used by both 21-deferred and 31-rsm and I made 06-bump shaders use the existing `mtxFromCols` instead of redefining them (incorrectly in one case).

Let me know if you want me to push recompiled shaders before merging or in another PR.