### PR TITLE
Fix macOS and iOS runtime detection

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -546,12 +546,12 @@ namespace bgfx { namespace mtl
 				|| (BX_ENABLED(BX_PLATFORM_IOS) && iOSVersionEqualOrGreater("10.0.0") )
 				;
 
-			m_macOS11Runtime = true
+			m_macOS11Runtime = false
 				&& BX_ENABLED(BX_PLATFORM_OSX)
 				&& macOSVersionEqualOrGreater(10, 11, 0)
 				;
 
-			m_iOS9Runtime = true
+			m_iOS9Runtime = false
 				&& BX_ENABLED(BX_PLATFORM_IOS)
 				&& iOSVersionEqualOrGreater("9.0.0")
 				;


### PR DESCRIPTION
I had some extra warnings on in my project which drew me to these lines which seem incorrectly using `true` as the first check which short circuits the other two checks for runtime detection.