### PR TITLE
Vulkan: correctly resolve attachments of destroyed framebuffer

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2327,6 +2327,11 @@ VK_IMPORT_DEVICE
 		{
 			FrameBufferVK& frameBuffer = m_frameBuffers[_handle.idx];
 
+			if (_handle.idx == m_fbh.idx)
+			{
+				setFrameBuffer(BGFX_INVALID_HANDLE, false);
+			}
+
 			uint16_t denseIdx = frameBuffer.destroy();
 			if (UINT16_MAX != denseIdx)
 			{
@@ -2748,7 +2753,7 @@ VK_IMPORT_DEVICE
 			setShaderUniform(_flags, _regIndex, _val, _numRegs);
 		}
 
-		void setFrameBuffer(FrameBufferHandle _fbh)
+		void setFrameBuffer(FrameBufferHandle _fbh, bool _acquire = true)
 		{
 			BX_ASSERT(false
 				  ||  isValid(_fbh)
@@ -2815,15 +2820,19 @@ VK_IMPORT_DEVICE
 
 				newFrameBuffer.acquire(m_commandBuffer);
 			}
-			else
+
+			if (_acquire)
 			{
 				int64_t start = bx::getHPCounter();
 
 				newFrameBuffer.acquire(m_commandBuffer);
 
 				int64_t now = bx::getHPCounter();
-
-				m_presentElapsed += now - start;
+				
+				if (NULL == newFrameBuffer.m_nwh)
+				{
+					m_presentElapsed += now - start;
+				}
 			}
 
 			m_fbh = _fbh;


### PR DESCRIPTION
Destroying a framebuffer in the Vulkan backend doesn't immediately reset/resolve the attachments for sampling operations. Normally that's not an issue since it happens when a new framebuffer is set. However, when destroying the FB, then not using any FB for several frames (compute-only or empty draw list) and then creating a new FB that gets assigned the same ID, the check for a new FB fails (since the IDs are identical). This results in
a) an assert ("Mismatching image layout") when trying to sample the destroyed FB's textures
b) the destroyed FB's textures not being resolved if they're multisampled

Repro in 01-cubes: [repro-pr-2547.patch.txt](https://github.com/bkaradzic/bgfx/files/6957246/repro-pr-2547.patch.txt)

This is a slightly less bandaid-y fix for https://github.com/bkaradzic/bgfx/pull/2547 and avoids the code duplication. I'd appreciate some feedback from @mcourteaux to see if this fixes his problem 🙏 

