### PR TITLE
Split embedded shaders into essl and glsl

### DIFF
--- a/include/bgfx/embedded_shader.h
+++ b/include/bgfx/embedded_shader.h
@@ -80,7 +80,7 @@
 #if BGFX_PLATFORM_SUPPORTS_ESSL
 #	undef  BGFX_EMBEDDED_SHADER_ESSL
 #	define BGFX_EMBEDDED_SHADER_ESSL(_renderer, _name) \
-		{ _renderer, BX_CONCATENATE(_name, _glsl), BX_COUNTOF(BX_CONCATENATE(_name, _glsl) ) },
+		{ _renderer, BX_CONCATENATE(_name, _essl), BX_COUNTOF(BX_CONCATENATE(_name, _essl) ) },
 #endif // BGFX_PLATFORM_SUPPORTS_ESSL
 
 #if BGFX_PLATFORM_SUPPORTS_GLSL

--- a/scripts/shader-embeded.mk
+++ b/scripts/shader-embeded.mk
@@ -24,8 +24,10 @@ SHADER_TMP = $(TEMP)/tmp
 
 vs_%.bin.h : vs_%.sc
 	@echo [$(<)]
-	 $(SILENT) $(SHADERC) $(VS_FLAGS) --platform linux                  -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
+	 $(SILENT) $(SHADERC) $(VS_FLAGS) --platform linux   -p 120         -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
 	@cat $(SHADER_TMP) > $(@)
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform android                -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_essl
+	-@cat $(SHADER_TMP) >> $(@)	
 	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform linux   -p spirv       -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_spv
 	-@cat $(SHADER_TMP) >> $(@)
 	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p vs_3_0 -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx9
@@ -39,8 +41,10 @@ vs_%.bin.h : vs_%.sc
 
 fs_%.bin.h : fs_%.sc
 	@echo [$(<)]
-	 $(SILENT) $(SHADERC) $(FS_FLAGS) --platform linux                  -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
+	 $(SILENT) $(SHADERC) $(FS_FLAGS) --platform linux   -p 120         -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
 	@cat $(SHADER_TMP) > $(@)
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform android                -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_essl
+	-@cat $(SHADER_TMP) >> $(@)	
 	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform linux   -p spirv       -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_spv
 	-@cat $(SHADER_TMP) >> $(@)
 	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p ps_3_0 -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx9
@@ -56,6 +60,8 @@ cs_%.bin.h : cs_%.sc
 	@echo [$(<)]
 	 $(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux -p 430           -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
 	@cat $(SHADER_TMP) > $(@)
+	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform android                -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_essl
+	-@cat $(SHADER_TMP) >> $(@)	
 #	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux   -p spirv       -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_spv
 #	-@cat $(SHADER_TMP) >> $(@)
 	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform windows -p cs_5_0 -O 1 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx11

--- a/src/makefile
+++ b/src/makefile
@@ -25,8 +25,10 @@ all: $(BIN)
 
 define shader-embedded
 	@echo [$(<)]
-	 $(SILENT) $(SHADERC) --type $(1) --platform linux                 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
+	 $(SILENT) $(SHADERC) --type $(1) --platform linux   -p 120        -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
 	 @cat $(SHADER_TMP) > $(@)
+	-$(SILENT) $(SHADERC) --type $(1) --platform android               -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_essl
+	-@cat $(SHADER_TMP) >> $(@)	 
 	-$(SILENT) $(SHADERC) --type $(1) --platform linux   -p spirv      -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_spv
 	-@cat $(SHADER_TMP) >> $(@)
 	-$(SILENT) $(SHADERC) --type $(1) --platform windows -p $(2)  -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx9


### PR DESCRIPTION
In non-embedded shaders there is a separation between essl binaries
(examples/runtime/shaders/essl) and glsl binaries
(examples/runtime/shaders/glsl). On embedded shaders there is no
such separation and by default essl shaders are being used by
the OpenGL runtime. This usually doesn't cause any issues but
in the case of the debugdraw shaders, that started using uvec4,
this now leads to a runtime error.
This patch fixes this by splitting the embedded shaders into essl
and glsl.