### PR TITLE
HLSL: add textureGather for all components

### DIFF
--- a/src/bgfx_shader.sh
+++ b/src/bgfx_shader.sh
@@ -315,17 +315,55 @@ vec2 bgfxTextureSize(BgfxUSampler2D _sampler, int _lod)
 	return result;
 }
 
-vec4 bgfxTextureGather(BgfxSampler2D _sampler, vec2 _coord)
+vec4 bgfxTextureGather0(BgfxSampler2D _sampler, vec2 _coord)
 {
-	return _sampler.m_texture.GatherRed(_sampler.m_sampler, _coord );
+	return _sampler.m_texture.GatherRed(_sampler.m_sampler, _coord);
 }
-vec4 bgfxTextureGatherOffset(BgfxSampler2D _sampler, vec2 _coord, ivec2 _offset)
+vec4 bgfxTextureGather1(BgfxSampler2D _sampler, vec2 _coord)
 {
-	return _sampler.m_texture.GatherRed(_sampler.m_sampler, _coord, _offset );
+	return _sampler.m_texture.GatherGreen(_sampler.m_sampler, _coord);
 }
-vec4 bgfxTextureGather(BgfxSampler2DArray _sampler, vec3 _coord)
+vec4 bgfxTextureGather2(BgfxSampler2D _sampler, vec2 _coord)
 {
-	return _sampler.m_texture.GatherRed(_sampler.m_sampler, _coord );
+	return _sampler.m_texture.GatherBlue(_sampler.m_sampler, _coord);
+}
+vec4 bgfxTextureGather3(BgfxSampler2D _sampler, vec2 _coord)
+{
+	return _sampler.m_texture.GatherAlpha(_sampler.m_sampler, _coord);
+}
+
+vec4 bgfxTextureGatherOffset0(BgfxSampler2D _sampler, vec2 _coord, ivec2 _offset)
+{
+	return _sampler.m_texture.GatherRed(_sampler.m_sampler, _coord, _offset);
+}
+vec4 bgfxTextureGatherOffset1(BgfxSampler2D _sampler, vec2 _coord, ivec2 _offset)
+{
+	return _sampler.m_texture.GatherGreen(_sampler.m_sampler, _coord, _offset);
+}
+vec4 bgfxTextureGatherOffset2(BgfxSampler2D _sampler, vec2 _coord, ivec2 _offset)
+{
+	return _sampler.m_texture.GatherBlue(_sampler.m_sampler, _coord, _offset);
+}
+vec4 bgfxTextureGatherOffset3(BgfxSampler2D _sampler, vec2 _coord, ivec2 _offset)
+{
+	return _sampler.m_texture.GatherAlpha(_sampler.m_sampler, _coord, _offset);
+}
+
+vec4 bgfxTextureGather0(BgfxSampler2DArray _sampler, vec3 _coord)
+{
+	return _sampler.m_texture.GatherRed(_sampler.m_sampler, _coord);
+}
+vec4 bgfxTextureGather1(BgfxSampler2DArray _sampler, vec3 _coord)
+{
+	return _sampler.m_texture.GatherGreen(_sampler.m_sampler, _coord);
+}
+vec4 bgfxTextureGather2(BgfxSampler2DArray _sampler, vec3 _coord)
+{
+	return _sampler.m_texture.GatherBlue(_sampler.m_sampler, _coord);
+}
+vec4 bgfxTextureGather3(BgfxSampler2DArray _sampler, vec3 _coord)
+{
+	return _sampler.m_texture.GatherAlpha(_sampler.m_sampler, _coord);
 }
 
 ivec4 bgfxTexelFetch(BgfxISampler2D _sampler, ivec2 _coord, int _lod)
@@ -440,8 +478,8 @@ vec3 bgfxTextureSize(BgfxSampler3D _sampler, int _lod)
 #		define texelFetch(_sampler, _coord, _lod) bgfxTexelFetch(_sampler, _coord, _lod)
 #		define texelFetchOffset(_sampler, _coord, _lod, _offset) bgfxTexelFetchOffset(_sampler, _coord, _lod, _offset)
 #		define textureSize(_sampler, _lod) bgfxTextureSize(_sampler, _lod)
-#		define textureGather(_sampler, _coord) bgfxTextureGather(_sampler, _coord)
-#		define textureGatherOffset(_sampler, _coord, _offset) bgfxTextureGatherOffset(_sampler, _coord, _offset)
+#		define textureGather(_sampler, _coord, _comp) bgfxTextureGather ## _comp(_sampler, _coord)
+#		define textureGatherOffset(_sampler, _coord, _offset, _comp) bgfxTextureGatherOffset ## _comp(_sampler, _coord, _offset)
 #	else
 
 #		define sampler2DShadow sampler2D


### PR DESCRIPTION
When compiling for D3D, `textureGather` was missing the `comp` parameter to pick the texture component to gather and always defaulted to the red channel. This patch adds that parameter and calls the correct `GatherXX` function on the texture.

However, the `comp` parameter is now mandatory. I can't overload on a macro (`Redefining defined variable "textureGather"`), and I assume all the sampling functions are macros and not functions themselves for a good reason.

### TL;DR

previous:
```glsl
textureGather(s_tex, uv) // red, OK
textureGather(s_tex, uv, 1) // green, ERROR
```
now:
```glsl
textureGather(s_tex, uv) // red, ERROR
textureGather(s_tex, uv, 0) // red, OK
```