### PR TITLE
Vulkan: add headless and MSAA backbuffer support

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3240,6 +3240,11 @@ VK_IMPORT_DEVICE
 				}
 			}
 
+			const VkRenderPass renderPass = isValid(m_fbh)
+				? m_frameBuffers[m_fbh.idx].m_renderPass
+				: m_swapChain.m_renderPass
+				;
+
 			bx::HashMurmur2A murmur;
 			murmur.begin();
 			murmur.add(_state);
@@ -3258,9 +3263,7 @@ VK_IMPORT_DEVICE
 			}
 
 			murmur.add(layout.m_attributes, sizeof(layout.m_attributes) );
-			murmur.add(m_fbh.idx);
-			murmur.add(isValid(m_fbh) ? 0 : m_swapChain.m_sci.imageFormat);
-			murmur.add(isValid(m_fbh) ? 0 : m_swapChain.m_sampler.Count);
+			murmur.add(renderPass);
 			murmur.add(_numInstanceData);
 			const uint32_t hash = murmur.end();
 
@@ -3391,7 +3394,7 @@ VK_IMPORT_DEVICE
 			graphicsPipeline.pColorBlendState    = &colorBlendState;
 			graphicsPipeline.pDynamicState       = &dynamicState;
 			graphicsPipeline.layout     = program.m_pipelineLayout;
-			graphicsPipeline.renderPass = isValid(m_fbh) ? m_frameBuffers[m_fbh.idx].m_renderPass : m_swapChain.m_renderPass;
+			graphicsPipeline.renderPass = renderPass;
 			graphicsPipeline.subpass    = 0;
 			graphicsPipeline.basePipelineHandle = VK_NULL_HANDLE;
 			graphicsPipeline.basePipelineIndex  = 0;

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -78,13 +78,13 @@
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceMemoryProperties);       \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceMemoryProperties2KHR);   \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceQueueFamilyProperties);  \
-			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceSurfaceCapabilitiesKHR); \
-			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceSurfaceFormatsKHR);      \
-			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceSurfacePresentModesKHR); \
-			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceSurfaceSupportKHR);      \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceSurfaceCapabilitiesKHR); \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceSurfaceFormatsKHR);      \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceSurfacePresentModesKHR); \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceSurfaceSupportKHR);      \
 			VK_IMPORT_INSTANCE_FUNC(false, vkCreateDevice);                            \
 			VK_IMPORT_INSTANCE_FUNC(false, vkDestroyDevice);                           \
-			VK_IMPORT_INSTANCE_FUNC(false, vkDestroySurfaceKHR);                       \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkDestroySurfaceKHR);                       \
 			/* VK_EXT_debug_report */                                                  \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateDebugReportCallbackEXT);            \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkDestroyDebugReportCallbackEXT);           \
@@ -93,11 +93,11 @@
 
 #define VK_IMPORT_DEVICE                                                   \
 			VK_IMPORT_DEVICE_FUNC(false, vkGetDeviceQueue);                \
-			VK_IMPORT_DEVICE_FUNC(false, vkCreateSwapchainKHR);            \
-			VK_IMPORT_DEVICE_FUNC(false, vkDestroySwapchainKHR);           \
-			VK_IMPORT_DEVICE_FUNC(false, vkGetSwapchainImagesKHR);         \
-			VK_IMPORT_DEVICE_FUNC(false, vkAcquireNextImageKHR);           \
-			VK_IMPORT_DEVICE_FUNC(false, vkQueuePresentKHR);               \
+			VK_IMPORT_DEVICE_FUNC(true,  vkCreateSwapchainKHR);            \
+			VK_IMPORT_DEVICE_FUNC(true,  vkDestroySwapchainKHR);           \
+			VK_IMPORT_DEVICE_FUNC(true,  vkGetSwapchainImagesKHR);         \
+			VK_IMPORT_DEVICE_FUNC(true,  vkAcquireNextImageKHR);           \
+			VK_IMPORT_DEVICE_FUNC(true,  vkQueuePresentKHR);               \
 			VK_IMPORT_DEVICE_FUNC(false, vkCreateFence);                   \
 			VK_IMPORT_DEVICE_FUNC(false, vkDestroyFence);                  \
 			VK_IMPORT_DEVICE_FUNC(false, vkCreateSemaphore);               \

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -611,6 +611,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 			, m_currentImageLayout(VK_IMAGE_LAYOUT_UNDEFINED)
 			, m_singleMsaaImage(VK_NULL_HANDLE)
 			, m_singleMsaaDeviceMem(VK_NULL_HANDLE)
+			, m_currentSingleMsaaImageLayout(VK_IMAGE_LAYOUT_UNDEFINED)
 		{
 		}
 
@@ -621,10 +622,10 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		void destroy();
 
 		void update(VkCommandBuffer _commandBuffer, uint8_t _side, uint8_t _mip, const Rect& _rect, uint16_t _z, uint16_t _depth, uint16_t _pitch, const Memory* _mem);
-		void resolve(VkCommandBuffer _commandBuffer, uint8_t _resolve);
+		void resolve(VkCommandBuffer _commandBuffer, uint8_t _resolve, uint32_t _layer, uint32_t _numLayers, uint32_t _mip);
 
 		void copyBufferToTexture(VkCommandBuffer _commandBuffer, VkBuffer _stagingBuffer, uint32_t _bufferImageCopyCount, VkBufferImageCopy* _bufferImageCopy);
-		void setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout);
+		void setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout, bool _singleMsaaImage = false);
 
 		VkImageView createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, VkImageViewType _type, bool _renderTarget) const;
 
@@ -652,6 +653,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		VkImage        m_singleMsaaImage;
 		VkDeviceMemory m_singleMsaaDeviceMem;
+		VkImageLayout  m_currentSingleMsaaImageLayout;
 
 		ReadbackVK m_readback;
 

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -293,6 +293,7 @@ namespace bgfx { namespace vk
 	void release(Vk##_name&)
 VK_DESTROY
 VK_DESTROY_FUNC(DeviceMemory);
+VK_DESTROY_FUNC(SurfaceKHR);
 #undef VK_DESTROY_FUNC
 
 	struct DslBinding
@@ -649,6 +650,81 @@ VK_DESTROY_FUNC(DeviceMemory);
 		VkDeviceMemory m_singleMsaaDeviceMem;
 
 		ReadbackVK m_readback;
+	};
+
+	struct SwapChainVK
+	{
+		SwapChainVK()
+			: m_swapchain(VK_NULL_HANDLE)
+			, m_lastImageRenderedSemaphore(VK_NULL_HANDLE)
+			, m_lastImageAcquiredSemaphore(VK_NULL_HANDLE)
+		{
+		}
+
+		VkResult create(uint32_t queueFamily, VkQueue _queue, VkCommandBuffer _commandBuffer, const Resolution& _resolution);
+		
+		void destroy();
+
+		void update(VkCommandBuffer _commandBuffer, uint32_t _width, uint32_t _height, uint32_t _reset);
+
+		VkResult createSurface(uint32_t _reset);
+		VkResult createSwapChain(uint32_t _reset);
+		VkResult createRenderPass();
+		VkResult createFrameBuffer();
+
+		void releaseSurface();
+		void releaseSwapChain();
+		void releaseRenderPass();
+		void releaseFrameBuffer();
+
+		void initImageLayout(VkCommandBuffer _commandBuffer);
+
+		uint32_t findPresentMode(bool _vsync);
+
+		bool acquire(VkCommandBuffer _commandBuffer);
+		void present();
+
+		VkQueue m_queue;
+		VkSwapchainCreateInfoKHR m_sci;
+
+		VkSurfaceKHR       m_surface;
+		VkSwapchainKHR     m_swapchain;
+		uint32_t           m_numSwapchainImages;
+		VkSurfaceFormatKHR m_backBufferColorFormat;
+		VkSurfaceFormatKHR m_backBufferColorFormatSrgb;
+		VkImageLayout      m_backBufferColorImageLayout[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkImage            m_backBufferColorImage[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkImageView        m_backBufferColorImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkImage            m_backBufferColorMsaaImage[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkImageView        m_backBufferColorMsaaImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkFramebuffer      m_backBufferFrameBuffer[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkFence            m_backBufferFence[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkRenderPass       m_renderPass;
+
+		VkSemaphore        m_presentDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkSemaphore        m_renderDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		uint32_t           m_currentSemaphore;
+
+		VkSemaphore        m_lastImageRenderedSemaphore;
+		VkSemaphore        m_lastImageAcquiredSemaphore;
+
+		uint32_t           m_backBufferColorIdx;
+		bool               m_needPresent;
+		bool               m_needToRefreshSwapchain;
+		bool               m_needToRecreateSurface;
+
+		VkFormat           m_backBufferDepthStencilFormat;
+		VkDeviceMemory     m_backBufferDepthStencilMemory;
+		VkImage            m_backBufferDepthStencilImage;
+		VkImageView        m_backBufferDepthStencilImageView;
+
+		VkImage m_backBufferColorMsaa;
+		VkImage m_backBufferDepth;
+
+		VkFormat m_colorFormat;
+		VkFormat m_depthFormat;
+
+		uint8_t m_sampleCount;
 	};
 
 	struct FrameBufferVK

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -625,7 +625,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		void resolve(VkCommandBuffer _commandBuffer, uint8_t _resolve, uint32_t _layer, uint32_t _numLayers, uint32_t _mip);
 
 		void copyBufferToTexture(VkCommandBuffer _commandBuffer, VkBuffer _stagingBuffer, uint32_t _bufferImageCopyCount, VkBufferImageCopy* _bufferImageCopy);
-		void setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout, bool _singleMsaaImage = false);
+		VkImageLayout setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout, bool _singleMsaaImage = false);
 
 		VkImageView createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, VkImageViewType _type, bool _renderTarget) const;
 

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -615,7 +615,11 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		}
 
 		void* create(VkCommandBuffer _commandBuffer, const Memory* _mem, uint64_t _flags, uint8_t _skip);
+		// internal render target
+		VkResult create(VkCommandBuffer _commandBuffer, uint32_t _width, uint32_t _height, uint64_t _flags, VkFormat _format, VkImageAspectFlags _aspectMask);
+
 		void destroy();
+
 		void update(VkCommandBuffer _commandBuffer, uint8_t _side, uint8_t _mip, const Rect& _rect, uint16_t _z, uint16_t _depth, uint16_t _pitch, const Memory* _mem);
 		void resolve(VkCommandBuffer _commandBuffer, uint8_t _resolve);
 
@@ -650,6 +654,9 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkDeviceMemory m_singleMsaaDeviceMem;
 
 		ReadbackVK m_readback;
+
+	private:
+		VkResult createImages(VkCommandBuffer _commandBuffer);
 	};
 
 	struct SwapChainVK
@@ -658,6 +665,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 			: m_swapchain(VK_NULL_HANDLE)
 			, m_lastImageRenderedSemaphore(VK_NULL_HANDLE)
 			, m_lastImageAcquiredSemaphore(VK_NULL_HANDLE)
+			, m_backBufferColorMsaaImageView(VK_NULL_HANDLE)
 		{
 		}
 
@@ -695,36 +703,29 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkImageLayout      m_backBufferColorImageLayout[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkImage            m_backBufferColorImage[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkImageView        m_backBufferColorImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkImage            m_backBufferColorMsaaImage[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkImageView        m_backBufferColorMsaaImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkFramebuffer      m_backBufferFrameBuffer[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkFence            m_backBufferFence[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkRenderPass       m_renderPass;
 
-		VkSemaphore        m_presentDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkSemaphore        m_renderDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		uint32_t           m_currentSemaphore;
+		VkSemaphore m_presentDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkSemaphore m_renderDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		uint32_t    m_currentSemaphore;
 
-		VkSemaphore        m_lastImageRenderedSemaphore;
-		VkSemaphore        m_lastImageAcquiredSemaphore;
+		VkSemaphore m_lastImageRenderedSemaphore;
+		VkSemaphore m_lastImageAcquiredSemaphore;
 
-		uint32_t           m_backBufferColorIdx;
-		bool               m_needPresent;
-		bool               m_needToRefreshSwapchain;
-		bool               m_needToRecreateSurface;
+		uint32_t m_backBufferColorIdx;
+		bool     m_needPresent;
+		bool     m_needToRefreshSwapchain;
+		bool     m_needToRecreateSurface;
 
-		VkFormat           m_backBufferDepthStencilFormat;
-		VkDeviceMemory     m_backBufferDepthStencilMemory;
-		VkImage            m_backBufferDepthStencilImage;
-		VkImageView        m_backBufferDepthStencilImageView;
+		VkFormat    m_backBufferDepthStencilFormat;
+		TextureVK   m_backBufferDepthStencil;
+		VkImageView m_backBufferDepthStencilImageView;
 
-		VkImage m_backBufferColorMsaa;
-		VkImage m_backBufferDepth;
-
-		VkFormat m_colorFormat;
-		VkFormat m_depthFormat;
-
-		uint8_t m_sampleCount;
+		TextureVK     m_backBufferColorMsaa;
+		VkImageView   m_backBufferColorMsaaImageView;
+		MsaaSamplerVK m_sampler;
 	};
 
 	struct FrameBufferVK


### PR DESCRIPTION
This PR adds support for headless instance/device creation (when setting `platformData.nwh` to `NULL`) and MSAA backbuffers (`BGFX_RESET_MSAA_XX`) to the Vulkan backend.

I also fixed a few issues with framebuffer resolve operations and blitting of MSAA images. Namely, resolve and mipgen only used the first layer, and mipgen always started at mip 0 instead of the mip attached to the framebuffer.

The diff is pretty huge because I moved the swapchain code into its own class. This is mostly in preparation for a follow-up PR for multiple window support (soon™ 🤡).