### PR TITLE
Fix crash when switching to fullscreen with vulkan

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -7320,6 +7320,7 @@ VK_DESTROY
 				BX_FALLTHROUGH;
 
 			case VK_ERROR_OUT_OF_DATE_KHR:
+			case VK_SUBOPTIMAL_KHR:
 				m_needToRefreshSwapchain = true;
 				return false;
 


### PR DESCRIPTION
Without this change, running examples under XWayland, SDL and vulkan
renderer results in a crash. Credit goes to @pezcode:
https://github.com/bkaradzic/bgfx/issues/2593#issuecomment-905462527