### PR TITLE
Fix textureGather in example 39

### DIFF
--- a/examples/39-assao/cs_assao_generate_importance_map.sc
+++ b/examples/39-assao/cs_assao_generate_importance_map.sc
@@ -28,7 +28,7 @@ void main()
 		UNROLL
 		for( int i = 0; i < 4; i++ )
 		{
-			vec4 vals = textureGather(s_finalSSAO, vec3( gatherUV, i ) );
+			vec4 vals = textureGather(s_finalSSAO, vec3( gatherUV, i ), 0);
 
 			// apply the same modifications that would have been applied in the main shader
 			vals = u_effectShadowStrength * vals;

--- a/examples/39-assao/cs_assao_generate_q.sh
+++ b/examples/39-assao/cs_assao_generate_q.sh
@@ -238,11 +238,11 @@ void GenerateSSAOShadowsInternal( out float outShadowTerm, out vec4 outEdges, ou
     float pixZ, pixLZ, pixTZ, pixRZ, pixBZ;
 
 #if BGFX_SHADER_LANGUAGE_GLSL  
-    vec4 valuesUL     = textureGather(s_viewspaceDepthSourceMirror, SVPosRounded * u_halfViewportPixelSize + vec2(0.0,u_halfViewportPixelSize.y)).wzyx;
-    vec4 valuesBR     = textureGatherOffset(s_viewspaceDepthSourceMirror, SVPosRounded * u_halfViewportPixelSize + vec2(0.0,u_halfViewportPixelSize.y), ivec2( 1, -1 ) ).wzyx;
+    vec4 valuesUL     = textureGather(s_viewspaceDepthSourceMirror, SVPosRounded * u_halfViewportPixelSize + vec2(0.0,u_halfViewportPixelSize.y), 0).wzyx;
+    vec4 valuesBR     = textureGatherOffset(s_viewspaceDepthSourceMirror, SVPosRounded * u_halfViewportPixelSize + vec2(0.0,u_halfViewportPixelSize.y), ivec2( 1, -1 ), 0).wzyx;
 #else
-    vec4 valuesUL     = textureGather(s_viewspaceDepthSourceMirror, SVPosRounded * u_halfViewportPixelSize );
-    vec4 valuesBR     = textureGatherOffset(s_viewspaceDepthSourceMirror, SVPosRounded * u_halfViewportPixelSize, ivec2( 1, 1 ) );
+    vec4 valuesUL     = textureGather(s_viewspaceDepthSourceMirror, SVPosRounded * u_halfViewportPixelSize, 0);
+    vec4 valuesBR     = textureGatherOffset(s_viewspaceDepthSourceMirror, SVPosRounded * u_halfViewportPixelSize, ivec2( 1, 1 ), 0);
 #endif
 
     // get this pixel's viewspace depth

--- a/examples/39-assao/cs_assao_smart_blur.sc
+++ b/examples/39-assao/cs_assao_smart_blur.sc
@@ -39,11 +39,11 @@ vec2 SampleBlurred( ivec2 inPos, vec2 coord )
     vec4 edgesLRTB    = UnpackEdges( packedEdges );
 
 #if BGFX_SHADER_LANGUAGE_GLSL
-    vec4 valuesUL     = textureGather(s_blurInput, vec3(coord - u_halfViewportPixelSize * 0.5 + vec2(0.0,u_halfViewportPixelSize.y), 0.0)).wzyx;
-    vec4 valuesBR     = textureGather(s_blurInput, vec3(coord + u_halfViewportPixelSize * 0.5 + vec2(0.0,-u_halfViewportPixelSize.y), 0.0)).wzyx;
+    vec4 valuesUL     = textureGather(s_blurInput, vec3(coord - u_halfViewportPixelSize * 0.5 + vec2(0.0,u_halfViewportPixelSize.y), 0.0), 0).wzyx;
+    vec4 valuesBR     = textureGather(s_blurInput, vec3(coord + u_halfViewportPixelSize * 0.5 + vec2(0.0,-u_halfViewportPixelSize.y), 0.0), 0).wzyx;
 #else
-    vec4 valuesUL     = textureGather(s_blurInput, vec3(coord - u_halfViewportPixelSize * 0.5, 0.0));
-    vec4 valuesBR     = textureGather(s_blurInput, vec3(coord + u_halfViewportPixelSize * 0.5, 0.0));
+    vec4 valuesUL     = textureGather(s_blurInput, vec3(coord - u_halfViewportPixelSize * 0.5, 0.0), 0);
+    vec4 valuesBR     = textureGather(s_blurInput, vec3(coord + u_halfViewportPixelSize * 0.5, 0.0), 0);
 #endif
 
     float ssaoValue     = valuesUL.y;


### PR DESCRIPTION
Follow-up to https://github.com/bkaradzic/bgfx/pull/2595. Forgot to commit the updated examples with the correct `textureGather` syntax.