### PR TITLE
Modified handle initialization to fix compilation error (clang-osx)

### DIFF
--- a/examples/46-fsr/fsr.cpp
+++ b/examples/46-fsr/fsr.cpp
@@ -54,30 +54,30 @@ struct FsrResources
 			uint32_t m_params[NumVec4 * 4];
 		};
 
-		bgfx::UniformHandle u_params{ BGFX_INVALID_HANDLE };
+		bgfx::UniformHandle u_params = BGFX_INVALID_HANDLE;
 	};
 
 	uint32_t m_width{ 0 };
 	uint32_t m_height{ 0 };
 
 	// Resource handles
-	bgfx::ProgramHandle m_bilinear16Program{ BGFX_INVALID_HANDLE };
-	bgfx::ProgramHandle m_bilinear32Program{ BGFX_INVALID_HANDLE };
-	bgfx::ProgramHandle m_easu16Program{ BGFX_INVALID_HANDLE };
-	bgfx::ProgramHandle m_easu32Program{ BGFX_INVALID_HANDLE };
-	bgfx::ProgramHandle m_rcas16Program{ BGFX_INVALID_HANDLE };
-	bgfx::ProgramHandle m_rcas32Program{ BGFX_INVALID_HANDLE };
+	bgfx::ProgramHandle m_bilinear16Program = BGFX_INVALID_HANDLE;
+	bgfx::ProgramHandle m_bilinear32Program = BGFX_INVALID_HANDLE;
+	bgfx::ProgramHandle m_easu16Program = BGFX_INVALID_HANDLE;
+	bgfx::ProgramHandle m_easu32Program = BGFX_INVALID_HANDLE;
+	bgfx::ProgramHandle m_rcas16Program = BGFX_INVALID_HANDLE;
+	bgfx::ProgramHandle m_rcas32Program = BGFX_INVALID_HANDLE;
 
 	// Shader uniforms
 	Uniforms m_uniforms;
 
 	// Uniforms to indentify texture samplers
-	bgfx::UniformHandle s_inputTexture{ BGFX_INVALID_HANDLE };
+	bgfx::UniformHandle s_inputTexture = BGFX_INVALID_HANDLE;
 
-	bgfx::TextureHandle m_easuTexture16F{ BGFX_INVALID_HANDLE };
-	bgfx::TextureHandle m_rcasTexture16F{ BGFX_INVALID_HANDLE };
-	bgfx::TextureHandle m_easuTexture32F{ BGFX_INVALID_HANDLE };
-	bgfx::TextureHandle m_rcasTexture32F{ BGFX_INVALID_HANDLE };
+	bgfx::TextureHandle m_easuTexture16F = BGFX_INVALID_HANDLE;
+	bgfx::TextureHandle m_rcasTexture16F = BGFX_INVALID_HANDLE;
+	bgfx::TextureHandle m_easuTexture32F = BGFX_INVALID_HANDLE;
+	bgfx::TextureHandle m_rcasTexture32F = BGFX_INVALID_HANDLE;
 };
 
 


### PR DESCRIPTION
Addresses the following error(s):
```
==== Building examples (release) ====
fsr.cpp
../../../examples/46-fsr/fsr.cpp:57:33: fatal error: braces around scalar initializer [-Wbraced-scalar-init]
                bgfx::UniformHandle u_params{ BGFX_INVALID_HANDLE };
                                              ^~~~~~~~~~~~~~~~~~~
../../../include/bgfx/bgfx.h:20:29: note: expanded from macro 'BGFX_INVALID_HANDLE'
#define BGFX_INVALID_HANDLE { bgfx::kInvalidHandle }
                            ^~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [../../osx-x64/obj/Release/examples/examples/46-fsr/fsr.o] Error 1
make[1]: *** [examples] Error 2
make: *** [osx-x64-release] Error 2
```