### PR TITLE
Fix shaderc consistency

### DIFF
--- a/3rdparty/glsl-optimizer/src/glsl/ir_print_glsl_visitor.cpp
+++ b/3rdparty/glsl-optimizer/src/glsl/ir_print_glsl_visitor.cpp
@@ -1344,7 +1344,7 @@ void print_float (string_buffer& buffer, float f)
 	// that so compiler output matches.
 	if (posE != NULL)
 	{
-		if((posE[1] == '+' || posE[1] == '-') && posE[2] == '0')
+		if((posE[1] == '+' || posE[1] == '-') && posE[2] == '0' && posE[3] == '0')
 		{
 			char* p = posE+2;
 			while (p[0])

--- a/tools/shaderc/shaderc.h
+++ b/tools/shaderc/shaderc.h
@@ -91,6 +91,7 @@ namespace bgfx
 			, regCount(0)
 			, texComponent(0)
 			, texDimension(0)
+			, texFormat(0)
 		{
 		}
 


### PR DESCRIPTION
Hi, recently I noticed that shaderc results differ on different platforms.
After some investigation, I found two issues:

1. 'texFormat' in struct Uniform wasn't intialized (similar with #2174).
2. glsl-optimizer did special treatment for MSVC in 'print_float' for result consistency, but it causes inconsistency on the latest MSVC.

For the second issue, look at the comment in 'print_float', it removes a zero in MSVC's print result, but didn't check if the extra zero is actually there, which gives something like 1.0e+7 on the latest MSVC.
```
	#if defined(_MSC_VER)
	// While gcc would print something like 1.0e+07, MSVC will print 1.0e+007 -
	// only for exponential notation, it seems, will add one extra useless zero. Let's try to remove
	// that so compiler output matches.
	if (posE != NULL)
	{
		if((posE[1] == '+' || posE[1] == '-') && posE[2] == '0')
		{
			char* p = posE+2;
			while (p[0])
			{
				p[0] = p[1];
				++p;
			}
		}
	}
	#endif
```
