### PR TITLE
#2556 Fix windows line endings handling (08.07 18:13)

### DIFF
--- a/3rdparty/fcpp/cpp2.c
+++ b/3rdparty/fcpp/cpp2.c
@@ -575,7 +575,7 @@ ReturnCode fpp_doinclude( struct Global *global )
 
     global->workp = global->work;
 
-    while( (c = fpp_get(global)) != '\n' && c != EOF_CHAR )
+    while( (c = fpp_get(global)) != '\n' && c != '\r' && c != EOF_CHAR )
         if( (ret = fpp_save( global, c )) )       /* Put it away.                */
             return( ret );
 


### PR DESCRIPTION
Please see #2556 for details.

The code adds processing of '\r' symbol in the same way the program processes '\n' symbol to better support windows environment.