### PR TITLE
Fixes for multiple windows and example 22

### DIFF
--- a/examples/22-windows/windows.cpp
+++ b/examples/22-windows/windows.cpp
@@ -177,20 +177,6 @@ public:
 		{
 			entry::MouseState mouseState = m_state.m_mouse;
 
-			imguiBeginFrame(mouseState.m_mx
-				,  mouseState.m_my
-				, (mouseState.m_buttons[entry::MouseButton::Left  ] ? IMGUI_MBUT_LEFT   : 0)
-				| (mouseState.m_buttons[entry::MouseButton::Right ] ? IMGUI_MBUT_RIGHT  : 0)
-				| (mouseState.m_buttons[entry::MouseButton::Middle] ? IMGUI_MBUT_MIDDLE : 0)
-				,  mouseState.m_mz
-				, uint16_t(m_width)
-				, uint16_t(m_height)
-				);
-
-			showExampleDialog(this);
-
-			imguiEndFrame();
-
 			if (isValid(m_state.m_handle) )
 			{
 				if (0 == m_state.m_handle.idx)
@@ -230,6 +216,20 @@ public:
 					}
 				}
 			}
+
+			imguiBeginFrame(mouseState.m_mx
+				,  mouseState.m_my
+				, (mouseState.m_buttons[entry::MouseButton::Left  ] ? IMGUI_MBUT_LEFT   : 0)
+				| (mouseState.m_buttons[entry::MouseButton::Right ] ? IMGUI_MBUT_RIGHT  : 0)
+				| (mouseState.m_buttons[entry::MouseButton::Middle] ? IMGUI_MBUT_MIDDLE : 0)
+				,  mouseState.m_mz
+				, uint16_t(m_width)
+				, uint16_t(m_height)
+				);
+
+			showExampleDialog(this);
+
+			imguiEndFrame();
 
 			const bx::Vec3 at  = { 0.0f, 0.0f,   0.0f };
 			const bx::Vec3 eye = { 0.0f, 0.0f, -35.0f };

--- a/examples/common/entry/entry_windows.cpp
+++ b/examples/common/entry/entry_windows.cpp
@@ -573,6 +573,8 @@ namespace entry
 							, (HINSTANCE)GetModuleHandle(NULL)
 							, 0
 							);
+
+						adjust(hwnd, msg->m_width, msg->m_height, true);
 						clear(hwnd);
 
 						m_hwnd[_wparam]  = hwnd;

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1406,7 +1406,7 @@ namespace bgfx
 		{
 			viewRemap[m_viewRemap[ii] ] = ViewId(ii);
 
-			View& view = s_ctx->m_view[ii];
+			View& view = m_view[ii];
 			Rect rect(0, 0, uint16_t(m_resolution.width), uint16_t(m_resolution.height) );
 
 			if (isValid(view.m_fbh) )

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1021,6 +1021,7 @@ namespace bgfx { namespace d3d12
 				m_resolution.width  = _init.resolution.width;
 				m_resolution.height = _init.resolution.height;
 
+				m_windows[0] = BGFX_INVALID_HANDLE;
 				m_numWindows = 1;
 
 #if BX_PLATFORM_WINDOWS


### PR DESCRIPTION
- fixed D3D12 backend crash, trying to index framebuffers with uninitialized handle
- use correct views (not last frame's views) for cropping view rect. this only showed up when combined with resizing windows
- example 22:
  - use correct window size for imgui
  - adjust window size to include the frame decoration. this was already done for the main window, but not for new ones. I checked all the other entry functions for creating windows (SDL, GLFW etc.) and according to their respective docs all of them create a window with the given size as the client area, so no fix needed for those. D3D doesn't seem to care about the render area being larger than the backbuffer, but Vulkan validation threw a fit.