### PR TITLE
Vulkan: raise maximum number of swapchain images

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -6795,16 +6795,16 @@ VK_DESTROY
 
 		const uint32_t minSwapBufferCount = bx::max<uint32_t>(surfaceCapabilities.minImageCount, 2);
 		const uint32_t maxSwapBufferCount = surfaceCapabilities.maxImageCount == 0
-			? BGFX_CONFIG_MAX_BACK_BUFFERS
-			: bx::min<uint32_t>(surfaceCapabilities.maxImageCount, BGFX_CONFIG_MAX_BACK_BUFFERS)
+			? SwapChainVK::MaxBackBuffers
+			: bx::min<uint32_t>(surfaceCapabilities.maxImageCount, SwapChainVK::MaxBackBuffers)
 			;
 
 		if (minSwapBufferCount > maxSwapBufferCount)
 		{
-			BX_TRACE("Create swapchain error: Incompatible swapchain image count (min: %d, max: %d, BGFX_CONFIG_MAX_BACK_BUFFERS: %d)."
+			BX_TRACE("Create swapchain error: Incompatible swapchain image count (min: %d, max: %d, MaxBackBuffers: %d)."
 				, minSwapBufferCount
 				, maxSwapBufferCount
-				, BGFX_CONFIG_MAX_BACK_BUFFERS
+				, SwapChainVK::MaxBackBuffers
 				);
 			return VK_ERROR_INITIALIZATION_FAILED;
 		}

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -704,18 +704,20 @@ VK_DESTROY_FUNC(DescriptorSet);
 		TextureFormat::Enum m_colorFormat;
 		TextureFormat::Enum m_depthFormat;
 
+		static constexpr size_t MaxBackBuffers = bx::max(BGFX_CONFIG_MAX_BACK_BUFFERS, 10);
+
 		VkSurfaceKHR   m_surface;
 		VkSwapchainKHR m_swapchain;
 		uint32_t       m_numSwapchainImages;
-		VkImageLayout  m_backBufferColorImageLayout[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkImage        m_backBufferColorImage[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkImageView    m_backBufferColorImageView[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkFramebuffer  m_backBufferFrameBuffer[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkFence        m_backBufferFence[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkImageLayout  m_backBufferColorImageLayout[MaxBackBuffers];
+		VkImage        m_backBufferColorImage[MaxBackBuffers];
+		VkImageView    m_backBufferColorImageView[MaxBackBuffers];
+		VkFramebuffer  m_backBufferFrameBuffer[MaxBackBuffers];
+		VkFence        m_backBufferFence[MaxBackBuffers];
 		uint32_t       m_backBufferColorIdx;
 
-		VkSemaphore m_presentDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
-		VkSemaphore m_renderDoneSemaphore[BGFX_CONFIG_MAX_BACK_BUFFERS];
+		VkSemaphore m_presentDoneSemaphore[MaxBackBuffers];
+		VkSemaphore m_renderDoneSemaphore[MaxBackBuffers];
 		uint32_t    m_currentSemaphore;
 
 		VkSemaphore m_lastImageRenderedSemaphore;


### PR DESCRIPTION
Hopefully fixes an issue reported by @belegdol on Discord. Apparently Mesa + Xwayland require 5 swapchain images, but the Vulkan backend only allowed up to 4.

The change is rather trivial (bump the 4 up to 10) but I can't personally test this, so if anyone can confirm this fixes it, that would be great :bow:

Related issues:
https://github.com/mamedev/mame/issues/8057
https://gitlab.freedesktop.org/mesa/mesa/-/issues/4727#note_1072645