### PR TITLE
Vulkan: fix present elapsed calculation

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2829,7 +2829,7 @@ VK_IMPORT_DEVICE
 
 				int64_t now = bx::getHPCounter();
 				
-				if (NULL == newFrameBuffer.m_nwh)
+				if (NULL != newFrameBuffer.m_nwh)
 				{
 					m_presentElapsed += now - start;
 				}


### PR DESCRIPTION
Small fix for a bug introduced in https://github.com/bkaradzic/bgfx/pull/2576