### PR TITLE
Use already injected RenderDoc dll, or load it from default location

### DIFF
--- a/src/debug_renderdoc.cpp
+++ b/src/debug_renderdoc.cpp
@@ -16,6 +16,8 @@ namespace bgfx
 	void* findModule(const char* _name)
 	{
 #if BX_PLATFORM_WINDOWS
+		// NOTE: there was some reason to do it this way instead of simply calling GetModuleHandleA,
+		// but not sure what it was.
 		HANDLE process = GetCurrentProcess();
 		DWORD size;
 		BOOL result = EnumProcessModules(process
@@ -52,7 +54,7 @@ namespace bgfx
 		}
 #else
 		BX_UNUSED(_name);
-#endif
+#endif // BX_PLATFORM_WINDOWS
 
 		return NULL;
 	}
@@ -74,17 +76,19 @@ namespace bgfx
 			return NULL;
 		}
 
-#if BX_PLATFORM_WINDOWS
 		// If RenderDoc is already injected in the process then use the already present DLL
 		void* renderDocDll = findModule("renderdoc.dll");
 		if (NULL == renderDocDll)
 		{
-			// Load the RenderDoc DLL from its default installation location
-			renderDocDll = bx::dlopen("C:\\Program Files\\RenderDoc\\renderdoc.dll");
-		}
+			// TODO: try common installation paths before looking in current directory
+			renderDocDll = bx::dlopen(
+#if BX_PLATFORM_WINDOWS
+					"renderdoc.dll"
 #else
-		void* renderDocDll = bx::dlopen("./librenderdoc.so");
-#endif
+					"./librenderdoc.so"
+#endif // BX_PLATFORM_WINDOWS
+					);
+		}
 
 		if (NULL != renderDocDll)
 		{


### PR DESCRIPTION
Hello. This PR arises out of a [discussion I had with BaldurK](https://github.com/baldurk/renderdoc/issues/2279#issuecomment-844588691) about the right way to load the RenderDoc DLL in Windows. It seems bgfx is currently expecting the dll to be either next to the executable, or in the system PATH, but these are not preferable or supported ways of loading it according to Baldur. This particularly causes problems with the Vulkan backend due to the way RenderDoc is implemented as a layer in Vulkan.

The changes here:
- on Windows, if the process was launched from RenderDoc and the dll is already injected in the process, use it
- otherwise try to load the dll from RenderDoc's default installation path in Program Files
- use `GetModuleHandleA` instead of `EnumProcessModules` etc in `findModule` - I couldn't see a reason why this was being done the long way, as `GetModuleHandleA` does the same thing AFAICT, but let me know if there is some reason to keep the previous version

Tested with example-01-cubes, launching both from RenderDoc and standalone, and verifying that a capture can be taken by hitting F11 in either case.

Thanks!