### PR TITLE
Vulkan: Fix FrameBuffer destroying: reset Image Memory Barriers to sampling layout.

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2327,6 +2327,11 @@ VK_IMPORT_DEVICE
 		{
 			FrameBufferVK& frameBuffer = m_frameBuffers[_handle.idx];
 
+			if (m_fbh.idx == _handle.idx)
+			{
+				m_fbh.idx = kInvalidHandle;
+			}
+
 			uint16_t denseIdx = frameBuffer.destroy();
 			if (UINT16_MAX != denseIdx)
 			{
@@ -7551,6 +7556,16 @@ VK_DESTROY
 
 	uint16_t FrameBufferVK::destroy()
 	{
+		for (uint8_t ii = 0, num = m_num; ii < num; ++ii)
+		{
+			TextureVK& texture = s_renderVK->m_textures[m_texture[ii].idx];
+			texture.setImageMemoryBarrier(s_renderVK->m_commandBuffer, texture.m_sampledLayout);
+			if (VK_NULL_HANDLE != texture.m_singleMsaaImage)
+			{
+				texture.setImageMemoryBarrier(s_renderVK->m_commandBuffer, texture.m_sampledLayout, true);
+			}
+		}
+
 		preReset();
 
 		if (NULL != m_nwh)


### PR DESCRIPTION
After a lot of debugging: there is a case where a framebuffer is destroyed, and a new one is created, but they happen to land on the same index. This causes some mechanisms to not detect the fact that the current framebuffer actually changed (because the indices are the same, yet the framebuffer itself is different).

I added code in the destroy that properly resets the image memory barriers of attached textures back to samplingLayout.

There might be OTHER mechanisms that still suffer from this delete/create-new where the idx is reused. But I'm not home in the code.

Thanks @pezcode. Consider this to be checked and thought about further (especially regarding my last comment).

Note that the `for` loop in `FrameBufferVk::destroy()` is now a bit of code duplication, taken from `RendererContextVK::setFrameBuffer()`.