### PR TITLE
Fix linking against glfw

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -263,7 +263,7 @@ function exampleProjectDefaults()
 
 	if _OPTIONS["with-glfw"] then
 		defines { "ENTRY_CONFIG_USE_GLFW=1" }
-		links   { "glfw3" }
+		links   { "glfw" }
 
 		configuration { "linux or freebsd" }
 			if _OPTIONS["with-wayland"] then

--- a/scripts/geometryv.lua
+++ b/scripts/geometryv.lua
@@ -48,7 +48,7 @@ project ("geometryv")
 
 	if _OPTIONS["with-glfw"] then
 		defines { "ENTRY_CONFIG_USE_GLFW=1" }
-		links   { "glfw3" }
+		links   { "glfw" }
 
 		configuration { "linux or freebsd" }
 			links {

--- a/scripts/texturev.lua
+++ b/scripts/texturev.lua
@@ -48,7 +48,7 @@ project ("texturev")
 
 	if _OPTIONS["with-glfw"] then
 		defines { "ENTRY_CONFIG_USE_GLFW=1" }
-		links   { "glfw3" }
+		links   { "glfw" }
 
 		configuration { "linux or freebsd" }
 			links {


### PR DESCRIPTION
As of glfw-3.3.4, the output of pkg-config --libs glfw3 is -lglfw, not -lglfw3