### PR TITLE
Vulkan: ignore unused storage buffers

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4342,9 +4342,7 @@ VK_IMPORT_DEVICE
 				const Binding& bind = renderBind.m_bind[stage];
 				const BindInfo& bindInfo = program.m_bindInfo[stage];
 
-				// bgfx does not seem to forbid setting a texture to a stage that a program does not use
-				if (bind.m_type == Binding::Texture
-				&& !isValid(bindInfo.uniformHandle) )
+				if (!isValid(bindInfo.uniformHandle) )
 				{
 					continue;
 				}
@@ -5386,6 +5384,10 @@ VK_DESTROY
 					{
 						// regCount is used for descriptor type
 						const bool isBuffer = idToDescriptorType(regCount) == DescriptorType::StorageBuffer;
+						if (0 == regIndex)
+						{
+							continue;
+						}
 						const uint16_t stage = regIndex - (isBuffer ? 16 : 32) - (fragment ? 48 : 0);  // regIndex is used for buffer binding index
 
 						m_bindInfo[stage].type = isBuffer ? BindType::Buffer : BindType::Image;


### PR DESCRIPTION
Shaderc writes out a list of all uniforms before optimization and then goes through the list of storage buffers, updating the uniform info. With unused storage buffers, that update never happens so the binding index stays 0, causing out-of-bounds access after calculating the stage [here](https://github.com/bkaradzic/bgfx/blob/b298851bf01e9bd16c2e70bcafe5bbf7cf0dd4fc/src/renderer_vk.cpp#L5389).

The way this manifested itself was a random write to `m_textures[i].m_textureImage`, causing a validation error while trying to destroy an invalid handle 3 frames later. That was fun to debug 💩 

I was working on a fix in shaderc but realized it's better to avoid making unnecessary changes to shaderc and that a fix should also work with old shaders.