### PR TITLE
Disable Batch indirect mode for Microsoft WARP

### DIFF
--- a/bindings/bf/bgfx.bf
+++ b/bindings/bf/bgfx.bf
@@ -1278,6 +1278,11 @@ public static class bgfx
 		/// nVidia adapter.
 		/// </summary>
 		Nvidia                 = 0x10de,
+	
+		/// <summary>
+		/// Microsoft adapter.
+		/// </summary>
+		Microsoft              = 0x1414,
 	}
 	
 	[AllowDuplicates]

--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -1277,6 +1277,11 @@ public static partial class bgfx
 		/// nVidia adapter.
 		/// </summary>
 		Nvidia                 = 0x10de,
+	
+		/// <summary>
+		/// Microsoft adapter.
+		/// </summary>
+		Microsoft              = 0x1414,
 	}
 	
 	[Flags]

--- a/bindings/d/types.d
+++ b/bindings/d/types.d
@@ -403,6 +403,7 @@ enum ushort BGFX_PCI_ID_SOFTWARE_RASTERIZER = 0x0001; /// Software rasterizer.
 enum ushort BGFX_PCI_ID_AMD = 0x1002; /// AMD adapter.
 enum ushort BGFX_PCI_ID_INTEL = 0x8086; /// Intel adapter.
 enum ushort BGFX_PCI_ID_NVIDIA = 0x10de; /// nVidia adapter.
+enum ushort BGFX_PCI_ID_MICROSOFT = 0x1414; /// Microsoft adapter.
 
 enum ubyte BGFX_CUBE_MAP_POSITIVE_X = 0x00; /// Cubemap +x.
 enum ubyte BGFX_CUBE_MAP_NEGATIVE_X = 0x01; /// Cubemap -x.

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -522,6 +522,7 @@
 #define BGFX_PCI_ID_AMD                           UINT16_C(0x1002) //!< AMD adapter.
 #define BGFX_PCI_ID_INTEL                         UINT16_C(0x8086) //!< Intel adapter.
 #define BGFX_PCI_ID_NVIDIA                        UINT16_C(0x10de) //!< nVidia adapter.
+#define BGFX_PCI_ID_MICROSOFT                     UINT16_C(0x1414) //!< Microsoft adapter
 
 #define BGFX_CUBE_MAP_POSITIVE_X                  UINT8_C(0x00) //!< Cubemap +x.
 #define BGFX_CUBE_MAP_NEGATIVE_X                  UINT8_C(0x01) //!< Cubemap -x.

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -522,7 +522,7 @@
 #define BGFX_PCI_ID_AMD                           UINT16_C(0x1002) //!< AMD adapter.
 #define BGFX_PCI_ID_INTEL                         UINT16_C(0x8086) //!< Intel adapter.
 #define BGFX_PCI_ID_NVIDIA                        UINT16_C(0x10de) //!< nVidia adapter.
-#define BGFX_PCI_ID_MICROSOFT                     UINT16_C(0x1414) //!< Microsoft adapter
+#define BGFX_PCI_ID_MICROSOFT                     UINT16_C(0x1414) //!< Microsoft adapter.
 
 #define BGFX_CUBE_MAP_POSITIVE_X                  UINT8_C(0x00) //!< Cubemap +x.
 #define BGFX_CUBE_MAP_NEGATIVE_X                  UINT8_C(0x01) //!< Cubemap -x.

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -427,6 +427,7 @@ flag.PciId { bits = 16 , const }
 	.Amd                 (0x1002) --- AMD adapter.
 	.Intel               (0x8086) --- Intel adapter.
 	.Nvidia              (0x10de) --- nVidia adapter.
+    .Microsoft           (0x1414) --- Microsoft adapter.
 	()
 
 flag.CubeMap { bits = 8, const }

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1331,7 +1331,7 @@ namespace bgfx { namespace d3d12
 				postReset();
 
 				m_batch.create(4<<10);
-				m_batch.setIndirectMode(BGFX_PCI_ID_NVIDIA != m_dxgi.m_adapterDesc.VendorId);
+				m_batch.setIndirectMode(BGFX_PCI_ID_NVIDIA != m_dxgi.m_adapterDesc.VendorId && BGFX_PCI_ID_MICROSOFT != m_dxgi.m_adapterDesc.VendorId);
 
 				m_gpuTimer.init();
 				m_occlusionQuery.init();


### PR DESCRIPTION
Indirect batching doesn't work with WARP driver (Microsoft Basic Render Driver). It's the case when running on Azure Pipelines for example or when forcing WARP in DirectX control panel.