### PR TITLE
Add compute shader type to shaderc help.

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -974,7 +974,7 @@ namespace bgfx
 			);
 
 		bx::printf(
-			  "Usage: shaderc -f <in> -o <out> --type <v/f> --platform <platform>\n"
+			  "Usage: shaderc -f <in> -o <out> --type <v/f/c> --platform <platform>\n"
 
 			  "\n"
 			  "Options:\n"
@@ -1019,7 +1019,7 @@ namespace bgfx
 			  "      --preprocess              Preprocess only.\n"
 			  "      --define <defines>        Add defines to preprocessor (semicolon separated).\n"
 			  "      --raw                     Do not process shader. No preprocessor, and no glsl-optimizer (GLSL only).\n"
-			  "      --type <type>             Shader type (vertex, fragment)\n"
+			  "      --type <type>             Shader type (vertex, fragment, compute)\n"
 			  "      --varyingdef <file path>  Path to varying.def.sc file.\n"
 			  "      --verbose                 Verbose.\n"
 


### PR DESCRIPTION
It was a bit confusing when I took a look at shaderc's help but compute shader type was not listed here and program said nothing when I passed `--type c` to it.
Wiki should be changed too: https://bkaradzic.github.io/bgfx/tools.html#shader-compiler-shaderc