### PR TITLE
Improve detection of EXT_gpu_shader4

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -794,7 +794,7 @@ namespace bgfx { namespace gl
 		{ "EXT_framebuffer_blit",                     BGFX_CONFIG_RENDERER_OPENGL >= 30, true  },
 		{ "EXT_framebuffer_object",                   BGFX_CONFIG_RENDERER_OPENGL >= 30, true  },
 		{ "EXT_framebuffer_sRGB",                     BGFX_CONFIG_RENDERER_OPENGL >= 30, true  },
-		{ "EXT_gpu_shader4",                          false,                             true  },
+		{ "EXT_gpu_shader4",                          BGFX_CONFIG_RENDERER_OPENGL >= 31, true  },
 		{ "EXT_multi_draw_indirect",                  false,                             true  }, // GLES3.1 extension.
 		{ "EXT_occlusion_query_boolean",              false,                             true  }, // GLES2 extension.
 		{ "EXT_packed_float",                         BGFX_CONFIG_RENDERER_OPENGL >= 33, true  },


### PR DESCRIPTION
This extension is used to detect support for gl_InstanceID and gl_VertexID. However, in more recent
versions of OpenGL, this is built-in functionality. On my system, it does not list that extension,
even though it supports those features, but BGFX was not detecting that.

Updated detection to look for GL>=3.1.

Note 1: even with this change, you do need to compile BGFX with the appropriate
BGFX_CONFIG_RENDERER_OPENGL value (>=31). The default of 21 is not high enough.

Note 2: Even with all of the above, you will likely hit issues with duplicate '#version' lines in
the generated shader code. For that, see issue #xxxx.

fixes issue #2570