### PR TITLE
Allow shaders to be compiled on msys2

### DIFF
--- a/scripts/shader-embeded.mk
+++ b/scripts/shader-embeded.mk
@@ -24,48 +24,48 @@ SHADER_TMP = $(TEMP)/tmp
 
 vs_%.bin.h : vs_%.sc
 	@echo [$(<)]
-	 $(SILENT) $(SHADERC) $(VS_FLAGS) --platform linux   -p 120         -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
-	@cat $(SHADER_TMP) > $(@)
-	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform android                -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_essl
-	-@cat $(SHADER_TMP) >> $(@)	
-	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform linux   -p spirv       -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_spv
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p vs_3_0 -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx9
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p vs_4_0 -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx11
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform ios     -p metal  -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_mtl
-	-@cat $(SHADER_TMP) >> $(@)
+	 $(SILENT) $(SHADERC) $(VS_FLAGS) --platform linux   -p 120         -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_glsl
+	@cat "$(SHADER_TMP)" > $(@)
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform android                -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_essl
+	-@cat "$(SHADER_TMP)" >> $(@)	
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform linux   -p spirv       -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_spv
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p vs_3_0 -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx9
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p vs_4_0 -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform ios     -p metal  -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_mtl
+	-@cat "$(SHADER_TMP)" >> $(@)
 	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
 	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 
 fs_%.bin.h : fs_%.sc
 	@echo [$(<)]
-	 $(SILENT) $(SHADERC) $(FS_FLAGS) --platform linux   -p 120         -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
-	@cat $(SHADER_TMP) > $(@)
-	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform android                -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_essl
-	-@cat $(SHADER_TMP) >> $(@)	
-	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform linux   -p spirv       -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_spv
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p ps_3_0 -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx9
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p ps_4_0 -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx11
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform ios     -p metal  -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_mtl
-	-@cat $(SHADER_TMP) >> $(@)
+	 $(SILENT) $(SHADERC) $(FS_FLAGS) --platform linux   -p 120         -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_glsl
+	@cat "$(SHADER_TMP)" > $(@)
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform android                -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_essl
+	-@cat "$(SHADER_TMP)" >> $(@)	
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform linux   -p spirv       -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_spv
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p ps_3_0 -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx9
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p ps_4_0 -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform ios     -p metal  -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_mtl
+	-@cat "$(SHADER_TMP)" >> $(@)
 	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
 	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 
 cs_%.bin.h : cs_%.sc
 	@echo [$(<)]
-	 $(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux -p 430           -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
-	@cat $(SHADER_TMP) > $(@)
-	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform android                -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_essl
-	-@cat $(SHADER_TMP) >> $(@)	
-#	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux   -p spirv       -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_spv
-#	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform windows -p cs_5_0 -O 1 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx11
-	-@cat $(SHADER_TMP) >> $(@)
+	 $(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux -p 430           -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_glsl
+	@cat "$(SHADER_TMP)" > $(@)
+	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform android                -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_essl
+	-@cat "$(SHADER_TMP)" >> $(@)	
+#	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux   -p spirv       -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_spv
+#	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform windows -p cs_5_0 -O 1 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
+	-@cat "$(SHADER_TMP)" >> $(@)
 	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
 	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 

--- a/scripts/tools.mk
+++ b/scripts/tools.mk
@@ -8,11 +8,13 @@ SILENT?=@
 THISDIR:=$(dir $(lastword $(MAKEFILE_LIST)))
 
 UNAME:=$(shell uname)
-ifeq ($(UNAME),$(filter $(UNAME),Linux Darwin))
+ifeq ($(UNAME),$(filter Linux Darwin MINGW%,$(UNAME)))
 CMD_MKDIR=mkdir -p "$(1)"
 CMD_RMDIR=rm -r "$(1)"
-ifeq ($(UNAME),$(filter $(UNAME),Darwin))
+ifeq ($(UNAME),$(filter Darwin,$(UNAME)))
 OS=darwin
+else ifeq ($(UNAME),$(filter MINGW%,$(UNAME)))
+OS=windows
 else
 OS=linux
 endif

--- a/src/makefile
+++ b/src/makefile
@@ -25,18 +25,18 @@ all: $(BIN)
 
 define shader-embedded
 	@echo [$(<)]
-	 $(SILENT) $(SHADERC) --type $(1) --platform linux   -p 120        -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_glsl
-	 @cat $(SHADER_TMP) > $(@)
-	-$(SILENT) $(SHADERC) --type $(1) --platform android               -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_essl
-	-@cat $(SHADER_TMP) >> $(@)	 
-	-$(SILENT) $(SHADERC) --type $(1) --platform linux   -p spirv      -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_spv
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) --type $(1) --platform windows -p $(2)  -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx9
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) --type $(1) --platform windows -p $(3)  -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_dx11
-	-@cat $(SHADER_TMP) >> $(@)
-	-$(SILENT) $(SHADERC) --type $(1) --platform ios     -p metal -O 3 -f $(<) -o $(SHADER_TMP) --bin2c $(basename $(<))_mtl
-	-@cat $(SHADER_TMP) >> $(@)
+	 $(SILENT) $(SHADERC) --type $(1) --platform linux   -p 120        -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_glsl
+	 @cat "$(SHADER_TMP)" > $(@)
+	-$(SILENT) $(SHADERC) --type $(1) --platform android               -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_essl
+	-@cat "$(SHADER_TMP)" >> $(@)	 
+	-$(SILENT) $(SHADERC) --type $(1) --platform linux   -p spirv      -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_spv
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) --type $(1) --platform windows -p $(2)  -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx9
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) --type $(1) --platform windows -p $(3)  -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
+	-@cat "$(SHADER_TMP)" >> $(@)
+	-$(SILENT) $(SHADERC) --type $(1) --platform ios     -p metal -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_mtl
+	-@cat "$(SHADER_TMP)" >> $(@)
 	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
 	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 endef


### PR DESCRIPTION
Adds support on tools.mk for the msys2 environment. The OS is still
considered windows but the command line tools for mkdir and rmdir
behave as if on linux.

The variable SHADER_TMP on the makefiles also had to be quoted to make
it work on msys2.