### PR TITLE
Fix device refCount d3d12

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -963,7 +963,6 @@ namespace bgfx { namespace d3d12
 
 				m_msaaRt = NULL;
 
-				if (NULL != m_scd.nwh)
 				{
 					hr = m_dxgi.createSwapChain(
 						  getDeviceForSwapChain()


### PR DESCRIPTION
When creating a d3d12 device without a window, the device refcount is not what's expected with shutting down bgfx.
Check is done here : https://github.com/bkaradzic/bgfx/blob/60c64a3f77aca01fea715fa8ba7a2b1f0ca77f38/src/renderer_d3d12.cpp#L1470

and ref count is 2 instead of 0.
I fixed it by removing a (non necessary ?) check in context initialization.
This was brought my automated tests running on Azure CI.