### PR TITLE
Fix 43-denoise when FB format invalid

### DIFF
--- a/examples/43-denoise/denoise.cpp
+++ b/examples/43-denoise/denoise.cpp
@@ -967,12 +967,16 @@ public:
 		m_gbufferTex[GBUFFER_RT_DEPTH]    = bgfx::createTexture2D(uint16_t(m_size[0]), uint16_t(m_size[1]), false, 1, bgfx::TextureFormat::D32F , pointSampleFlags);
 		m_gbuffer = bgfx::createFrameBuffer(BX_COUNTOF(m_gbufferTex), m_gbufferTex, true);
 
-		m_currentColor.init(m_size[0], m_size[1], bgfx::TextureFormat::RG11B10F, bilinearFlags);
-		m_previousColor.init(m_size[0], m_size[1], bgfx::TextureFormat::RG11B10F, bilinearFlags);
-		m_txaaColor.init(m_size[0], m_size[1], bgfx::TextureFormat::RG11B10F, bilinearFlags);
-		m_temporaryColor.init(m_size[0], m_size[1], bgfx::TextureFormat::RG11B10F, bilinearFlags);
-		m_previousNormal.init(m_size[0], m_size[1], bgfx::TextureFormat::RG11B10F, pointSampleFlags);
-		m_previousDenoise.init(m_size[0], m_size[1], bgfx::TextureFormat::RG11B10F, bilinearFlags);
+		bgfx::TextureFormat::Enum format = bgfx::TextureFormat::RG11B10F;
+		if (!bgfx::isTextureValid(1, false, 1, format, bilinearFlags))
+			format = bgfx::TextureFormat::RGBA16F;
+
+		m_currentColor.init(m_size[0], m_size[1], format, bilinearFlags);
+		m_previousColor.init(m_size[0], m_size[1], format, bilinearFlags);
+		m_txaaColor.init(m_size[0], m_size[1], format, bilinearFlags);
+		m_temporaryColor.init(m_size[0], m_size[1], format, bilinearFlags);
+		m_previousNormal.init(m_size[0], m_size[1], format, pointSampleFlags);
+		m_previousDenoise.init(m_size[0], m_size[1], format, bilinearFlags);
 	}
 
 	// all buffers set to destroy their textures


### PR DESCRIPTION
WebGPU doesn't actually support using `RG11B10F` format as a render target.

So to make `43-denoise` work with WebGPU I added a `isTextureValid` check and fallback on `RGBA16F` format because I didn't really know what else I could use (although twice bigger, but it's just an example after all). If you have any other idea I can change something