### PR TITLE
Make the generated embedded shader headers the same between linux and gnuwin32

### DIFF
--- a/scripts/shader-embeded.mk
+++ b/scripts/shader-embeded.mk
@@ -36,8 +36,8 @@ vs_%.bin.h : vs_%.sc
 	-@cat $(SHADER_TMP) >> $(@)
 	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform ios     -p metal  -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_mtl
 	-@cat $(SHADER_TMP) >> $(@)
-	-@echo extern const uint8_t* $(basename $(<))_pssl;>> $(@)
-	-@echo extern const uint32_t $(basename $(<))_pssl_size;>> $(@)
+	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
+	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 
 fs_%.bin.h : fs_%.sc
 	@echo [$(<)]
@@ -53,8 +53,8 @@ fs_%.bin.h : fs_%.sc
 	-@cat $(SHADER_TMP) >> $(@)
 	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform ios     -p metal  -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_mtl
 	-@cat $(SHADER_TMP) >> $(@)
-	-@echo extern const uint8_t* $(basename $(<))_pssl;>> $(@)
-	-@echo extern const uint32_t $(basename $(<))_pssl_size;>> $(@)
+	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
+	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 
 cs_%.bin.h : cs_%.sc
 	@echo [$(<)]
@@ -66,8 +66,8 @@ cs_%.bin.h : cs_%.sc
 #	-@cat $(SHADER_TMP) >> $(@)
 	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform windows -p cs_5_0 -O 1 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx11
 	-@cat $(SHADER_TMP) >> $(@)
-	-@echo extern const uint8_t* $(basename $(<))_pssl;>> $(@)
-	-@echo extern const uint32_t $(basename $(<))_pssl_size;>> $(@)
+	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
+	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 
 .PHONY: all
 all: $(BIN)

--- a/src/makefile
+++ b/src/makefile
@@ -37,8 +37,8 @@ define shader-embedded
 	-@cat $(SHADER_TMP) >> $(@)
 	-$(SILENT) $(SHADERC) --type $(1) --platform ios     -p metal -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_mtl
 	-@cat $(SHADER_TMP) >> $(@)
-	-@echo extern const uint8_t* $(basename $(<))_pssl;>> $(@)
-	-@echo extern const uint32_t $(basename $(<))_pssl_size;>> $(@)
+	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
+	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 endef
 
 vs_debugfont.bin.h : vs_debugfont.sc


### PR DESCRIPTION
This echo command on the makefile behaves differently between linux and gnuwin32:
```
-@echo extern const uint8_t* $(basename $(<))_pssl;>> $(@)
```

On linux the semicolon immediately ends the echo command and its output is never piped to the embedded shader's header.
If you try to fix it by quoting the string:
```
-@echo "extern const uint8_t* $(basename $(<))_pssl;" >> $(@)
```

It will work on linux but not on gnuwin32 because the quotes will appear on the outputted string.
The solution was to use printf which works consistently between the two.

Also on gnuwin32 the outputted string has 'CRLF' line endings, which clashes with the rest of the 'LF' line endings of the
embedded shaders header which were produced by shaderc.
The solution was to remove the 'CR' from the outputted string by using the tr command.