### PR TITLE
Vulkan: merge shader bindings

### DIFF
--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -494,7 +494,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 
 		uint32_t m_uniformBinding;
 		uint16_t m_numBindings;
-		VkDescriptorSetLayoutBinding m_bindings[32];
+		VkDescriptorSetLayoutBinding m_bindings[2 * BGFX_CONFIG_MAX_TEXTURE_SAMPLERS + 1];
 
 		bool m_oldBindingModel;
 	};
@@ -504,7 +504,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		ProgramVK()
 			: m_vsh(NULL)
 			, m_fsh(NULL)
-			, m_descriptorSetLayoutHash(0)
+			, m_descriptorSetLayout(VK_NULL_HANDLE)
 			, m_pipelineLayout(VK_NULL_HANDLE)
 		{
 		}
@@ -523,7 +523,7 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		PredefinedUniform m_predefined[PredefinedUniform::Count * 2];
 		uint8_t m_numPredefined;
 
-		uint32_t m_descriptorSetLayoutHash;
+		VkDescriptorSetLayout m_descriptorSetLayout;
 		VkPipelineLayout m_pipelineLayout;
 	};
 


### PR DESCRIPTION
Fix for https://github.com/bkaradzic/bgfx/issues/2410.

If vertex and fragment shader use the same stage and the shaders weren't both compiled with binary version 11 or higher, there is now an assert. For newer versions, the stages are merged correctly.

While I was touching that part of the code I also removed a needless indirection for the descriptor set layout. Instead of storing the hash and always looking it up in the cache, it stores the handle directly.