### PR TITLE
Vulkan: fix RGBA8 backbuffer capture

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3965,6 +3965,7 @@ VK_IMPORT_DEVICE
 				if (_swapChain.m_colorFormat == TextureFormat::RGBA8)
 				{
 					bimg::imageSwizzleBgra8(src, pitch, width, height, src, pitch);
+					_func(src, width, height, pitch, _userData);
 				}
 				else if (_swapChain.m_colorFormat == TextureFormat::BGRA8)
 				{


### PR DESCRIPTION
`g_callback->captureFrame` never gets called if the format is RGBA8, this fix correctly invokes the callback. Got introduced in https://github.com/bkaradzic/bgfx/pull/2491.