### PR TITLE
Vulkan: occlusion queries, housekeeping

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2322,14 +2322,16 @@ VK_IMPORT_DEVICE
 			{
 				BX_UNUSED(_len);
 
+				const uint32_t abgr = kColorMarker;
+
 				VkDebugUtilsLabelEXT dul;
 				dul.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
 				dul.pNext = NULL;
 				dul.pLabelName = _marker;
-				dul.color[0] = 1.0f;
-				dul.color[1] = 0.0f;
-				dul.color[2] = 0.0f;
-				dul.color[3] = 1.0f;
+				dul.color[0] = ((abgr >> 24) & 0xff) / 255.0f;
+				dul.color[1] = ((abgr >> 16) & 0xff) / 255.0f;
+				dul.color[2] = ((abgr >> 8)  & 0xff) / 255.0f;
+				dul.color[3] = ((abgr >> 0)  & 0xff) / 255.0f;
 
 				vkCmdInsertDebugUtilsLabelEXT(m_commandBuffer, &dul);
 			}
@@ -4549,7 +4551,6 @@ VK_DESTROY
 		bx::read(&reader, magic);
 
 		VkShaderStageFlagBits shaderStage = VK_SHADER_STAGE_ALL;
-		BX_UNUSED(shaderStage);
 
 		if (isShaderType(magic, 'C') )
 		{
@@ -5027,7 +5028,7 @@ VK_DESTROY
 						if (UINT16_MAX != vsBindingIdx)
 						{
 							BX_ASSERT(
-								bindings[vsBindingIdx].descriptorType == fsBinding.descriptorType
+								  bindings[vsBindingIdx].descriptorType == fsBinding.descriptorType
 								, "Mismatching descriptor types. Shaders compiled with different versions of shaderc?"
 								);
 							bindings[vsBindingIdx].stageFlags |= fsBinding.stageFlags;
@@ -8295,6 +8296,12 @@ VK_DESTROY
 				}
 			}
 
+			if (beginRenderPass)
+			{
+				vkCmdEndRenderPass(m_commandBuffer);
+				beginRenderPass = false;
+			}
+
 			if (wasCompute)
 			{
 				setViewType(view, "C");
@@ -8303,12 +8310,6 @@ VK_DESTROY
 			}
 
 			submitBlit(bs, BGFX_CONFIG_MAX_VIEWS);
-
-			if (beginRenderPass)
-			{
-				vkCmdEndRenderPass(m_commandBuffer);
-				beginRenderPass = false;
-			}
 
 			if (0 < _render->m_numRenderItems)
 			{

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -1848,6 +1848,11 @@ VK_IMPORT_DEVICE
 					m_textVideoMem.resize(false, _init.resolution.width, _init.resolution.height);
 					m_textVideoMem.clear();
 
+					for (uint8_t ii = 0; ii < BX_COUNTOF(m_swapchainFormats); ++ii)
+					{
+						m_swapchainFormats[ii] = TextureFormat::Enum(ii);
+					}
+
 					result = m_backBuffer.create(UINT16_MAX, g_platformData.nwh, m_resolution.width, m_resolution.height, m_resolution.format);
 
 					if (VK_SUCCESS != result)
@@ -2306,6 +2311,8 @@ VK_IMPORT_DEVICE
 
 		void createFrameBuffer(FrameBufferHandle _handle, void* _nwh, uint32_t _width, uint32_t _height, TextureFormat::Enum _format, TextureFormat::Enum _depthFormat) override
 		{
+			BX_ASSERT(NULL != m_backBuffer.m_nwh, "Creating window frame buffer in headless mode.");
+
 			for (uint32_t ii = 0, num = m_numWindows; ii < num; ++ii)
 			{
 				FrameBufferHandle handle = m_windows[ii];
@@ -4352,6 +4359,7 @@ VK_IMPORT_DEVICE
 		bool m_timerQuerySupport;
 
 		FrameBufferVK m_backBuffer;
+		TextureFormat::Enum m_swapchainFormats[TextureFormat::Count];
 
 		uint16_t m_numWindows;
 		FrameBufferHandle m_windows[BGFX_CONFIG_MAX_FRAME_BUFFERS];
@@ -7240,8 +7248,10 @@ VK_DESTROY
 				&&  requestedVkFormat == surfaceFormats[jj].format)
 				{
 					selectedFormat = requested;
-					if (0 != ii)
+					if (0 != ii
+					&&  s_renderVK->m_swapchainFormats[_format] != selectedFormat)
 					{
+						s_renderVK->m_swapchainFormats[_format] = selectedFormat;
 						BX_TRACE(
 							"findSurfaceFormat: Surface format %s not found! Defaulting to %s."
 							, bimg::getName(bimg::TextureFormat::Enum(_format) )

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4114,15 +4114,14 @@ VK_IMPORT_DEVICE
 				}
 			}
 
-			if (0 != depthAspectMask
-			&& (BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL) & _clear.m_flags)
-			{
-				attachments[mrt].colorAttachment = mrt;
-				attachments[mrt].aspectMask = 0;
-				attachments[mrt].aspectMask |= (_clear.m_flags & BGFX_CLEAR_DEPTH  ) ? VK_IMAGE_ASPECT_DEPTH_BIT   : 0;
-				attachments[mrt].aspectMask |= (_clear.m_flags & BGFX_CLEAR_STENCIL) ? VK_IMAGE_ASPECT_STENCIL_BIT : 0;
-				attachments[mrt].aspectMask &= depthAspectMask;
+			depthAspectMask &= 0
+				| (_clear.m_flags & BGFX_CLEAR_DEPTH   ? VK_IMAGE_ASPECT_DEPTH_BIT   : 0)
+				| (_clear.m_flags & BGFX_CLEAR_STENCIL ? VK_IMAGE_ASPECT_STENCIL_BIT : 0)
+				;
 
+			if (0 != depthAspectMask)
+			{
+				attachments[mrt].aspectMask = depthAspectMask;
 				attachments[mrt].clearValue.depthStencil.stencil = _clear.m_stencil;
 				attachments[mrt].clearValue.depthStencil.depth   = _clear.m_depth;
 				++mrt;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -258,7 +258,6 @@ VK_IMPORT_DEVICE
 		enum Enum
 		{
 			VK_LAYER_LUNARG_standard_validation,
-			VK_LAYER_LUNARG_vktrace,
 			VK_LAYER_KHRONOS_validation,
 
 			Count
@@ -275,9 +274,8 @@ VK_IMPORT_DEVICE
 	//
 	static Layer s_layer[] =
 	{
-		{ "VK_LAYER_LUNARG_standard_validation",  1, { false, BGFX_CONFIG_DEBUG }, { false, false             } },
-		{ "VK_LAYER_LUNARG_vktrace",              1, { false, false             }, { false, false             } },
-		{ "VK_LAYER_KHRONOS_validation",          1, { false, BGFX_CONFIG_DEBUG }, { false, BGFX_CONFIG_DEBUG } },
+		{ "VK_LAYER_LUNARG_standard_validation", 1, { false, false }, { false, false } },
+		{ "VK_LAYER_KHRONOS_validation",         1, { false, false }, { false, false } },
 	};
 	BX_STATIC_ASSERT(Layer::Count == BX_COUNTOF(s_layer) );
 
@@ -720,7 +718,7 @@ VK_IMPORT_DEVICE
 			for (uint32_t layer = 0; layer < numLayerProperties; ++layer)
 			{
 				updateLayer(
-					layerProperties[layer].layerName
+					  layerProperties[layer].layerName
 					, layerProperties[layer].implementationVersion
 					, VK_NULL_HANDLE == _physicalDevice
 					);
@@ -1145,7 +1143,22 @@ VK_IMPORT
 			}
 
 			{
+				if (_init.debug)
+				{
+					s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_device.m_initialize   = true;
+					s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_instance.m_initialize = true;
+					s_layer[Layer::VK_LAYER_KHRONOS_validation        ].m_device.m_initialize   = true;
+					s_layer[Layer::VK_LAYER_KHRONOS_validation        ].m_instance.m_initialize = true;
+				}
+
 				dumpExtensions(VK_NULL_HANDLE, s_extension);
+
+				if (s_layer[Layer::VK_LAYER_KHRONOS_validation].m_device.m_supported
+				||  s_layer[Layer::VK_LAYER_KHRONOS_validation].m_instance.m_supported)
+				{
+					s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_device.m_supported   = false;
+					s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_instance.m_supported = false;
+				}
 
 				uint32_t numEnabledLayers = 0;
 

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -6358,6 +6358,7 @@ VK_DESTROY
 					m_sci.oldSwapchain = VK_NULL_HANDLE;
 					releaseSurface();
 					s_renderVK->kick(true);
+					_commandBuffer = s_renderVK->m_commandBuffer;
 
 					VkResult result = createSurface();
 					if (VK_SUCCESS != result)

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4387,7 +4387,14 @@ VK_DESTROY
 			, &mr
 			);
 
-		VK_CHECK(s_renderVK->allocateMemory(&mr, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &m_deviceMem) );
+		VkMemoryPropertyFlags flags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+		VkResult result = s_renderVK->allocateMemory(&mr, flags, &m_deviceMem);
+
+		if (VK_SUCCESS != result)
+		{
+			flags &= ~VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+			VK_CHECK(s_renderVK->allocateMemory(&mr, flags, &m_deviceMem) );
+		}
 
 		m_size = (uint32_t)mr.size;
 		m_pos  = 0;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -8408,10 +8408,13 @@ VK_DESTROY
 						bufferOffsetIndirect = draw.m_startIndirect * BGFX_CONFIG_DRAW_INDIRECT_STRIDE;
 					}
 
+					uint32_t numPrimsSubmitted = 0;
 					uint32_t numIndices = 0;
 
 					if (!isValid(draw.m_indexBuffer) )
 					{
+						numPrimsSubmitted = numVertices / prim.m_div - prim.m_sub;
+
 						if (isValid(draw.m_indirectBuffer) )
 						{
 							vkCmdDrawIndirect(
@@ -8444,6 +8447,8 @@ VK_DESTROY
 							? ib.m_size / indexSize
 							: draw.m_numIndices
 							;
+
+						numPrimsSubmitted = numIndices / prim.m_div - prim.m_sub;
 
 						if (currentState.m_indexBuffer.idx != draw.m_indexBuffer.idx
 						||  currentIndexFormat != indexFormat)
@@ -8482,7 +8487,6 @@ VK_DESTROY
 						}
 					}
 
-					uint32_t numPrimsSubmitted = numIndices / prim.m_div - prim.m_sub;
 					uint32_t numPrimsRendered  = numPrimsSubmitted*draw.m_numInstances;
 
 					statsNumPrimsSubmitted[primIndex] += numPrimsSubmitted;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -327,13 +327,13 @@ VK_IMPORT_DEVICE
 	//
 	static Extension s_extension[] =
 	{
-		{ "VK_EXT_debug_utils",                     1, false, false, BGFX_CONFIG_DEBUG_OBJECT_NAME, Layer::Count },
-		{ "VK_EXT_debug_report",                    1, false, false, BGFX_CONFIG_DEBUG            , Layer::Count },
-		{ "VK_EXT_memory_budget",                   1, false, false, true                         , Layer::Count },
-		{ "VK_KHR_get_physical_device_properties2", 1, false, false, true                         , Layer::Count },
-		{ "VK_EXT_conservative_rasterization",      1, false, false, true                         , Layer::Count },
-		{ "VK_EXT_line_rasterization",              1, false, false, true                         , Layer::Count },
-		{ "VK_EXT_shader_viewport_index_layer",     1, false, false, true                         , Layer::Count }
+		{ "VK_EXT_debug_utils",                     1, false, false, BGFX_CONFIG_DEBUG_OBJECT_NAME || BGFX_CONFIG_DEBUG_ANNOTATION, Layer::Count },
+		{ "VK_EXT_debug_report",                    1, false, false, false                                                        , Layer::Count },
+		{ "VK_EXT_memory_budget",                   1, false, false, true                                                         , Layer::Count },
+		{ "VK_KHR_get_physical_device_properties2", 1, false, false, true                                                         , Layer::Count },
+		{ "VK_EXT_conservative_rasterization",      1, false, false, true                                                         , Layer::Count },
+		{ "VK_EXT_line_rasterization",              1, false, false, true                                                         , Layer::Count },
+		{ "VK_EXT_shader_viewport_index_layer",     1, false, false, true                                                         , Layer::Count }
 	};
 	BX_STATIC_ASSERT(Extension::Count == BX_COUNTOF(s_extension) );
 
@@ -634,7 +634,7 @@ VK_IMPORT_DEVICE
 			, _messageCode
 			, _message
 			);
-		return VK_TRUE;
+		return VK_FALSE;
 	}
 
 	VkResult enumerateLayerProperties(VkPhysicalDevice _physicalDevice, uint32_t* _propertyCount, VkLayerProperties* _properties)
@@ -1150,6 +1150,8 @@ VK_IMPORT
 					s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_instance.m_initialize = true;
 					s_layer[Layer::VK_LAYER_KHRONOS_validation        ].m_device.m_initialize   = true;
 					s_layer[Layer::VK_LAYER_KHRONOS_validation        ].m_instance.m_initialize = true;
+
+					s_extension[Extension::EXT_debug_report].m_initialize = true;
 				}
 
 				dumpExtensions(VK_NULL_HANDLE, s_extension);
@@ -1876,10 +1878,8 @@ VK_IMPORT_DEVICE
 				vkSetDebugUtilsObjectNameEXT = stubSetDebugUtilsObjectNameEXT;
 			}
 
-			if (!s_extension[Extension::EXT_debug_utils].m_supported
-			||  NULL == vkCmdBeginDebugUtilsLabelEXT
-			||  NULL == vkCmdEndDebugUtilsLabelEXT
-			   )
+			if (NULL == vkCmdBeginDebugUtilsLabelEXT
+			||  NULL == vkCmdEndDebugUtilsLabelEXT)
 			{
 				vkCmdBeginDebugUtilsLabelEXT = stubCmdBeginDebugUtilsLabelEXT;
 				vkCmdEndDebugUtilsLabelEXT   = stubCmdEndDebugUtilsLabelEXT;

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -8319,11 +8319,6 @@ VK_DESTROY
 					continue;
 				}
 
-				if (!isFrameBufferValid)
-				{
-					continue;
-				}
-
 				const RenderDraw& draw = renderItem.draw;
 
 				const bool hasOcclusionQuery = 0 != (draw.m_stateFlags & BGFX_STATE_INTERNAL_OCCLUSION_QUERY);
@@ -8335,13 +8330,15 @@ VK_DESTROY
 						;
 
 					if (occluded
+					||  !isFrameBufferValid
+					||  0 == draw.m_streamMask
 					||  _render->m_frameCache.isZeroArea(viewScissorRect, draw.m_scissor) )
 					{
 						continue;
 					}
 				}
 
-				uint64_t changedFlags = currentState.m_stateFlags ^ draw.m_stateFlags;
+				const uint64_t changedFlags = currentState.m_stateFlags ^ draw.m_stateFlags;
 				currentState.m_stateFlags = draw.m_stateFlags;
 
 				if (!beginRenderPass)

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -7745,6 +7745,11 @@ VK_DESTROY
 			return;
 		}
 
+		if (_render->m_capture)
+		{
+			renderDocTriggerCapture();
+		}
+
 		BGFX_VK_PROFILER_BEGIN_LITERAL("rendererSubmit", kColorView);
 
 		int64_t timeBegin = bx::getHPCounter();

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -1162,6 +1162,9 @@ VK_IMPORT
 					s_extension[Extension::EXT_debug_report].m_initialize = true;
 				}
 
+				s_extension[Extension::EXT_shader_viewport_index_layer].m_initialize = !!(_init.capabilities & BGFX_CAPS_VIEWPORT_LAYER_ARRAY);
+				s_extension[Extension::EXT_conservative_rasterization ].m_initialize = !!(_init.capabilities & BGFX_CAPS_CONSERVATIVE_RASTER );
+
 				dumpExtensions(VK_NULL_HANDLE, s_extension);
 
 				if (s_layer[Layer::VK_LAYER_KHRONOS_validation].m_device.m_supported
@@ -1441,6 +1444,8 @@ VK_IMPORT_INSTANCE
 
 				BX_TRACE("Using physical device %d: %s", physicalDeviceIdx, m_deviceProperties.deviceName);
 
+				VkPhysicalDeviceFeatures supportedFeatures;
+
 				if (s_extension[Extension::KHR_get_physical_device_properties2].m_supported)
 				{
 					VkPhysicalDeviceFeatures2KHR deviceFeatures2;
@@ -1468,14 +1473,33 @@ VK_IMPORT_INSTANCE
 					nextFeatures = deviceFeatures2.pNext;
 
 					vkGetPhysicalDeviceFeatures2KHR(m_physicalDevice, &deviceFeatures2);
-					m_deviceFeatures = deviceFeatures2.features;
+					supportedFeatures = deviceFeatures2.features;
 				}
 				else
 				{
-					vkGetPhysicalDeviceFeatures(m_physicalDevice, &m_deviceFeatures);
+					vkGetPhysicalDeviceFeatures(m_physicalDevice, &supportedFeatures);
 				}
 
-				m_deviceFeatures.robustBufferAccess = VK_FALSE;
+				memset(&m_deviceFeatures, 0, sizeof(m_deviceFeatures) );
+
+				m_deviceFeatures.fullDrawIndexUint32       = supportedFeatures.fullDrawIndexUint32;
+				m_deviceFeatures.imageCubeArray            = supportedFeatures.imageCubeArray            && (_init.capabilities & BGFX_CAPS_TEXTURE_CUBE_ARRAY);
+				m_deviceFeatures.independentBlend          = supportedFeatures.independentBlend          && (_init.capabilities & BGFX_CAPS_BLEND_INDEPENDENT);
+				m_deviceFeatures.multiDrawIndirect         = supportedFeatures.multiDrawIndirect         && (_init.capabilities & BGFX_CAPS_DRAW_INDIRECT);
+				m_deviceFeatures.drawIndirectFirstInstance = supportedFeatures.drawIndirectFirstInstance && (_init.capabilities & BGFX_CAPS_DRAW_INDIRECT);
+				m_deviceFeatures.depthClamp        = supportedFeatures.depthClamp;
+				m_deviceFeatures.fillModeNonSolid  = supportedFeatures.fillModeNonSolid;
+				m_deviceFeatures.largePoints       = supportedFeatures.largePoints;
+				m_deviceFeatures.samplerAnisotropy = supportedFeatures.samplerAnisotropy;
+				m_deviceFeatures.textureCompressionETC2 = supportedFeatures.textureCompressionETC2;
+				m_deviceFeatures.textureCompressionBC   = supportedFeatures.textureCompressionBC;
+				m_deviceFeatures.vertexPipelineStoresAndAtomics = supportedFeatures.vertexPipelineStoresAndAtomics;
+				m_deviceFeatures.fragmentStoresAndAtomics  = supportedFeatures.fragmentStoresAndAtomics;
+				m_deviceFeatures.shaderImageGatherExtended = supportedFeatures.shaderImageGatherExtended;
+				m_deviceFeatures.shaderStorageImageExtendedFormats = supportedFeatures.shaderStorageImageExtendedFormats;
+				m_deviceFeatures.shaderClipDistance   = supportedFeatures.shaderClipDistance;
+				m_deviceFeatures.shaderCullDistance   = supportedFeatures.shaderCullDistance;
+				m_deviceFeatures.shaderResourceMinLod = supportedFeatures.shaderResourceMinLod;
 
 				m_lineAASupport = true
 					&& s_extension[Extension::EXT_line_rasterization].m_supported

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -1112,6 +1112,8 @@ VK_IMPORT_DEVICE
 				m_renderDocDll = loadRenderDoc();
 			}
 
+			setGraphicsDebuggerPresent(NULL != m_renderDocDll);
+
 			m_vulkan1Dll = bx::dlopen(
 #if BX_PLATFORM_WINDOWS
 				"vulkan-1.dll"

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -816,7 +816,7 @@ VK_IMPORT_DEVICE
 	}
 
 	template<typename Ty>
-	VkObjectType getType();
+	constexpr VkObjectType getType();
 
 	template<> VkObjectType getType<VkBuffer             >() { return VK_OBJECT_TYPE_BUFFER;                }
 	template<> VkObjectType getType<VkCommandPool        >() { return VK_OBJECT_TYPE_COMMAND_POOL;          }
@@ -1152,15 +1152,12 @@ VK_IMPORT
 			}
 
 			{
-				if (_init.debug)
-				{
-					s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_device.m_initialize   = true;
-					s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_instance.m_initialize = true;
-					s_layer[Layer::VK_LAYER_KHRONOS_validation        ].m_device.m_initialize   = true;
-					s_layer[Layer::VK_LAYER_KHRONOS_validation        ].m_instance.m_initialize = true;
+				s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_device.m_initialize   = _init.debug;
+				s_layer[Layer::VK_LAYER_LUNARG_standard_validation].m_instance.m_initialize = _init.debug;
+				s_layer[Layer::VK_LAYER_KHRONOS_validation        ].m_device.m_initialize   = _init.debug;
+				s_layer[Layer::VK_LAYER_KHRONOS_validation        ].m_instance.m_initialize = _init.debug;
 
-					s_extension[Extension::EXT_debug_report].m_initialize = true;
-				}
+				s_extension[Extension::EXT_debug_report].m_initialize = _init.debug;
 
 				s_extension[Extension::EXT_shader_viewport_index_layer].m_initialize = !!(_init.capabilities & BGFX_CAPS_VIEWPORT_LAYER_ARRAY);
 				s_extension[Extension::EXT_conservative_rasterization ].m_initialize = !!(_init.capabilities & BGFX_CAPS_CONSERVATIVE_RASTER );

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -180,6 +180,8 @@
 			VK_IMPORT_DEVICE_FUNC(false, vkCmdBlitImage);                  \
 			VK_IMPORT_DEVICE_FUNC(false, vkCmdResetQueryPool);             \
 			VK_IMPORT_DEVICE_FUNC(false, vkCmdWriteTimestamp);             \
+			VK_IMPORT_DEVICE_FUNC(false, vkCmdBeginQuery);                 \
+			VK_IMPORT_DEVICE_FUNC(false, vkCmdEndQuery);                   \
 			VK_IMPORT_DEVICE_FUNC(false, vkCmdCopyQueryPoolResults);       \
 			VK_IMPORT_DEVICE_FUNC(false, vkMapMemory);                     \
 			VK_IMPORT_DEVICE_FUNC(false, vkUnmapMemory);                   \
@@ -555,6 +557,30 @@ VK_DESTROY_FUNC(DescriptorSet);
 		VkDeviceMemory m_readbackMemory;
 		VkQueryPool m_queryPool;
 		const uint64_t* m_queryResult;
+		bx::RingBufferControl m_control;
+	};
+
+	struct OcclusionQueryVK
+	{
+		OcclusionQueryVK()
+			: m_control(BX_COUNTOF(m_handle) )
+		{
+		}
+
+		VkResult init();
+		void shutdown();
+		void begin(OcclusionQueryHandle _handle);
+		void end();
+		void flush(Frame* _render);
+		void resolve(Frame* _render);
+		void invalidate(OcclusionQueryHandle _handle);
+
+		OcclusionQueryHandle m_handle[BGFX_CONFIG_MAX_OCCLUSION_QUERIES];
+
+		VkBuffer m_readback;
+		VkDeviceMemory m_readbackMemory;
+		VkQueryPool m_queryPool;
+		const uint32_t* m_queryResult;
 		bx::RingBufferControl m_control;
 	};
 

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -755,6 +755,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 		SwapChainVK m_swapChain;
 		void* m_nwh;
 		bool m_needPresent;
+		bool m_needResolve;
 
 		VkImageView m_textureImageViews[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 		VkFramebuffer m_framebuffer;

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -94,7 +94,6 @@
 			/* VK_EXT_debug_report */                                                  \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateDebugReportCallbackEXT);            \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkDestroyDebugReportCallbackEXT);           \
-			VK_IMPORT_INSTANCE_FUNC(true,  vkDebugReportMessageEXT);                   \
 			VK_IMPORT_INSTANCE_PLATFORM
 
 #define VK_IMPORT_DEVICE                                                   \
@@ -196,24 +195,11 @@
 			VK_IMPORT_DEVICE_FUNC(true,  vkGetSwapchainImagesKHR);         \
 			VK_IMPORT_DEVICE_FUNC(true,  vkAcquireNextImageKHR);           \
 			VK_IMPORT_DEVICE_FUNC(true,  vkQueuePresentKHR);               \
-			/* VK_EXT_debug_marker */                                      \
-			VK_IMPORT_DEVICE_FUNC(true,  vkDebugMarkerSetObjectTagEXT);    \
-			VK_IMPORT_DEVICE_FUNC(true,  vkDebugMarkerSetObjectNameEXT);   \
-			VK_IMPORT_DEVICE_FUNC(true,  vkCmdDebugMarkerBeginEXT);        \
-			VK_IMPORT_DEVICE_FUNC(true,  vkCmdDebugMarkerEndEXT);          \
-			VK_IMPORT_DEVICE_FUNC(true,  vkCmdDebugMarkerInsertEXT);       \
 			/* VK_EXT_debug_utils */                                       \
 			VK_IMPORT_DEVICE_FUNC(true,  vkSetDebugUtilsObjectNameEXT);    \
-			VK_IMPORT_DEVICE_FUNC(true,  vkSetDebugUtilsObjectTagEXT);     \
-			VK_IMPORT_DEVICE_FUNC(true,  vkQueueBeginDebugUtilsLabelEXT);  \
-			VK_IMPORT_DEVICE_FUNC(true,  vkQueueEndDebugUtilsLabelEXT);    \
-			VK_IMPORT_DEVICE_FUNC(true,  vkQueueInsertDebugUtilsLabelEXT); \
 			VK_IMPORT_DEVICE_FUNC(true,  vkCmdBeginDebugUtilsLabelEXT);    \
 			VK_IMPORT_DEVICE_FUNC(true,  vkCmdEndDebugUtilsLabelEXT);      \
 			VK_IMPORT_DEVICE_FUNC(true,  vkCmdInsertDebugUtilsLabelEXT);   \
-			VK_IMPORT_DEVICE_FUNC(true,  vkCreateDebugUtilsMessengerEXT);  \
-			VK_IMPORT_DEVICE_FUNC(true,  vkDestroyDebugUtilsMessengerEXT); \
-			VK_IMPORT_DEVICE_FUNC(true,  vkSubmitDebugUtilsMessageEXT);    \
 
 #define VK_DESTROY                                \
 			VK_DESTROY_FUNC(Buffer);              \

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -632,7 +632,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 		void copyBufferToTexture(VkCommandBuffer _commandBuffer, VkBuffer _stagingBuffer, uint32_t _bufferImageCopyCount, VkBufferImageCopy* _bufferImageCopy);
 		VkImageLayout setImageMemoryBarrier(VkCommandBuffer _commandBuffer, VkImageLayout _newImageLayout, bool _singleMsaaImage = false);
 
-		VkResult createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, VkImageViewType _type, bool _renderTarget, ::VkImageView* _view) const;
+		VkResult createView(uint32_t _layer, uint32_t _numLayers, uint32_t _mip, uint32_t _numMips, VkImageViewType _type, VkImageAspectFlags _aspectMask, bool _renderTarget, ::VkImageView* _view) const;
 
 		void*    m_directAccessPtr;
 		uint64_t m_flags;

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -634,6 +634,8 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		VkDeviceMemory m_singleMsaaDeviceMem;
 		VkImageLayout  m_currentSingleMsaaImageLayout;
 
+		VkImageLayout m_sampledLayout;
+
 		ReadbackVK m_readback;
 
 	private:

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -11,7 +11,6 @@
 #	define KHR_SURFACE_EXTENSION_NAME VK_KHR_ANDROID_SURFACE_EXTENSION_NAME
 #	define VK_IMPORT_INSTANCE_PLATFORM VK_IMPORT_INSTANCE_ANDROID
 #elif BX_PLATFORM_LINUX
-//#	define VK_USE_PLATFORM_MIR_KHR
 #	define VK_USE_PLATFORM_XLIB_KHR
 #	define VK_USE_PLATFORM_XCB_KHR
 //#	define VK_USE_PLATFORM_WAYLAND_KHR
@@ -42,28 +41,33 @@
 			VK_IMPORT_FUNC(false, vkGetDeviceProcAddr);                    \
 			VK_IMPORT_FUNC(false, vkEnumerateInstanceExtensionProperties); \
 			VK_IMPORT_FUNC(false, vkEnumerateInstanceLayerProperties);     \
+			/* 1.1 */                                                      \
 			VK_IMPORT_FUNC(true,  vkEnumerateInstanceVersion);             \
 
-#define VK_IMPORT_INSTANCE_ANDROID \
-			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateAndroidSurfaceKHR);
+#define VK_IMPORT_INSTANCE_ANDROID                                     \
+			/* VK_KHR_android_surface */                               \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateAndroidSurfaceKHR); \
 
 #define VK_IMPORT_INSTANCE_LINUX                                                           \
+			/* VK_KHR_xlib_surface */                                                      \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateXlibSurfaceKHR);                        \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceXlibPresentationSupportKHR); \
+			/* VK_KHR_xcb_surface */                                                       \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateXcbSurfaceKHR);                         \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceXcbPresentationSupportKHR);  \
 
+//			/* VK_KHR_wayland_surface */
 //			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateWaylandSurfaceKHR);
 //			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceWaylandPresentationSupportKHR);
-//			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateMirSurfaceKHR);
-//			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceMirPresentationSupportKHR);
 
-#define VK_IMPORT_INSTANCE_WINDOWS \
-			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateWin32SurfaceKHR); \
-			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceWin32PresentationSupportKHR);
+#define VK_IMPORT_INSTANCE_WINDOWS                                                          \
+			/* VK_KHR_win32_surface */                                                      \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateWin32SurfaceKHR);                        \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceWin32PresentationSupportKHR); \
 
-#define VK_IMPORT_INSTANCE_MACOS \
-			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateMacOSSurfaceMVK);
+#define VK_IMPORT_INSTANCE_MACOS                                     \
+			/* VK_MVK_macos_surface */                               \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateMacOSSurfaceMVK); \
 
 #define VK_IMPORT_INSTANCE                                                             \
 			VK_IMPORT_INSTANCE_FUNC(false, vkDestroyInstance);                         \
@@ -73,18 +77,20 @@
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceProperties);             \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFormatProperties);       \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceFeatures);               \
-			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceFeatures2KHR);           \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceImageFormatProperties);  \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceMemoryProperties);       \
-			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceMemoryProperties2KHR);   \
 			VK_IMPORT_INSTANCE_FUNC(false, vkGetPhysicalDeviceQueueFamilyProperties);  \
+			VK_IMPORT_INSTANCE_FUNC(false, vkCreateDevice);                            \
+			VK_IMPORT_INSTANCE_FUNC(false, vkDestroyDevice);                           \
+			/* VK_KHR_surface */                                                       \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceSurfaceCapabilitiesKHR); \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceSurfaceFormatsKHR);      \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceSurfacePresentModesKHR); \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceSurfaceSupportKHR);      \
-			VK_IMPORT_INSTANCE_FUNC(false, vkCreateDevice);                            \
-			VK_IMPORT_INSTANCE_FUNC(false, vkDestroyDevice);                           \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkDestroySurfaceKHR);                       \
+			/* VK_KHR_get_physical_device_properties2 */                               \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceFeatures2KHR);           \
+			VK_IMPORT_INSTANCE_FUNC(true,  vkGetPhysicalDeviceMemoryProperties2KHR);   \
 			/* VK_EXT_debug_report */                                                  \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateDebugReportCallbackEXT);            \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkDestroyDebugReportCallbackEXT);           \
@@ -93,11 +99,6 @@
 
 #define VK_IMPORT_DEVICE                                                   \
 			VK_IMPORT_DEVICE_FUNC(false, vkGetDeviceQueue);                \
-			VK_IMPORT_DEVICE_FUNC(true,  vkCreateSwapchainKHR);            \
-			VK_IMPORT_DEVICE_FUNC(true,  vkDestroySwapchainKHR);           \
-			VK_IMPORT_DEVICE_FUNC(true,  vkGetSwapchainImagesKHR);         \
-			VK_IMPORT_DEVICE_FUNC(true,  vkAcquireNextImageKHR);           \
-			VK_IMPORT_DEVICE_FUNC(true,  vkQueuePresentKHR);               \
 			VK_IMPORT_DEVICE_FUNC(false, vkCreateFence);                   \
 			VK_IMPORT_DEVICE_FUNC(false, vkDestroyFence);                  \
 			VK_IMPORT_DEVICE_FUNC(false, vkCreateSemaphore);               \
@@ -189,6 +190,12 @@
 			VK_IMPORT_DEVICE_FUNC(false, vkInvalidateMappedMemoryRanges);  \
 			VK_IMPORT_DEVICE_FUNC(false, vkBindBufferMemory);              \
 			VK_IMPORT_DEVICE_FUNC(false, vkBindImageMemory);               \
+			/* VK_KHR_swapchain */                                         \
+			VK_IMPORT_DEVICE_FUNC(true,  vkCreateSwapchainKHR);            \
+			VK_IMPORT_DEVICE_FUNC(true,  vkDestroySwapchainKHR);           \
+			VK_IMPORT_DEVICE_FUNC(true,  vkGetSwapchainImagesKHR);         \
+			VK_IMPORT_DEVICE_FUNC(true,  vkAcquireNextImageKHR);           \
+			VK_IMPORT_DEVICE_FUNC(true,  vkQueuePresentKHR);               \
 			/* VK_EXT_debug_marker */                                      \
 			VK_IMPORT_DEVICE_FUNC(true,  vkDebugMarkerSetObjectTagEXT);    \
 			VK_IMPORT_DEVICE_FUNC(true,  vkDebugMarkerSetObjectNameEXT);   \

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -299,6 +299,7 @@ namespace bgfx { namespace vk
 VK_DESTROY
 VK_DESTROY_FUNC(DeviceMemory);
 VK_DESTROY_FUNC(SurfaceKHR);
+VK_DESTROY_FUNC(DescriptorSet);
 #undef VK_DESTROY_FUNC
 
 	template<typename Ty>
@@ -363,25 +364,17 @@ VK_DESTROY_FUNC(SurfaceKHR);
 		{
 		}
 
-		void create(uint32_t _size, uint32_t _count, uint32_t _maxDescriptors);
+		void create(uint32_t _size, uint32_t _count);
 		void destroy();
 		void reset();
 		uint32_t write(const void* _data, uint32_t _size);
 		void flush();
 
-		VkDescriptorSet& getCurrentDS()
-		{
-			return m_descriptorSet[m_currentDs - 1];
-		}
-
-		VkDescriptorSet* m_descriptorSet;
 		VkBuffer m_buffer;
 		VkDeviceMemory m_deviceMem;
 		uint8_t* m_data;
 		uint32_t m_size;
 		uint32_t m_pos;
-		uint32_t m_currentDs;
-		uint32_t m_maxDescriptors;
 	};
 
 	struct BufferVK

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -296,19 +296,6 @@ VK_DESTROY_FUNC(DeviceMemory);
 VK_DESTROY_FUNC(SurfaceKHR);
 #undef VK_DESTROY_FUNC
 
-	struct DslBinding
-	{
-		enum Enum
-		{
-//			CombinedImageSampler,
-			VertexUniformBuffer,
-			FragmentUniformBuffer,
-//			StorageBuffer,
-
-			Count
-		};
-	};
-
 	template<typename Ty>
 	class StateCacheT
 	{

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -695,7 +695,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 		bool acquire(VkCommandBuffer _commandBuffer);
 		void present();
 
-		void transitionImage(VkCommandBuffer _commandBuffer, VkImageLayout _newLayout);
+		void transitionImage(VkCommandBuffer _commandBuffer);
 
 		VkQueue m_queue;
 		VkSwapchainCreateInfoKHR m_sci;


### PR DESCRIPTION
Wanted to tie up a few loose ends that have been on my todo list for a bit 🍌 

- support for `BGFX_CAPS_OCCLUSION_QUERY`
- support for `BGFX_SAMPLER_SAMPLE_STENCIL`
- support for `BGFX_SAMPLER_BORDER_COLOR`
    - this depends on [VK_EXT_custom_border_color](https://vulkan.gpuinfo.org/listdevicescoverage.php?extension=VK_EXT_custom_border_color) which seems to be supported on most recent desktop GPUs, but not much luck on mobile
- support for timer queries (`Stats::gpuTimeBegin/End` + `Stats::viewStats[i]::gpuTimeBegin/End`)
- use correct cached memory type for readbacks. This makes a drastic performance difference for backbuffer capture on my GPU
- less state binding between draw calls, where possible
- clear and blit are now performed before compute, as in the other renderers
- validation layers are now enabled with `Init::debug`, not always through debug build config. This won't change the default behaviour, but you can explicitly turn them off now
- use `Init::capabilities` to decide which features and extensions to enable
- reduce spam about unsupported swapchain formats (https://github.com/bkaradzic/bgfx/pull/2491)
- miscellaneous other minor fixes, see commit log