### PR TITLE
Fixed shadow map sampling for 130 and above glsl profiles.

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -2370,6 +2370,13 @@ namespace bgfx
 											  "#define shadow2DProj shadow2DProjEXT\n"
 											);
 									}
+									else
+									{
+										bx::stringPrintf(code
+											, "#define shadow2D(_sampler, _coord) texture(_sampler, _coord)\n"
+											  "#define shadow2DProj(_sampler, _coord) textureProj(_sampler, _coord)\n"
+											);
+									}
 
 									if (usesGpuShader5)
 									{

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -2304,7 +2304,7 @@ namespace bgfx
 											);
 									}
 
-									if (need130)
+									if (need130 || (glsl_profile >= 130))
 									{
 										bx::stringPrintf(code
 											, "#define bgfxShadow2D(_sampler, _coord)     vec4_splat(texture(_sampler, _coord))\n"


### PR DESCRIPTION
The fix exists for 120 shaders that use some 130 features. On the other hand, if a 130 (or above) shader is not using those features, the actual code path will not apply that fix and the shader will fail to compile at runtime. 