### PR TITLE
Fix isTextureValid number of layers check

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4608,7 +4608,7 @@ namespace bgfx
 			);
 
 		BGFX_ERROR_CHECK(false
-			|| _numLayers < g_caps.limits.maxTextureLayers
+			|| _numLayers <= g_caps.limits.maxTextureLayers
 			, _err
 			, BGFX_ERROR_TEXTURE_VALIDATION
 			, "Requested number of texture array layers is above the `maxTextureLayers` limit."


### PR DESCRIPTION
The check against the max layer count isn't correct. This blew up on D3D9 for 01-cubes with `g_caps.limits.maxTextureLayers == 1`.