### PR TITLE
Enhance docs for BGFX_DEBUG_PROFILER

### DIFF
--- a/bindings/bf/bgfx.bf
+++ b/bindings/bf/bgfx.bf
@@ -604,7 +604,7 @@ public static class bgfx
 		Text                   = 0x00000008,
 	
 		/// <summary>
-		/// Enable profiler.
+		/// Enable profiler. This causes per-view statistics to be collected, available through `bgfx::Stats::ViewStats`. This is unrelated to the profiler functions in `bgfx::CallbackI`.
 		/// </summary>
 		Profiler               = 0x00000010,
 	}

--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -603,7 +603,7 @@ public static partial class bgfx
 		Text                   = 0x00000008,
 	
 		/// <summary>
-		/// Enable profiler.
+		/// Enable profiler. This causes per-view statistics to be collected, available through `bgfx::Stats::ViewStats`. This is unrelated to the profiler functions in `bgfx::CallbackI`.
 		/// </summary>
 		Profiler               = 0x00000010,
 	}

--- a/bindings/d/types.d
+++ b/bindings/d/types.d
@@ -211,7 +211,7 @@ enum uint BGFX_DEBUG_WIREFRAME = 0x00000001; /// Enable wireframe for all primit
 enum uint BGFX_DEBUG_IFH = 0x00000002;
 enum uint BGFX_DEBUG_STATS = 0x00000004; /// Enable statistics display.
 enum uint BGFX_DEBUG_TEXT = 0x00000008; /// Enable debug text display.
-enum uint BGFX_DEBUG_PROFILER = 0x00000010; /// Enable profiler.
+enum uint BGFX_DEBUG_PROFILER = 0x00000010; /// Enable profiler. This causes per-view statistics to be collected, available through `bgfx::Stats::ViewStats`. This is unrelated to the profiler functions in `bgfx::CallbackI`.
 
 enum ushort BGFX_BUFFER_COMPUTE_FORMAT_8X1 = 0x0001; /// 1 8-bit value
 enum ushort BGFX_BUFFER_COMPUTE_FORMAT_8X2 = 0x0002; /// 2 8-bit values

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -275,7 +275,7 @@
 #define BGFX_DEBUG_IFH                            UINT32_C(0x00000002)
 #define BGFX_DEBUG_STATS                          UINT32_C(0x00000004) //!< Enable statistics display.
 #define BGFX_DEBUG_TEXT                           UINT32_C(0x00000008) //!< Enable debug text display.
-#define BGFX_DEBUG_PROFILER                       UINT32_C(0x00000010) //!< Enable profiler.
+#define BGFX_DEBUG_PROFILER                       UINT32_C(0x00000010) //!< Enable profiler. This causes per-view statistics to be collected, available through `bgfx::Stats::ViewStats`. This is unrelated to the profiler functions in `bgfx::CallbackI`.
 
 #define BGFX_BUFFER_COMPUTE_FORMAT_8X1            UINT16_C(0x0001) //!< 1 8-bit value
 #define BGFX_BUFFER_COMPUTE_FORMAT_8X2            UINT16_C(0x0002) //!< 2 8-bit values

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -219,7 +219,7 @@ flag.Debug { bits = 32 }
 	           --- It's useful when profiling to quickly assess bottleneck between CPU and GPU.
 	.Stats     --- Enable statistics display.
 	.Text      --- Enable debug text display.
-	.Profiler  --- Enable profiler.
+	.Profiler  --- Enable profiler. This causes per-view statistics to be collected, available through `bgfx::Stats::ViewStats`. This is unrelated to the profiler functions in `bgfx::CallbackI`.
 	()
 
 flag.BufferComputeFormat { bits = 16, shift = 0, range = 4, base = 1 }


### PR DESCRIPTION
Current docs are a little ambiguous with the term "profiling"; sometimes it means
bgfx::CallbackI functions, and sometimes per-view stats collection. This makes it a little clearer.