### PR TITLE
Fix font rendering

### DIFF
--- a/examples/10-font/font.cpp
+++ b/examples/10-font/font.cpp
@@ -266,7 +266,10 @@ public:
 			float view[16];
 			bx::mtxLookAt(view, eye, at);
 
-			const float centering = 0.5f;
+			const float centering = 0.0f;
+			if (bgfx::getRendererType() == bgfx::RendererType::Direct3D9) {
+				centering = -0.5f;
+			}
 
 			// Setup a top-left ortho matrix for screen space drawing.
 			const bgfx::Caps* caps = bgfx::getCaps();

--- a/examples/10-font/font.cpp
+++ b/examples/10-font/font.cpp
@@ -266,7 +266,7 @@ public:
 			float view[16];
 			bx::mtxLookAt(view, eye, at);
 
-			const float centering = 0.0f;
+			float centering = 0.0f;
 			if (bgfx::getRendererType() == bgfx::RendererType::Direct3D9) {
 				centering = -0.5f;
 			}

--- a/examples/11-fontsdf/fontsdf.cpp
+++ b/examples/11-fontsdf/fontsdf.cpp
@@ -253,7 +253,10 @@ public:
 			float view[16];
 			bx::mtxLookAt(view, eye, at);
 
-			const float centering = 0.5f;
+			const float centering = 0.0f;
+			if (bgfx::getRendererType() == bgfx::RendererType::Direct3D9) {
+				centering = -0.5f;
+			}
 
 			// Setup a top-left ortho matrix for screen space drawing.
 			const bgfx::Caps* caps = bgfx::getCaps();

--- a/examples/11-fontsdf/fontsdf.cpp
+++ b/examples/11-fontsdf/fontsdf.cpp
@@ -253,7 +253,7 @@ public:
 			float view[16];
 			bx::mtxLookAt(view, eye, at);
 
-			const float centering = 0.0f;
+			float centering = 0.0f;
 			if (bgfx::getRendererType() == bgfx::RendererType::Direct3D9) {
 				centering = -0.5f;
 			}

--- a/examples/common/cube_atlas.h
+++ b/examples/common/cube_atlas.h
@@ -135,8 +135,6 @@ public:
 	}
 
 private:
-	void init();
-
 	struct PackedLayer;
 	PackedLayer* m_layers;
 	AtlasRegion* m_regions;
@@ -148,7 +146,6 @@ private:
 	bgfx::TextureHandle m_textureHandle;
 	uint16_t m_textureSize;
 	float m_texelSize;
-	float m_texelOffset[2];
 
 	uint16_t m_regionCount;
 	uint16_t m_maxRegionCount;


### PR DESCRIPTION
I faced a similar issue described in https://github.com/bkaradzic/bgfx/issues/534

First screenshot from Windows 7 with Direct3D11 rendering:
![win7_dx11](https://user-images.githubusercontent.com/2587074/140987640-5b9e8d90-b07f-47aa-893e-0741e8e4ea1f.png)

Second from Android with OpenGLES rendering:
(A similar problem arises on MacOS with Metal rendering)
![android_gles2](https://user-images.githubusercontent.com/2587074/140987654-a17551d3-6852-49b6-8222-5881fa80299d.png)

My fix is based on how I render the font in ImGui. 
Tested on Direct3D9, Direct3D11, OpenGL, OpenGLES, Metal and Vulkan. All looks good.