### PR TITLE
Vulkan: multiple windows, capture support

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2641,11 +2641,18 @@ VK_IMPORT_DEVICE
 			{
 				flags &= ~BGFX_RESET_INTERNAL_FORCE;
 
+				const uint64_t recreateSurfaceMask = BGFX_RESET_HIDPI;
+
+				m_backBuffer.m_swapChain.m_needToRecreateSurface = false
+					|| m_backBuffer.m_swapChain.m_needToRecreateSurface
+					|| g_platformData.nwh != m_backBuffer.m_nwh
+					|| (flags & recreateSurfaceMask) != (m_resolution.reset & recreateSurfaceMask)
+					;
+
 				if (g_platformData.nwh != m_backBuffer.m_nwh)
 				{
 					m_backBuffer.m_nwh = g_platformData.nwh;
 					m_backBuffer.m_swapChain.m_nwh = g_platformData.nwh;
-					m_backBuffer.m_swapChain.m_needToRecreateSurface = true;
 				}
 
 				const uint64_t recreateMask = 0

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2641,6 +2641,13 @@ VK_IMPORT_DEVICE
 			{
 				flags &= ~BGFX_RESET_INTERNAL_FORCE;
 
+				if (g_platformData.nwh != m_backBuffer.m_nwh)
+				{
+					m_backBuffer.m_nwh = g_platformData.nwh;
+					m_backBuffer.m_swapChain.m_nwh = g_platformData.nwh;
+					m_backBuffer.m_swapChain.m_needToRecreateSurface = true;
+				}
+
 				const uint64_t recreateMask = 0
 					| BGFX_RESET_VSYNC
 					| BGFX_RESET_SRGB_BACKBUFFER

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -685,7 +685,6 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkResult createSwapChain(VkCommandBuffer _commandBuffer, uint32_t _reset);
 		VkResult createFrameBuffer();
 
-		void releaseSurface();
 		void releaseSwapChain();
 		void releaseFrameBuffer();
 
@@ -693,6 +692,8 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		bool acquire(VkCommandBuffer _commandBuffer);
 		void present();
+
+		void transitionImage(VkCommandBuffer _commandBuffer, VkImageLayout _newLayout);
 
 		VkQueue m_queue;
 		VkSwapchainCreateInfoKHR m_sci;
@@ -755,7 +756,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		void update(VkCommandBuffer _commandBuffer, uint32_t _width, uint32_t _height, uint32_t _reset, TextureFormat::Enum _format = TextureFormat::Count);
 
 		void resolve();
-		void destroy();
+		uint16_t destroy();
 
 		bool acquire(VkCommandBuffer _commandBuffer);
 		void present();
@@ -789,9 +790,13 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkResult init(uint32_t _queueFamily, VkQueue _queue, uint32_t _numFramesInFlight);
 		VkResult reset();
 		void shutdown();
+
 		VkResult alloc(VkCommandBuffer* _commandBuffer);
-		void kick(VkSemaphore _waitSemaphore = VK_NULL_HANDLE, VkSemaphore _signalSemaphore = VK_NULL_HANDLE, bool _wait = false);
+		void addWaitSemaphore(VkSemaphore _semaphore, VkPipelineStageFlags _waitFlags = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+		void addSignalSemaphore(VkSemaphore _semaphore);
+		void kick(bool _wait = false);
 		void finish(bool _finishAll = false);
+
 		void release(uint64_t _handle, VkObjectType _type);
 		void consume();
 
@@ -805,18 +810,23 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		VkCommandBuffer m_activeCommandBuffer;
 
-		VkSemaphore m_kickedSemaphore;
+		VkFence m_upcomingFence;
 		VkFence m_kickedFence;
 
 		struct CommandList
 		{
 			VkCommandPool m_commandPool = VK_NULL_HANDLE;
 			VkCommandBuffer m_commandBuffer = VK_NULL_HANDLE;
-			VkSemaphore m_semaphore = VK_NULL_HANDLE;
 			VkFence m_fence = VK_NULL_HANDLE;
 		};
 
 		CommandList m_commandList[BGFX_CONFIG_MAX_FRAME_LATENCY];
+
+		uint32_t             m_numWaitSemaphores;
+		VkSemaphore          m_waitSemaphores[BGFX_CONFIG_MAX_FRAME_BUFFERS];
+		VkPipelineStageFlags m_waitSemaphoreStages[BGFX_CONFIG_MAX_FRAME_BUFFERS];
+		uint32_t             m_numSignalSemaphores;
+		VkSemaphore          m_signalSemaphores[BGFX_CONFIG_MAX_FRAME_BUFFERS];
 
 		struct Resource
 		{

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -42,7 +42,7 @@
 			VK_IMPORT_FUNC(false, vkGetDeviceProcAddr);                    \
 			VK_IMPORT_FUNC(false, vkEnumerateInstanceExtensionProperties); \
 			VK_IMPORT_FUNC(false, vkEnumerateInstanceLayerProperties);     \
-			VK_IMPORT_FUNC(false, vkEnumerateInstanceVersion);             \
+			VK_IMPORT_FUNC(true,  vkEnumerateInstanceVersion);             \
 
 #define VK_IMPORT_INSTANCE_ANDROID \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateAndroidSurfaceKHR);

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -709,6 +709,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkImageView        m_backBufferColorImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkFramebuffer      m_backBufferFrameBuffer[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkFence            m_backBufferFence[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		bool               m_supportsReadback;
 
 		VkSemaphore m_presentDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkSemaphore m_renderDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
@@ -729,6 +730,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		TextureVK     m_backBufferColorMsaa;
 		VkImageView   m_backBufferColorMsaaImageView;
 		MsaaSamplerVK m_sampler;
+		bool          m_supportsManualResolve;
 	};
 
 	struct FrameBufferVK
@@ -758,7 +760,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		bool acquire(VkCommandBuffer _commandBuffer);
 		void present();
 
-		bool valid() const;
+		bool isRenderable() const;
 
 		TextureHandle m_texture[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 		TextureHandle m_depth;

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -591,16 +591,16 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 	struct ReadbackVK
 	{
-		void create(VkImage _image, uint32_t _width, uint32_t _height, bimg::TextureFormat::Enum _format);
+		void create(VkImage _image, uint32_t _width, uint32_t _height, TextureFormat::Enum _format);
 		void destroy();
 		uint32_t pitch(uint8_t _mip = 0) const;
 		void copyImageToBuffer(VkCommandBuffer _commandBuffer, VkBuffer _buffer, VkImageLayout _layout, VkImageAspectFlags _aspect, uint8_t _mip = 0) const;
 		void readback(VkDeviceMemory _memory, VkDeviceSize _offset, void* _data, uint8_t _mip = 0) const;
 
-		VkImage m_image;
+		VkImage  m_image;
 		uint32_t m_width;
 		uint32_t m_height;
-		bimg::TextureFormat::Enum m_format;
+		TextureFormat::Enum  m_format;
 	};
 
 	struct TextureVK
@@ -682,9 +682,9 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		void update(VkCommandBuffer _commandBuffer, void* _nwh, const Resolution& _resolution);
 
-		VkResult createSurface(void* _nwh, uint32_t _reset);
-		VkResult createSwapChain(uint32_t _reset);
-		VkResult createAttachments(VkCommandBuffer _commandBuffer, uint32_t _reset);
+		VkResult createSurface();
+		VkResult createSwapChain();
+		VkResult createAttachments(VkCommandBuffer _commandBuffer);
 		VkResult createFrameBuffer();
 
 		void releaseSurface();
@@ -693,6 +693,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		void releaseFrameBuffer();
 
 		uint32_t findPresentMode(bool _vsync);
+		TextureFormat::Enum findSurfaceFormat(TextureFormat::Enum _format, VkColorSpaceKHR _colorSpace, bool _srgb);
 
 		bool acquire(VkCommandBuffer _commandBuffer);
 		void present();
@@ -705,17 +706,18 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		void* m_nwh;
 		Resolution m_resolution;
 
-		VkSurfaceKHR       m_surface;
-		VkSwapchainKHR     m_swapchain;
-		uint32_t           m_numSwapchainImages;
-		VkSurfaceFormatKHR m_backBufferColorFormat;
-		VkSurfaceFormatKHR m_backBufferColorFormatSrgb;
-		VkImageLayout      m_backBufferColorImageLayout[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkImage            m_backBufferColorImage[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkImageView        m_backBufferColorImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkFramebuffer      m_backBufferFrameBuffer[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkFence            m_backBufferFence[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		bool               m_supportsReadback;
+		TextureFormat::Enum m_colorFormat;
+		TextureFormat::Enum m_depthFormat;
+
+		VkSurfaceKHR   m_surface;
+		VkSwapchainKHR m_swapchain;
+		uint32_t       m_numSwapchainImages;
+		VkImageLayout  m_backBufferColorImageLayout[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkImage        m_backBufferColorImage[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkImageView    m_backBufferColorImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkFramebuffer  m_backBufferFrameBuffer[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkFence        m_backBufferFence[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		uint32_t       m_backBufferColorIdx;
 
 		VkSemaphore m_presentDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkSemaphore m_renderDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
@@ -723,20 +725,20 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		VkSemaphore m_lastImageRenderedSemaphore;
 		VkSemaphore m_lastImageAcquiredSemaphore;
-
-		uint32_t m_backBufferColorIdx;
-		bool     m_needPresent;
-		bool     m_needToRefreshSwapchain;
-		bool     m_needToRecreateSurface;
-
-		TextureFormat::Enum m_backBufferDepthStencilFormat;
-		TextureVK           m_backBufferDepthStencil;
-		VkImageView         m_backBufferDepthStencilImageView;
+		
+		bool m_needPresent;
+		bool m_needToRefreshSwapchain;
+		bool m_needToRecreateSurface;
+		
+		TextureVK   m_backBufferDepthStencil;
+		VkImageView m_backBufferDepthStencilImageView;
 
 		TextureVK     m_backBufferColorMsaa;
 		VkImageView   m_backBufferColorMsaaImageView;
 		MsaaSamplerVK m_sampler;
-		bool          m_supportsManualResolve;
+
+		bool m_supportsReadback;
+		bool m_supportsManualResolve;
 	};
 
 	struct FrameBufferVK

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -620,7 +620,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		void* create(VkCommandBuffer _commandBuffer, const Memory* _mem, uint64_t _flags, uint8_t _skip);
 		// internal render target
-		VkResult create(VkCommandBuffer _commandBuffer, uint32_t _width, uint32_t _height, uint64_t _flags, VkFormat _format, VkImageAspectFlags _aspectMask);
+		VkResult create(VkCommandBuffer _commandBuffer, uint32_t _width, uint32_t _height, uint64_t _flags, VkFormat _format);
 
 		void destroy();
 
@@ -662,6 +662,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 	private:
 		VkResult createImages(VkCommandBuffer _commandBuffer);
+		static VkImageAspectFlags getAspectMask(VkFormat _format);
 	};
 
 	struct SwapChainVK
@@ -728,9 +729,9 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		bool     m_needToRefreshSwapchain;
 		bool     m_needToRecreateSurface;
 
-		VkFormat    m_backBufferDepthStencilFormat;
-		TextureVK   m_backBufferDepthStencil;
-		VkImageView m_backBufferDepthStencilImageView;
+		TextureFormat::Enum m_backBufferDepthStencilFormat;
+		TextureVK           m_backBufferDepthStencil;
+		VkImageView         m_backBufferDepthStencilImageView;
 
 		TextureVK     m_backBufferColorMsaa;
 		VkImageView   m_backBufferColorMsaaImageView;

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -685,6 +685,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkResult createSwapChain(VkCommandBuffer _commandBuffer, uint32_t _reset);
 		VkResult createFrameBuffer();
 
+		void releaseSurface();
 		void releaseSwapChain();
 		void releaseFrameBuffer();
 

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -683,12 +683,10 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		VkResult createSurface(void* _nwh, uint32_t _reset);
 		VkResult createSwapChain(VkCommandBuffer _commandBuffer, uint32_t _reset);
-		VkResult createRenderPass();
 		VkResult createFrameBuffer();
 
 		void releaseSurface();
 		void releaseSwapChain();
-		void releaseRenderPass();
 		void releaseFrameBuffer();
 
 		uint32_t findPresentMode(bool _vsync);
@@ -711,7 +709,6 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkImageView        m_backBufferColorImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkFramebuffer      m_backBufferFrameBuffer[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkFence            m_backBufferFence[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkRenderPass       m_renderPass;
 
 		VkSemaphore m_presentDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
 		VkSemaphore m_renderDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -743,7 +743,6 @@ VK_DESTROY_FUNC(SurfaceKHR);
 			, m_denseIdx(kInvalidHandle)
 			, m_num(0)
 			, m_numTh(0)
-			, m_needRecreate(false)
 			, m_nwh(NULL)
 			, m_needPresent(false)
 			, m_framebuffer(VK_NULL_HANDLE)
@@ -752,11 +751,14 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		void create(uint8_t _num, const Attachment* _attachment);
 		VkResult create(uint16_t _denseIdx, void* _nwh, uint32_t _width, uint32_t _height, TextureFormat::Enum _format = TextureFormat::Count, TextureFormat::Enum _depthFormat = TextureFormat::Count);
+		uint16_t destroy();
 
 		void update(VkCommandBuffer _commandBuffer, uint32_t _width, uint32_t _height, uint32_t _reset, TextureFormat::Enum _format = TextureFormat::Count);
 
+		void preReset();
+		void postReset();
+
 		void resolve();
-		uint16_t destroy();
 
 		bool acquire(VkCommandBuffer _commandBuffer);
 		void present();
@@ -770,7 +772,6 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		uint16_t m_denseIdx;
 		uint8_t m_num;
 		uint8_t m_numTh;
-		bool m_needRecreate;
 		Attachment m_attachment[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 
 		SwapChainVK m_swapChain;

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -630,7 +630,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		void copyBufferToTexture(VkCommandBuffer _commandBuffer, VkBuffer _stagingBuffer, uint32_t _bufferImageCopyCount, VkBufferImageCopy* _bufferImageCopy);
 		VkImageLayout setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout, bool _singleMsaaImage = false);
 
-		VkImageView createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, VkImageViewType _type, bool _renderTarget) const;
+		VkResult createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, VkImageViewType _type, bool _renderTarget, ::VkImageView* _view) const;
 
 		void*    m_directAccessPtr;
 		uint64_t m_flags;
@@ -679,14 +679,16 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		
 		void destroy();
 
-		void update(VkCommandBuffer _commandBuffer, uint32_t _width, uint32_t _height, uint32_t _reset, TextureFormat::Enum _format);
+		void update(VkCommandBuffer _commandBuffer, void* _nwh, const Resolution& _resolution);
 
 		VkResult createSurface(void* _nwh, uint32_t _reset);
-		VkResult createSwapChain(VkCommandBuffer _commandBuffer, uint32_t _reset);
+		VkResult createSwapChain(uint32_t _reset);
+		VkResult createAttachments(VkCommandBuffer _commandBuffer, uint32_t _reset);
 		VkResult createFrameBuffer();
 
 		void releaseSurface();
 		void releaseSwapChain();
+		void releaseAttachments();
 		void releaseFrameBuffer();
 
 		uint32_t findPresentMode(bool _vsync);
@@ -700,6 +702,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkSwapchainCreateInfoKHR m_sci;
 
 		void* m_nwh;
+		Resolution m_resolution;
 
 		VkSurfaceKHR       m_surface;
 		VkSwapchainKHR     m_swapchain;
@@ -754,7 +757,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkResult create(uint16_t _denseIdx, void* _nwh, uint32_t _width, uint32_t _height, TextureFormat::Enum _format = TextureFormat::Count, TextureFormat::Enum _depthFormat = TextureFormat::Count);
 		uint16_t destroy();
 
-		void update(VkCommandBuffer _commandBuffer, uint32_t _width, uint32_t _height, uint32_t _reset, TextureFormat::Enum _format = TextureFormat::Count);
+		void update(VkCommandBuffer _commandBuffer, const Resolution& _resolution);
 
 		void preReset();
 		void postReset();


### PR DESCRIPTION
Main two additions in this PR are:
- support for multiple windows (`BGFX_CAPS_SWAP_CHAIN`)
- support for backbuffer capture (`BGFX_RESET_CAPTURE`)

A few mostly related changes:
- use backbuffer color format supplied in `Init::resolution::format` and `reset()`, falls back to BGRA8/RGBA8 if not supported by swapchain
- swapchain recreation without stalling on the CPU if possible, should make window resizing smoother on some platforms
- fix init error when running on an Android 1.0 driver
- report all texture format caps (`FRAMEBUFFER_MSAA`, `VERTEX`, `MIP_AUTOGEN` were missing), check properly for a few more caps/limits

If anyone with a Linux system could give this a try, I'd appreciate it 🦆 My laptop decided to stop working and I don't have dual boot.