### PR TITLE
Fixes texturev embedded shaders compilation

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -2313,49 +2313,6 @@ namespace bgfx
 										bx::stringPrintf(code, "precision highp float;\n");
 										bx::stringPrintf(code, "precision highp int;\n");
 									}
-									else
-									{
-										code +=
-											"mat2 transpose(mat2 _mtx)\n"
-											"{\n"
-											"	vec2 v0 = _mtx[0];\n"
-											"	vec2 v1 = _mtx[1];\n"
-											"\n"
-											"	return mat2(\n"
-											"		  vec2(v0.x, v1.x)\n"
-											"		, vec2(v0.y, v1.y)\n"
-											"		);\n"
-											"}\n"
-											"\n"
-											"mat3 transpose(mat3 _mtx)\n"
-											"{\n"
-											"	vec3 v0 = _mtx[0];\n"
-											"	vec3 v1 = _mtx[1];\n"
-											"	vec3 v2 = _mtx[2];\n"
-											"\n"
-											"	return mat3(\n"
-											"		  vec3(v0.x, v1.x, v2.x)\n"
-											"		, vec3(v0.y, v1.y, v2.y)\n"
-											"		, vec3(v0.z, v1.z, v2.z)\n"
-											"		);\n"
-											"}\n"
-											"\n"
-											"mat4 transpose(mat4 _mtx)\n"
-											"{\n"
-											"	vec4 v0 = _mtx[0];\n"
-											"	vec4 v1 = _mtx[1];\n"
-											"	vec4 v2 = _mtx[2];\n"
-											"	vec4 v3 = _mtx[3];\n"
-											"\n"
-											"	return mat4(\n"
-											"		  vec4(v0.x, v1.x, v2.x, v3.x)\n"
-											"		, vec4(v0.y, v1.y, v2.y, v3.y)\n"
-											"		, vec4(v0.z, v1.z, v2.z, v3.z)\n"
-											"		, vec4(v0.w, v1.w, v2.w, v3.w)\n"
-											"		);\n"
-											"}\n"
-											;
-									}
 
 									// Pretend that all extensions are available.
 									// This will be stripped later.
@@ -2418,6 +2375,50 @@ namespace bgfx
 										bx::stringPrintf(code
 											, "#extension GL_EXT_texture_array : enable\n"
 											);
+									}
+
+									if (glsl_profile == 100)
+									{
+										code +=
+											"mat2 transpose(mat2 _mtx)\n"
+											"{\n"
+											"	vec2 v0 = _mtx[0];\n"
+											"	vec2 v1 = _mtx[1];\n"
+											"\n"
+											"	return mat2(\n"
+											"		  vec2(v0.x, v1.x)\n"
+											"		, vec2(v0.y, v1.y)\n"
+											"		);\n"
+											"}\n"
+											"\n"
+											"mat3 transpose(mat3 _mtx)\n"
+											"{\n"
+											"	vec3 v0 = _mtx[0];\n"
+											"	vec3 v1 = _mtx[1];\n"
+											"	vec3 v2 = _mtx[2];\n"
+											"\n"
+											"	return mat3(\n"
+											"		  vec3(v0.x, v1.x, v2.x)\n"
+											"		, vec3(v0.y, v1.y, v2.y)\n"
+											"		, vec3(v0.z, v1.z, v2.z)\n"
+											"		);\n"
+											"}\n"
+											"\n"
+											"mat4 transpose(mat4 _mtx)\n"
+											"{\n"
+											"	vec4 v0 = _mtx[0];\n"
+											"	vec4 v1 = _mtx[1];\n"
+											"	vec4 v2 = _mtx[2];\n"
+											"	vec4 v3 = _mtx[3];\n"
+											"\n"
+											"	return mat4(\n"
+											"		  vec4(v0.x, v1.x, v2.x, v3.x)\n"
+											"		, vec4(v0.y, v1.y, v2.y, v3.y)\n"
+											"		, vec4(v0.z, v1.z, v2.z, v3.z)\n"
+											"		, vec4(v0.w, v1.w, v2.w, v3.w)\n"
+											"		);\n"
+											"}\n"
+											;											
 									}
 								}
 							}


### PR DESCRIPTION
Compiling 'fs_texture_array.sc' with shaderc for OpenGLES fails with a syntax error,
because the matrix transpose function definitions occur before extension directives,
in this case EXT_texture_array.

Here is the error that shows up when trying to rebuild the texturev embedded shaders:

```
\bgfx\tools\texturev>make rebuild
Cleaning...
removed `vs_texture.bin.h'
removed `vs_texture_cube.bin.h'
removed `fs_texture.bin.h'
removed `fs_texture_3d.bin.h'
removed `fs_texture_array.bin.h'
removed `fs_texture_cube.bin.h'
removed `fs_texture_cube2.bin.h'
removed `fs_texture_msdf.bin.h'
removed `fs_texture_sdf.bin.h'
[vs_texture.sc]
[vs_texture_cube.sc]
[fs_texture.sc]
[fs_texture_3d.sc]
[fs_texture_array.sc]
Code:
---
     90: }
     91: vec3 toGamma(vec3 _rgb)
     92: {
     93: return pow(abs(_rgb), vec3_splat(1.0/2.2) );
     94: }
     95: vec4 toEv(vec4 _color)
     96: {
     97: vec3 rgb = mix(toLinear(_color.xyz), _color.xyz, u_params.z);
     98: return vec4(toGamma(rgb * pow(2.0, u_params.w) ), _color.w);
     99: }

>>> 100: uniform sampler2DArray s_texColor;
>>>  24:                        ^

    101: void main()
    102: {
    103: vec4 color = texture2DArrayLod(s_texColor, vec3(v_texcoord0.xy, u_params.y), u_params.x);
    104: gl_FragColor = toEv(color * v_color0);
    105: }
---
Error: (100,24): error: syntax error, unexpected NEW_IDENTIFIER, expecting '{'

Failed to build shader.
make: *** [fs_texture_array.bin.h] Error 1

```