### PR TITLE
Cleanup: change POD casts from static_cast to functional/ctor casts

### DIFF
--- a/examples/46-fsr/app.cpp
+++ b/examples/46-fsr/app.cpp
@@ -253,12 +253,12 @@ namespace
 
 		void drawToScreen(bgfx::ViewId &view, AppState const &state)
 		{
-			float invScreenScaleX = 1.0f / static_cast<float>(state.m_width);
-			float invScreenScaleY = 1.0f / static_cast<float>(state.m_height);
+			float invScreenScaleX = 1.0f / float(state.m_width);
+			float invScreenScaleY = 1.0f / float(state.m_height);
 			float scaleX = m_widgetWidth * invScreenScaleX;
 			float scaleY = m_widgetHeight * invScreenScaleY;
-			float offsetX = -bx::min(bx::max(m_position.x - m_widgetWidth * 0.5f, -3.0f), static_cast<float>(state.m_width - m_widgetWidth + 3) ) * invScreenScaleX;
-			float offsetY = -bx::min(bx::max(m_position.y - m_widgetHeight * 0.5f, -3.0f), static_cast<float>(state.m_height - m_widgetHeight + 3) ) * invScreenScaleY;
+			float offsetX = -bx::min(bx::max(m_position.x - m_widgetWidth * 0.5f, -3.0f), float(state.m_width - m_widgetWidth + 3) ) * invScreenScaleX;
+			float offsetY = -bx::min(bx::max(m_position.y - m_widgetHeight * 0.5f, -3.0f), float(state.m_height - m_widgetHeight + 3) ) * invScreenScaleY;
 
 			bgfx::setState(0 | BGFX_STATE_WRITE_RGB | BGFX_STATE_WRITE_A | BGFX_STATE_DEPTH_TEST_ALWAYS | BGFX_STATE_BLEND_ALPHA);
 			bgfx::setTexture(0, state.s_color, m_widgetTexture);
@@ -278,12 +278,12 @@ namespace
 			}
 
 			const float verticalPos = caps->originBottomLeft ? state.m_height - m_position.y : m_position.y;
-			const float invMagScaleX = 1.0f / static_cast<float>(m_content.m_width);
-			const float invMagScaleY = 1.0f / static_cast<float>(m_content.m_height);
+			const float invMagScaleX = 1.0f / float(m_content.m_width);
+			const float invMagScaleY = 1.0f / float(m_content.m_height);
 			const float scaleX = state.m_width * invMagScaleX;
 			const float scaleY = state.m_height * invMagScaleY;
-			const float offsetX = bx::min(bx::max(m_position.x - m_content.m_width * 0.5f, 0.0f), static_cast<float>(state.m_width - m_content.m_width) ) * scaleX / state.m_width;
-			const float offsetY = bx::min(bx::max(verticalPos - m_content.m_height * 0.5f, 0.0f), static_cast<float>(state.m_height - m_content.m_height) ) * scaleY / state.m_height;
+			const float offsetX = bx::min(bx::max(m_position.x - m_content.m_width * 0.5f, 0.0f), float(state.m_width - m_content.m_width) ) * scaleX / state.m_width;
+			const float offsetY = bx::min(bx::max(verticalPos - m_content.m_height * 0.5f, 0.0f), float(state.m_height - m_content.m_height) ) * scaleY / state.m_height;
 
 			bgfx::setViewName(view, "magnifier");
 			bgfx::setViewRect(view, 0, 0, uint16_t(m_content.m_width), uint16_t(m_content.m_height) );

--- a/examples/46-fsr/fsr.cpp
+++ b/examples/46-fsr/fsr.cpp
@@ -333,14 +333,14 @@ bool Fsr::supports16BitPrecision() const
 
 void Fsr::updateUniforms()
 {
-	const float srcWidth = static_cast<float>(m_resources->m_width) / m_config.m_superSamplingFactor;
-	const float srcHeight = static_cast<float>(m_resources->m_height) / m_config.m_superSamplingFactor;
+	const float srcWidth = float(m_resources->m_width) / m_config.m_superSamplingFactor;
+	const float srcHeight = float(m_resources->m_height) / m_config.m_superSamplingFactor;
 
 	m_resources->m_uniforms.ViewportSizeRcasAttenuation.x = srcWidth;
 	m_resources->m_uniforms.ViewportSizeRcasAttenuation.y = srcHeight;
 	m_resources->m_uniforms.ViewportSizeRcasAttenuation.z = m_config.m_rcasAttenuation;
-	m_resources->m_uniforms.SrcSize.x = static_cast<float>(m_resources->m_width);
-	m_resources->m_uniforms.SrcSize.y = static_cast<float>(m_resources->m_height);
-	m_resources->m_uniforms.DstSize.x = static_cast<float>(m_resources->m_width);
-	m_resources->m_uniforms.DstSize.y = static_cast<float>(m_resources->m_height);
+	m_resources->m_uniforms.SrcSize.x = float(m_resources->m_width);
+	m_resources->m_uniforms.SrcSize.y = float(m_resources->m_height);
+	m_resources->m_uniforms.DstSize.x = float(m_resources->m_width);
+	m_resources->m_uniforms.DstSize.y = float(m_resources->m_height);
 }

--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -222,7 +222,7 @@ namespace bgfx { namespace metal
 
 		bx::ErrorAssert err;
 
-		uint16_t count = static_cast<uint16_t>(uniforms.size() );
+		uint16_t count = uint16_t(uniforms.size());
 		bx::write(_writer, count, &err);
 
 		uint32_t fragmentBit = isFragmentShader ? kUniformFragmentBit : 0;

--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -328,7 +328,7 @@ namespace bgfx { namespace spirv
 
 		bx::ErrorAssert err;
 
-		uint16_t count = static_cast<uint16_t>(uniforms.size() );
+		uint16_t count = uint16_t(uniforms.size());
 		bx::write(_writer, count, &err);
 
 		uint32_t fragmentBit = isFragmentShader ? kUniformFragmentBit : 0;


### PR DESCRIPTION
As per the previous PR where we said POD casts should use C-style or ctor casts, I changed all the others to ctor casts, for consistency.