### PR TITLE
d3d11: fix unintialized memory

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -665,6 +665,7 @@ namespace bgfx { namespace d3d11
 			, m_ags(NULL)
 			, m_featureLevel(D3D_FEATURE_LEVEL(0) )
 			, m_swapChain(NULL)
+			, m_msaaRt(NULL)
 			, m_needPresent(false)
 			, m_lost(false)
 			, m_numWindows(0)


### PR DESCRIPTION
this then caused `DX_RELEASE(m_msaaRt, 0);` in `error:` to fire an assert since it tries to deref the garbage ptr