### PR TITLE
Remove unused attributes in debug draw shaders

### DIFF
--- a/examples/common/debugdraw/vs_debugdraw_fill_lit_mesh.sc
+++ b/examples/common/debugdraw/vs_debugdraw_fill_lit_mesh.sc
@@ -1,4 +1,4 @@
-$input a_position, a_indices
+$input a_position
 $output v_view, v_world
 
 /*

--- a/examples/common/debugdraw/vs_debugdraw_fill_mesh.sc
+++ b/examples/common/debugdraw/vs_debugdraw_fill_mesh.sc
@@ -1,4 +1,4 @@
-$input a_position, a_indices
+$input a_position
 
 /*
  * Copyright 2011-2021 Branimir Karadzic. All rights reserved.


### PR DESCRIPTION
This fixes validation errors in the VK backend with example 29-debugdraw.

The attributes are unused, but they're included in the resulting SPIR-V. VK backend doesn't find the attribute in `VertexLayout` because it doesn't exist and uses RGB32F as a fallback.

I'm not sure if this warrants a fix in shaderc or if that is expected behaviour.

@bkaradzic with this PR, if you recompile shaders for 31, 37, 39 and debugdraw, all the Vulkan examples should work, without any (validation) errors, apart from the ones missing features (multiple windows and occlusion queries) 🙏 