### PR TITLE
fix usage of fatal() function when Clang analyzer is used

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -67,7 +67,7 @@
 namespace bgfx
 {
 #if BX_COMPILER_CLANG_ANALYZER
-	void __attribute__( (analyzer_noreturn) ) fatal(Fatal::Enum _code, const char* _format, ...);
+	void __attribute__( (analyzer_noreturn) ) fatal(const char* _filePath, uint16_t _line, Fatal::Enum _code, const char* _format, ...);
 #else
 	void fatal(const char* _filePath, uint16_t _line, Fatal::Enum _code, const char* _format, ...);
 #endif // BX_COMPILER_CLANG_ANALYZER


### PR DESCRIPTION
Hi there ! 👋 

When running code analysis, the Particubes (https://particubes.com) dev team got a compilation error and noticed this error in the usage of `fatal` function.

It seems to be a trivial fix / PR.

Thanks for your review 🙂 