### PR TITLE
Fix hardcoded bgfx dir from include paths in makefiles

### DIFF
--- a/examples/common/debugdraw/makefile
+++ b/examples/common/debugdraw/makefile
@@ -3,7 +3,7 @@
 # License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
 #
 
-include ../../../../bgfx/scripts/shader-embeded.mk
+include ../../../scripts/shader-embeded.mk
 
 rebuild:
 	@make -s --no-print-directory clean all

--- a/examples/common/ps/makefile
+++ b/examples/common/ps/makefile
@@ -3,7 +3,7 @@
 # License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
 #
 
-include ../../../../bgfx/scripts/shader-embeded.mk
+include ../../../scripts/shader-embeded.mk
 
 rebuild:
 	@make -s --no-print-directory clean all

--- a/tools/geometryv/makefile
+++ b/tools/geometryv/makefile
@@ -3,4 +3,4 @@
 # License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
 #
 
-include ../../../bgfx/scripts/shader-embeded.mk
+include ../../scripts/shader-embeded.mk

--- a/tools/texturev/makefile
+++ b/tools/texturev/makefile
@@ -3,4 +3,4 @@
 # License: https://github.com/bkaradzic/bgfx#license-bsd-2-clause
 #
 
-include ../../../bgfx/scripts/shader-embeded.mk
+include ../../scripts/shader-embeded.mk


### PR DESCRIPTION
Only these four makefiles had these hardcoded paths.
All other makefiles don't specify the bgfx dir name.