### PR TITLE
Fixes for shader_dxbc

### DIFF
--- a/src/shader_dxbc.cpp
+++ b/src/shader_dxbc.cpp
@@ -624,6 +624,54 @@ namespace bgfx
 	};
 	BX_STATIC_ASSERT(BX_COUNTOF(s_dxbcCustomDataClass) == DxbcCustomDataClass::Count);
 
+	static const char* s_dxbcComponentType[] =
+	{
+		"",
+		"Uint32",
+		"Int32",
+		"Float",
+	};
+	BX_STATIC_ASSERT(BX_COUNTOF(s_dxbcComponentType) == DxbcComponentType::Count);
+
+	static const char *s_dxbcBuiltin[] =
+	{
+		"",
+		"Position",
+		"ClipDistance",
+		"CullDistance",
+		"RenderTargetArrayIndex",
+		"ViewportArrayIndex",
+		"VertexId",
+		"PrimitiveId",
+		"InstanceId",
+		"IsFrontFace",
+		"SampleIndex",
+		"FinalQuadUEq0EdgeTessFactor",
+		"FinalQuadVEq0EdgeTessFactor",
+		"FinalQuadUEq1EdgeTessFactor",
+		"FinalQuadVEq1EdgeTessFactor",
+		"FinalQuadUInsideTessFactor",
+		"FinalQuadVInsideTessFactor",
+		"FinalTriUEq0EdgeTessFactor",
+		"FinalTriVEq0EdgeTessFactor",
+		"FinalTriWEq0EdgeTessFactor",
+		"FinalTriInsideTessFactor",
+		"FinalLineDetailTessFactor",
+		"FinalLineDensityTessFactor",
+		"Target", // = 64
+		"Depth",
+		"Coverage",
+		"DepthGreaterEqual",
+		"DepthLessEqual",
+		"StencilRef",
+		"InnerCoverage",
+	};
+	const char *toString(DxbcBuiltin::Enum _value)
+	{
+		constexpr int offset = DxbcBuiltin::Target - DxbcBuiltin::FinalLineDensityTessFactor - 1;
+		return s_dxbcBuiltin[_value < DxbcBuiltin::Target ? _value : _value - offset];
+	}
+
 #define DXBC_MAX_NAME_STRING 512
 
 	int32_t readString(bx::ReaderSeekerI* _reader, int64_t _offset, char* _out, uint32_t _max, bx::Error* _err)
@@ -1580,6 +1628,22 @@ namespace bgfx
 		return size;
 	}
 
+	int32_t toString(char* _out, int32_t _size, uint8_t _mask, const char *prefix = "")
+	{
+		int32_t size = 0;
+
+		size += bx::snprintf(&_out[size], bx::uint32_imax(0, _size-size)
+					, "%s%s%s%s%s"
+					, prefix
+					, 0 == (_mask & 1) ? "" : "x"
+					, 0 == (_mask & 2) ? "" : "y"
+					, 0 == (_mask & 4) ? "" : "z"
+					, 0 == (_mask & 8) ? "" : "w"
+					);
+
+		return size;
+	}
+
 	int32_t toString(char* _out, int32_t _size, DxbcOperandMode::Enum _mode, uint8_t _modeBits)
 	{
 		int32_t size = 0;
@@ -1590,13 +1654,7 @@ namespace bgfx
 			if (0xf > _modeBits
 			&&  0   < _modeBits)
 			{
-				size += bx::snprintf(&_out[size], bx::uint32_imax(0, _size-size)
-							, ".%s%s%s%s"
-							, 0 == (_modeBits & 1) ? "" : "x"
-							, 0 == (_modeBits & 2) ? "" : "y"
-							, 0 == (_modeBits & 4) ? "" : "z"
-							, 0 == (_modeBits & 8) ? "" : "w"
-							);
+				size += toString(&_out[size], bx::uint32_imax(0, _size-size), _modeBits, ".");
 			}
 			break;
 
@@ -1623,6 +1681,26 @@ namespace bgfx
 		default:
 			break;
 		}
+
+		return size;
+	}
+
+	int32_t toString(char* _out, int32_t _size, const DxbcSignature::Element& _element)
+	{
+		int32_t size = 0;
+
+		size += bx::snprintf(&_out[size], bx::uint32_imax(0, _size-size)
+					, "%12s i%d r%d s%x %12s %s"
+					, _element.name.c_str()
+					, _element.semanticIndex
+					, _element.registerIndex
+					, _element.stream
+					, toString(_element.valueType)
+					, s_dxbcComponentType[_element.componentType]
+					);
+
+		size += toString(&_out[size], bx::uint32_imax(0, _size-size), _element.mask, " ");
+		size += toString(&_out[size], bx::uint32_imax(0, _size-size), _element.readWriteMask, " ");
 
 		return size;
 	}
@@ -1826,7 +1904,7 @@ namespace bgfx
 		return size;
 	}
 
-	int32_t read(bx::ReaderSeekerI* _reader, DxbcSignature& _signature, bx::Error* _err)
+	int32_t read(bx::ReaderSeekerI* _reader, DxbcSignature& _signature, bool _readStream, bx::Error* _err)
 	{
 		int32_t size = 0;
 
@@ -1839,6 +1917,15 @@ namespace bgfx
 		for (uint32_t ii = 0; ii < num; ++ii)
 		{
 			DxbcSignature::Element element;
+
+			if (_readStream)
+			{
+				size += bx::read(_reader, element.stream, _err);
+			}
+			else
+			{
+				element.stream = 0;
+			}
 
 			uint32_t nameOffset;
 			size += bx::read(_reader, nameOffset, _err);
@@ -1853,10 +1940,9 @@ namespace bgfx
 			size += bx::read(_reader, element.registerIndex, _err);
 			size += bx::read(_reader, element.mask, _err);
 			size += bx::read(_reader, element.readWriteMask, _err);
-			size += bx::read(_reader, element.stream, _err);
 
 			// padding
-			uint8_t padding;
+			uint16_t padding;
 			size += bx::read(_reader, padding, _err);
 
 			_signature.elements.push_back(element);
@@ -1865,7 +1951,7 @@ namespace bgfx
 		return size;
 	}
 
-	int32_t write(bx::WriterI* _writer, const DxbcSignature& _signature, bx::Error* _err)
+	int32_t write(bx::WriterI* _writer, const DxbcSignature& _signature, bool _writeStream, bx::Error* _err)
 	{
 		int32_t size = 0;
 
@@ -1876,11 +1962,20 @@ namespace bgfx
 		typedef stl::unordered_map<stl::string, uint32_t> NameOffsetMap;
 		NameOffsetMap nom;
 
-		const uint8_t pad = 0;
+		const uint16_t pad = 0;
 		uint32_t nameOffset = num * 24 + 8;
+		if (_writeStream)
+		{
+			nameOffset += 4;
+		}
 		for (uint32_t ii = 0; ii < num; ++ii)
 		{
 			const DxbcSignature::Element& element = _signature.elements[ii];
+
+			if (_writeStream)
+			{
+				size += bx::write(_writer, element.stream, _err);
+			}
 
 			NameOffsetMap::iterator it = nom.find(element.name);
 			if (it == nom.end() )
@@ -1900,7 +1995,6 @@ namespace bgfx
 			size += bx::write(_writer, element.registerIndex, _err);
 			size += bx::write(_writer, element.mask, _err);
 			size += bx::write(_writer, element.readWriteMask, _err);
-			size += bx::write(_writer, element.stream, _err);
 			size += bx::write(_writer, pad, _err);
 		}
 
@@ -1999,13 +2093,16 @@ namespace bgfx
 
 			case BX_MAKEFOURCC('I', 'S', 'G', '1'):
 			case DXBC_CHUNK_INPUT_SIGNATURE:
-				size += read(_reader, _dxbc.inputSignature, _err);
+				size += read(_reader, _dxbc.inputSignature, false, _err);
 				break;
 
-			case BX_MAKEFOURCC('O', 'S', 'G', '1'):
-			case BX_MAKEFOURCC('O', 'S', 'G', '5'):
+			case BX_MAKEFOURCC( 'O', 'S', 'G', '1' ):
 			case DXBC_CHUNK_OUTPUT_SIGNATURE:
-				size += read(_reader, _dxbc.outputSignature, _err);
+				size += read(_reader, _dxbc.outputSignature, false, _err);
+				break;
+
+			case BX_MAKEFOURCC( 'O', 'S', 'G', '5' ):
+				size += read(_reader, _dxbc.outputSignature, true, _err);
 				break;
 
 			case BX_MAKEFOURCC('A', 'o', 'n', '9'): // Contains DX9BC for feature level 9.x (*s_4_0_level_9_*) shaders.
@@ -2119,19 +2216,26 @@ namespace bgfx
 			case BX_MAKEFOURCC('I', 'S', 'G', '1'):
 			case DXBC_CHUNK_INPUT_SIGNATURE:
 				chunkOffset[idx] = uint32_t(bx::seek(_writer) - dxbcOffset);
-				size += bx::write(_writer, DXBC_CHUNK_INPUT_SIGNATURE, _err);
+				size += bx::write(_writer, _dxbc.chunksFourcc[ii], _err);
 				size += bx::write(_writer, UINT32_C(0), _err);
-				chunkSize[idx] = write(_writer, _dxbc.inputSignature, _err);
+				chunkSize[idx] = write(_writer, _dxbc.inputSignature, false, _err);
 				size += chunkSize[idx++];
 				break;
 
 			case BX_MAKEFOURCC('O', 'S', 'G', '1'):
-			case BX_MAKEFOURCC('O', 'S', 'G', '5'):
 			case DXBC_CHUNK_OUTPUT_SIGNATURE:
 				chunkOffset[idx] = uint32_t(bx::seek(_writer) - dxbcOffset);
-				size += bx::write(_writer, DXBC_CHUNK_OUTPUT_SIGNATURE, _err);
+				size += bx::write(_writer, _dxbc.chunksFourcc[ii], _err);
 				size += bx::write(_writer, UINT32_C(0), _err);
-				chunkSize[idx] = write(_writer, _dxbc.outputSignature, _err);
+				chunkSize[idx] = write(_writer, _dxbc.outputSignature, false, _err);
+				size += chunkSize[idx++];
+				break;
+
+			case BX_MAKEFOURCC( 'O', 'S', 'G', '5' ):
+				chunkOffset[idx] = uint32_t(bx::seek(_writer) - dxbcOffset);
+				size += bx::write(_writer, _dxbc.chunksFourcc[ii], _err);
+				size += bx::write(_writer, UINT32_C(0), _err);
+				chunkSize[idx] = write(_writer, _dxbc.outputSignature, true, _err);
 				size += chunkSize[idx++];
 				break;
 

--- a/src/shader_dxbc.cpp
+++ b/src/shader_dxbc.cpp
@@ -108,17 +108,17 @@ namespace bgfx
 		{ 1, 0 }, // DCL_CONSTANT_BUFFER
 		{ 1, 0 }, // DCL_SAMPLER
 		{ 1, 1 }, // DCL_INDEX_RANGE
-		{ 1, 0 }, // DCL_GS_OUTPUT_PRIMITIVE_TOPOLOGY
-		{ 1, 0 }, // DCL_GS_INPUT_PRIMITIVE
+		{ 0, 0 }, // DCL_GS_OUTPUT_PRIMITIVE_TOPOLOGY
+		{ 0, 0 }, // DCL_GS_INPUT_PRIMITIVE
 		{ 0, 1 }, // DCL_MAX_OUTPUT_VERTEX_COUNT
 		{ 1, 0 }, // DCL_INPUT
 		{ 1, 1 }, // DCL_INPUT_SGV
-		{ 1, 0 }, // DCL_INPUT_SIV
+		{ 1, 1 }, // DCL_INPUT_SIV
 		{ 1, 0 }, // DCL_INPUT_PS
 		{ 1, 1 }, // DCL_INPUT_PS_SGV
 		{ 1, 1 }, // DCL_INPUT_PS_SIV
 		{ 1, 0 }, // DCL_OUTPUT
-		{ 1, 0 }, // DCL_OUTPUT_SGV
+		{ 1, 1 }, // DCL_OUTPUT_SGV
 		{ 1, 1 }, // DCL_OUTPUT_SIV
 		{ 0, 1 }, // DCL_TEMPS
 		{ 0, 3 }, // DCL_INDEXABLE_TEMP
@@ -135,8 +135,8 @@ namespace bgfx
 		{ 0, 0 }, // HS_CONTROL_POINT_PHASE
 		{ 0, 0 }, // HS_FORK_PHASE
 		{ 0, 0 }, // HS_JOIN_PHASE
-		{ 0, 0 }, // EMIT_STREAM
-		{ 0, 0 }, // CUT_STREAM
+		{ 1, 0 }, // EMIT_STREAM
+		{ 1, 0 }, // CUT_STREAM
 		{ 1, 0 }, // EMITTHENCUT_STREAM
 		{ 1, 0 }, // INTERFACE_CALL
 		{ 0, 0 }, // BUFINFO
@@ -161,7 +161,7 @@ namespace bgfx
 		{ 5, 0 }, // BFI
 		{ 0, 0 }, // BFREV
 		{ 5, 0 }, // SWAPC
-		{ 0, 0 }, // DCL_STREAM
+		{ 1, 0 }, // DCL_STREAM
 		{ 1, 0 }, // DCL_FUNCTION_BODY
 		{ 0, 0 }, // DCL_FUNCTION_TABLE
 		{ 0, 0 }, // DCL_INTERFACE
@@ -502,6 +502,69 @@ namespace bgfx
 		"linear noperspective sample",
 	};
 	BX_STATIC_ASSERT(BX_COUNTOF(s_dxbcInterpolationName) == DxbcInterpolation::Count);
+
+	const char *s_dxbcPrimitiveTopologyName[] =
+	{
+		"",
+		"PointList",
+		"LineList",
+		"LineStrip",
+		"TriangleList",
+		"TriangleStrip",
+		"",
+		"",
+		"",
+		"",
+		"LineListAdj",
+		"LineStripAdj",
+		"TriangleListAdj",
+		"TriangleStripAdj",
+	};
+	BX_STATIC_ASSERT(BX_COUNTOF(s_dxbcPrimitiveTopologyName) == DxbcPrimitiveTopology::Count);
+
+	const char *s_dxbcPrimitiveName[] = {
+		"",
+		"Point",
+		"Line",
+		"Triangle",
+		"",
+		"",
+		"LineAdj",
+		"TriangleAdj",
+		"_1ControlPointPatch",
+		"_2ControlPointPatch",
+		"_3ControlPointPatch",
+		"_4ControlPointPatch",
+		"_5ControlPointPatch",
+		"_6ControlPointPatch",
+		"_7ControlPointPatch",
+		"_8ControlPointPatch",
+		"_9ControlPointPatch",
+		"_10ControlPointPatch",
+		"_11ControlPointPatch",
+		"_12ControlPointPatch",
+		"_13ControlPointPatch",
+		"_14ControlPointPatch",
+		"_15ControlPointPatch",
+		"_16ControlPointPatch",
+		"_17ControlPointPatch",
+		"_18ControlPointPatch",
+		"_19ControlPointPatch",
+		"_20ControlPointPatch",
+		"_21ControlPointPatch",
+		"_22ControlPointPatch",
+		"_23ControlPointPatch",
+		"_24ControlPointPatch",
+		"_25ControlPointPatch",
+		"_26ControlPointPatch",
+		"_27ControlPointPatch",
+		"_28ControlPointPatch",
+		"_29ControlPointPatch",
+		"_30ControlPointPatch",
+		"_31ControlPointPatch",
+		"_32ControlPointPatch",
+	};
+	BX_STATIC_ASSERT(BX_COUNTOF(s_dxbcPrimitiveName) == DxbcPrimitive::Count);
 
 	// mesa/src/gallium/state_trackers/d3d1x/d3d1xshader/defs/shortfiles.txt
 	static const char* s_dxbcOperandType[] =
@@ -1149,7 +1212,26 @@ namespace bgfx
 				_instruction.enableShaderExtensions = 0 != (token & UINT32_C(0x00040000) );
 				break;
 
-			case DxbcOpcode::DCL_INPUT_PS:
+			case DxbcOpcode::DCL_GS_INPUT_PRIMITIVE:
+				// 0       1       2       3
+				// 76543210765432107654321076543210
+				// ........       pppppp...........
+				//                ^----------------- Primitive
+
+				_instruction.primitive = DxbcPrimitive::Enum( (token & UINT32_C(0x0001f800) ) >> 11);
+				break;
+
+			case DxbcOpcode::DCL_GS_OUTPUT_PRIMITIVE_TOPOLOGY:
+				// 0       1       2       3
+				// 76543210765432107654321076543210
+				// ........       pppppp...........
+				//                ^----------------- Primitive Topology
+
+				_instruction.primitiveTopology = DxbcPrimitiveTopology::Enum( (token & UINT32_C(0x0001f800) ) >> 11);
+				break;
+
+			case DxbcOpcode::DCL_INPUT_PS: BX_FALLTHROUGH;
+			case DxbcOpcode::DCL_INPUT_PS_SIV:
 				// 0       1       2       3
 				// 76543210765432107654321076543210
 				// ........        iiiii...........
@@ -1381,7 +1463,16 @@ namespace bgfx
 				token |= _instruction.enableShaderExtensions ? UINT32_C(0x00040000) : 0;
 				break;
 
-			case DxbcOpcode::DCL_INPUT_PS:
+			case DxbcOpcode::DCL_GS_INPUT_PRIMITIVE:
+				token |= (_instruction.primitive << 11) & UINT32_C(0x0001f800);
+				break;
+
+			case DxbcOpcode::DCL_GS_OUTPUT_PRIMITIVE_TOPOLOGY:
+				token |= (_instruction.primitiveTopology << 11) & UINT32_C(0x0001f800);
+				break;
+
+			case DxbcOpcode::DCL_INPUT_PS: BX_FALLTHROUGH;
+			case DxbcOpcode::DCL_INPUT_PS_SIV:
 				token |= (_instruction.interpolation << 11) & UINT32_C(0x0000f800);
 				break;
 
@@ -1546,6 +1637,22 @@ namespace bgfx
 			size += bx::snprintf(&_out[size], bx::uint32_imax(0, _size-size)
 						, "%s"
 						, s_dxbcCustomDataClass[_instruction.customDataClass]
+						);
+			break;
+
+		case DxbcOpcode::DCL_GS_OUTPUT_PRIMITIVE_TOPOLOGY:
+			size += bx::snprintf(&_out[size], bx::uint32_imax(0, _size-size)
+						, "%s %s"
+						, getName(_instruction.opcode)
+						, s_dxbcPrimitiveTopologyName[_instruction.primitiveTopology]
+						);
+			break;
+
+		case DxbcOpcode::DCL_GS_INPUT_PRIMITIVE:
+			size += bx::snprintf(&_out[size], bx::uint32_imax(0, _size-size)
+						, "%s %s"
+						, getName(_instruction.opcode)
+						, s_dxbcPrimitiveName[_instruction.primitive]
 						);
 			break;
 

--- a/src/shader_dxbc.h
+++ b/src/shader_dxbc.h
@@ -685,17 +685,18 @@ namespace bgfx
 			DxbcBuiltin::Enum valueType;
 			DxbcComponentType::Enum componentType;
 			uint32_t registerIndex;
+			uint32_t stream;
 			uint8_t mask;
 			uint8_t readWriteMask;
-			uint8_t stream;
 		};
 
 		uint32_t key;
 		stl::vector<Element> elements;
 	};
 
-	int32_t read(bx::ReaderSeekerI* _reader, DxbcSignature& _signature, bx::Error* _err);
-	int32_t write(bx::WriterI* _writer, const DxbcSignature& _signature, bx::Error* _err);
+	int32_t read(bx::ReaderSeekerI* _reader, DxbcSignature& _signature, bool _readStream, bx::Error* _err);
+	int32_t write(bx::WriterI* _writer, const DxbcSignature& _signature, bool _writeStream, bx::Error* _err);
+	int32_t toString(char* _out, int32_t _size, const DxbcSignature::Element& _element);
 
 	struct DxbcShader
 	{

--- a/src/shader_dxbc.h
+++ b/src/shader_dxbc.h
@@ -326,6 +326,72 @@ namespace bgfx
 		};
 	};
 
+	struct DxbcPrimitiveTopology
+	{
+		enum Enum
+		{
+			Unknown,
+			PointList,
+			LineList,
+			LineStrip,
+			TriangleList,
+			TriangleStrip,
+			LineListAdj = 10,
+			LineStripAdj,
+			TriangleListAdj,
+			TriangleStripAdj,
+
+			Count
+		};
+	};
+
+	struct DxbcPrimitive
+	{
+		enum Enum
+		{
+			Unknown,
+			Point,
+			Line,
+			Triangle,
+			LineAdj = 6,
+			TriangleAdj,
+			_1ControlPointPatch,
+			_2ControlPointPatch,
+			_3ControlPointPatch,
+			_4ControlPointPatch,
+			_5ControlPointPatch,
+			_6ControlPointPatch,
+			_7ControlPointPatch,
+			_8ControlPointPatch,
+			_9ControlPointPatch,
+			_10ControlPointPatch,
+			_11ControlPointPatch,
+			_12ControlPointPatch,
+			_13ControlPointPatch,
+			_14ControlPointPatch,
+			_15ControlPointPatch,
+			_16ControlPointPatch,
+			_17ControlPointPatch,
+			_18ControlPointPatch,
+			_19ControlPointPatch,
+			_20ControlPointPatch,
+			_21ControlPointPatch,
+			_22ControlPointPatch,
+			_23ControlPointPatch,
+			_24ControlPointPatch,
+			_25ControlPointPatch,
+			_26ControlPointPatch,
+			_27ControlPointPatch,
+			_28ControlPointPatch,
+			_29ControlPointPatch,
+			_30ControlPointPatch,
+			_31ControlPointPatch,
+			_32ControlPointPatch,
+
+			Count
+		};
+	};
+
 	struct DxbcResourceReturnType
 	{
 		enum Enum
@@ -560,6 +626,12 @@ namespace bgfx
 
 		//
 		DxbcInterpolation::Enum interpolation;
+
+		//
+		DxbcPrimitiveTopology::Enum primitiveTopology;
+
+		//
+		DxbcPrimitive::Enum primitive;
 
 		//
 		bool shadow;


### PR DESCRIPTION
Fixes #2709

Note: d3d11TokenizedProgramFormat.hpp claims DCL_GS_OUTPUT_PRIMITIVE_TOPOLOGY uses bits [17:11] for PRIMITIVE_TOPOLOGY, but then defines the mask of 0x0001f800.  DCL_GS_INPUT_PRIMITIVE uses bits [16:11] with the same mask.  It's unclear if the comment or the code for DCL_GS_OUTPUT_PRIMITIVE_TOPOLOGY is correct here, but since the enum values fit in the smaller mask, I deferred to the code.