### PR TITLE
Shaderc: Add missing raw compilation targets

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -1454,6 +1454,14 @@ namespace bgfx
 
 				compiled = true;
 			}
+			else if (profile->lang == ShadingLang::Metal)
+			{
+				compiled = compileMetalShader(_options, BX_MAKEFOURCC('M', 'T', 'L', 0), input, _writer);
+			}
+			else if (profile->lang == ShadingLang::SpirV)
+			{
+				compiled = compileSPIRVShader(_options, profile->id, input, _writer);
+			}
 			else if (profile->lang == ShadingLang::PSSL)
 			{
 				compiled = compilePSSLShader(_options, 0, input, _writer);


### PR DESCRIPTION
I needed to build some raw SPIRV shaders with shaderc and noticed those targets were missing from the code so I added them