### PR TITLE
Vertex buffer fixes

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -5561,6 +5561,8 @@ namespace bgfx { namespace d3d11
 		currentState.m_stateFlags = BGFX_STATE_NONE;
 		currentState.m_stencil = packStencil(BGFX_STENCIL_NONE, BGFX_STENCIL_NONE);
 
+		uint32_t currentNumVertices = 0;
+
 		RenderBind currentBind;
 		currentBind.clear();
 
@@ -6191,6 +6193,8 @@ namespace bgfx { namespace d3d11
 						}
 					}
 
+					currentNumVertices = numVertices;
+
 					if (0 < numStreams)
 					{
 						deviceCtx->IASetVertexBuffers(0, numStreams, buffers, strides, offsets);
@@ -6249,7 +6253,7 @@ namespace bgfx { namespace d3d11
 
 				if (0 != currentState.m_streamMask)
 				{
-					uint32_t numVertices       = draw.m_numVertices;
+					uint32_t numVertices       = currentNumVertices;
 					uint32_t numIndices        = 0;
 					uint32_t numPrimsSubmitted = 0;
 					uint32_t numInstances      = 0;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -7457,6 +7457,7 @@ VK_DESTROY
 
 					const VertexLayout* layouts[BGFX_CONFIG_MAX_VERTEX_STREAMS];
 					uint8_t numStreams = 0;
+					uint32_t numVertices = draw.m_numVertices;
 					if (UINT8_MAX != draw.m_streamMask)
 					{
 						for (uint32_t idx = 0, streamMask = draw.m_streamMask
@@ -7479,8 +7480,15 @@ VK_DESTROY
 								: vb.m_layoutHandle.idx
 								;
 							const VertexLayout& layout = m_vertexLayouts[decl];
+							const uint32_t stride = layout.m_stride;
 
 							layouts[numStreams] = &layout;
+
+							numVertices = bx::uint32_min(UINT32_MAX == draw.m_numVertices
+								? vb.m_size/stride
+								: draw.m_numVertices
+								, numVertices
+								);
 						}
 					}
 
@@ -7685,14 +7693,6 @@ VK_DESTROY
 
 					if (!isValid(draw.m_indexBuffer) )
 					{
-						const VertexBufferVK& vertexBuffer = m_vertexBuffers[draw.m_stream[0].m_handle.idx];
-						const VertexLayout* layout = layouts[0];
-
-						const uint32_t numVertices = UINT32_MAX == draw.m_numVertices
-							? vertexBuffer.m_size / layout->m_stride
-							: draw.m_numVertices
-							;
-
 						if (isValid(draw.m_indirectBuffer) )
 						{
 							vkCmdDrawIndirect(


### PR DESCRIPTION
Fixes two issues related to vertex buffers in the D3D11 and VK backends.

1. https://github.com/bkaradzic/bgfx/discussions/2456, repro can be found there
2. VK backend only used the first stream's vertex offset and count

Repro for issue 2 in example 34-mvs:

1. add 8 times black (`{ 0x00000000 },`) to the front of `s_cubeColorVertices`
2. change `bgfx::setVertexBuffer(1, m_vbh[1])` to `bgfx::setVertexBuffer(1, m_vbh[1], 8, 8)`
3. cubes are black