### PR TITLE
Minor alteration to clarify that BGFX_DISCARD_STATE also discards uniforms

### DIFF
--- a/bindings/bf/bgfx.bf
+++ b/bindings/bf/bgfx.bf
@@ -554,7 +554,7 @@ public static class bgfx
 		InstanceData           = 0x00000004,
 	
 		/// <summary>
-		/// Discard state.
+		/// Discard state and uniform bindings.
 		/// </summary>
 		State                  = 0x00000008,
 	

--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -553,7 +553,7 @@ public static partial class bgfx
 		InstanceData           = 0x00000004,
 	
 		/// <summary>
-		/// Discard state.
+		/// Discard state and uniform bindings.
 		/// </summary>
 		State                  = 0x00000008,
 	

--- a/bindings/d/types.d
+++ b/bindings/d/types.d
@@ -197,7 +197,7 @@ enum ubyte BGFX_DISCARD_NONE = 0x00; /// Preserve everything.
 enum ubyte BGFX_DISCARD_BINDINGS = 0x01; /// Discard texture sampler and buffer bindings.
 enum ubyte BGFX_DISCARD_INDEX_BUFFER = 0x02; /// Discard index buffer.
 enum ubyte BGFX_DISCARD_INSTANCE_DATA = 0x04; /// Discard instance data.
-enum ubyte BGFX_DISCARD_STATE = 0x08; /// Discard state.
+enum ubyte BGFX_DISCARD_STATE = 0x08; /// Discard state and uniform bindings.
 enum ubyte BGFX_DISCARD_TRANSFORM = 0x10; /// Discard transform.
 enum ubyte BGFX_DISCARD_VERTEX_STREAMS = 0x20; /// Discard vertex streams.
 enum ubyte BGFX_DISCARD_ALL = 0xff; /// Discard all states.
@@ -1062,4 +1062,3 @@ struct bgfx_uniform_handle_t { ushort idx; }
 struct bgfx_vertex_buffer_handle_t { ushort idx; }
 
 struct bgfx_vertex_layout_handle_t { ushort idx; }
-

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -262,7 +262,7 @@
 #define BGFX_DISCARD_BINDINGS                     UINT8_C(0x01) //!< Discard texture sampler and buffer bindings.
 #define BGFX_DISCARD_INDEX_BUFFER                 UINT8_C(0x02) //!< Discard index buffer.
 #define BGFX_DISCARD_INSTANCE_DATA                UINT8_C(0x04) //!< Discard instance data.
-#define BGFX_DISCARD_STATE                        UINT8_C(0x08) //!< Discard state.
+#define BGFX_DISCARD_STATE                        UINT8_C(0x08) //!< Discard state and uniform bindings.
 #define BGFX_DISCARD_TRANSFORM                    UINT8_C(0x10) //!< Discard transform.
 #define BGFX_DISCARD_VERTEX_STREAMS               UINT8_C(0x20) //!< Discard vertex streams.
 #define BGFX_DISCARD_ALL                          UINT8_C(0xff) //!< Discard all states.

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -206,7 +206,7 @@ flag.Discard { bits = 8, const, desc = "Discard flags" }
 	.Bindings      (0x01) --- Discard texture sampler and buffer bindings.
 	.IndexBuffer   (0x02) --- Discard index buffer.
 	.InstanceData  (0x04) --- Discard instance data.
-	.State         (0x08) --- Discard state.
+	.State         (0x08) --- Discard state and uniform bindings.
 	.Transform     (0x10) --- Discard transform.
 	.VertexStreams (0x20) --- Discard vertex streams.
 	.All           (0xff) --- Discard all states.


### PR DESCRIPTION
Would've helped me understand a uniform binding issue, since BGFX_DISCARD_BINDINGS wont discard any bound texture samplers/uniforms per draw call. Let me know if theres a better way to describe. I am assuming doc generation is done out of hand so didn't bother with that in this PR, just replaced some references.