### PR TITLE
Fix "GDI resource leak".

### DIFF
--- a/examples/common/entry/entry_windows.cpp
+++ b/examples/common/entry/entry_windows.cpp
@@ -938,6 +938,7 @@ namespace entry
 			SelectObject(hdc, brush);
 			FillRect(hdc, &rect, brush);
 			ReleaseDC(_hwnd, hdc);
+			DeleteObject(brush);
 		}
 
 		void adjust(HWND _hwnd, uint32_t _width, uint32_t _height, bool _windowFrame)


### PR DESCRIPTION
"When you no longer need the HBRUSH object, call the DeleteObject function to delete it."
https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createsolidbrush
👍