### PR TITLE
Fix use of constant only available on macOS 12+

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -536,7 +536,7 @@ namespace bgfx { namespace mtl
 
 					if (0 != registryId)
 					{
-						entry = IOServiceGetMatchingService(kIOMainPortDefault, IORegistryEntryIDMatching(registryId) );
+						entry = IOServiceGetMatchingService(NULL, IORegistryEntryIDMatching(registryId) );
 
 						if (0 != entry)
 						{


### PR DESCRIPTION
`kIOMainPortDefault` is only available on macOS 12 or later, as shown in `IOKitLib.h`:
```objc
/*! @const kIOMainPortDefault
    @abstract The default mach port used to initiate communication with IOKit.
    @discussion When specifying a main port to IOKit functions, the NULL argument indicates "use the default". This is a synonym for NULL, if you'd rather use a named constant. */

extern
const mach_port_t kIOMainPortDefault
__API_AVAILABLE(macos(12.0), ios(15.0), watchos(8.0), tvos(15.0));
```
There is a deprecated version of the same thing, `kIOMasterPortDefault`, but both are [a named constant for NULL](https://developer.apple.com/documentation/iokit/kiomasterportdefault), so to avoid availability issues in either direction I have changed it to `NULL`. 