### PR TITLE
Retain reset flags when creating a new metal frame buffer for a window.

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -936,7 +936,7 @@ namespace bgfx { namespace mtl
 
 			FrameBufferMtl& fb = m_frameBuffers[_handle.idx];
 			fb.create(denseIdx, _nwh, _width, _height, _format, _depthFormat);
-			fb.m_swapChain->resize(m_frameBuffers[_handle.idx], _width, _height, 0);
+			fb.m_swapChain->resize(m_frameBuffers[_handle.idx], _width, _height, m_resolution.reset);
 		}
 
 		void destroyFrameBuffer(FrameBufferHandle _handle) override


### PR DESCRIPTION
With the metal renderer, if you create a frame buffer for a window it could zero reset flags like VSYNC when created.
This passes the existing flags in when creating the frame buffer.