### PR TITLE
WebGPU: Fix 37-gpudrivenrendering

### DIFF
--- a/examples/37-gpudrivenrendering/fs_gdr_render_occlusion.sc
+++ b/examples/37-gpudrivenrendering/fs_gdr_render_occlusion.sc
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2011-2021 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
+ */
+
+#include "../common/common.sh"
+
+void main()
+{
+}

--- a/examples/37-gpudrivenrendering/gpudrivenrendering.cpp
+++ b/examples/37-gpudrivenrendering/gpudrivenrendering.cpp
@@ -603,7 +603,10 @@ public:
 			m_indirectBuffer = bgfx::createIndirectBuffer(m_noofProps);
 
 			// Create programs from shaders for occlusion pass.
-			m_programOcclusionPass    = loadProgram("vs_gdr_render_occlusion", NULL);
+			if (bgfx::RendererType::WebGPU == bgfx::getRendererType())
+				m_programOcclusionPass = loadProgram("vs_gdr_render_occlusion", "fs_gdr_render_occlusion");
+			else
+				m_programOcclusionPass = loadProgram("vs_gdr_render_occlusion", NULL);
 			m_programCopyZ            = loadProgram("cs_gdr_copy_z", NULL);
 			m_programDownscaleHiZ     = loadProgram("cs_gdr_downscale_hi_z", NULL);
 			m_programOccludeProps     = loadProgram("cs_gdr_occlude_props", NULL);


### PR DESCRIPTION
WebGPU/Dawn doesn't support programs with no fragment shaders for now, so we have to workaround that to make `37-gpudrivenrendering` work