### PR TITLE
no more optional param for bx:write

### DIFF
--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -284,11 +284,11 @@ EGL_IMPORT
 #	else
 				if (hasEglKhrCreateContext)
 				{
-					bx::write(&writer, EGLint(EGL_CONTEXT_MAJOR_VERSION_KHR) );
-					bx::write(&writer, EGLint(gles / 10) );
+					bx::write(&writer, EGLint(EGL_CONTEXT_MAJOR_VERSION_KHR), bx::ErrorAssert{} );
+					bx::write(&writer, EGLint(gles / 10), bx::ErrorAssert{} );
 
-					bx::write(&writer, EGLint(EGL_CONTEXT_MINOR_VERSION_KHR) );
-					bx::write(&writer, EGLint(gles % 10) );
+					bx::write(&writer, EGLint(EGL_CONTEXT_MINOR_VERSION_KHR), bx::ErrorAssert{} );
+					bx::write(&writer, EGLint(gles % 10), bx::ErrorAssert{} );
 
 					flags |= BGFX_CONFIG_DEBUG && hasEglKhrNoError ? 0
 						| EGL_CONTEXT_FLAG_NO_ERROR_BIT_KHR
@@ -303,18 +303,18 @@ EGL_IMPORT
 							: 0
 							;
 
-						bx::write(&writer, EGLint(EGL_CONTEXT_FLAGS_KHR) );
-						bx::write(&writer, flags);
+						bx::write(&writer, EGLint(EGL_CONTEXT_FLAGS_KHR), bx::ErrorAssert{} );
+						bx::write(&writer, flags, bx::ErrorAssert{});
 					}
 				}
 				else
 #	endif // BX_PLATFORM_RPI
 				{
-					bx::write(&writer, EGLint(EGL_CONTEXT_CLIENT_VERSION) );
-					bx::write(&writer, EGLint(gles / 10));
+					bx::write(&writer, EGLint(EGL_CONTEXT_CLIENT_VERSION), bx::ErrorAssert{} );
+					bx::write(&writer, EGLint(gles / 10), bx::ErrorAssert{} );
 				}
 
-				bx::write(&writer, EGLint(EGL_NONE) );
+				bx::write(&writer, EGLint(EGL_NONE), bx::ErrorAssert{} );
 
 				m_context = eglCreateContext(m_display, m_config, EGL_NO_CONTEXT, s_contextAttrs);
 				if (NULL != m_context)


### PR DESCRIPTION
bx::write used to have a default parameter before this commit:

https://github.com/bkaradzic/bx/commit/51c326484623c719bf0d0de8ff7ca0511a01feb4#diff-8aeee1800c8c4a41e89d09b8f6eee3dfdb361125aee087eeccd34af0240e2e13

But `glcontext_egl.cpp` was not updated.