### PR TITLE
Fix various typos

### DIFF
--- a/bindings/bf/bgfx.bf
+++ b/bindings/bf/bgfx.bf
@@ -3658,7 +3658,7 @@ public static class bgfx
 	
 	/// <summary>
 	/// Reserve matrices in internal matrix cache.
-	/// @attention Pointer returned can be modifed until `bgfx::frame` is called.
+	/// @attention Pointer returned can be modified until `bgfx::frame` is called.
 	/// </summary>
 	///
 	/// <param name="_transform">Pointer to `Transform` structure.</param>
@@ -3777,7 +3777,7 @@ public static class bgfx
 	public static extern void encoder_set_transient_vertex_buffer_with_layout(Encoder* _this, uint8 _stream, TransientVertexBuffer* _tvb, uint32 _startVertex, uint32 _numVertices, VertexLayoutHandle _layoutHandle);
 	
 	/// <summary>
-	/// Set number of vertices for auto generated vertices use in conjuction
+	/// Set number of vertices for auto generated vertices use in conjunction
 	/// with gl_VertexID.
 	/// @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	/// </summary>
@@ -3821,7 +3821,7 @@ public static class bgfx
 	public static extern void encoder_set_instance_data_from_dynamic_vertex_buffer(Encoder* _this, DynamicVertexBufferHandle _handle, uint32 _startVertex, uint32 _num);
 	
 	/// <summary>
-	/// Set number of instances for auto generated instances use in conjuction
+	/// Set number of instances for auto generated instances use in conjunction
 	/// with gl_InstanceID.
 	/// @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	/// </summary>
@@ -4206,7 +4206,7 @@ public static class bgfx
 	
 	/// <summary>
 	/// Reserve matrices in internal matrix cache.
-	/// @attention Pointer returned can be modifed until `bgfx::frame` is called.
+	/// @attention Pointer returned can be modified until `bgfx::frame` is called.
 	/// </summary>
 	///
 	/// <param name="_transform">Pointer to `Transform` structure.</param>
@@ -4335,7 +4335,7 @@ public static class bgfx
 	public static extern void set_transient_vertex_buffer_with_layout(uint8 _stream, TransientVertexBuffer* _tvb, uint32 _startVertex, uint32 _numVertices, VertexLayoutHandle _layoutHandle);
 	
 	/// <summary>
-	/// Set number of vertices for auto generated vertices use in conjuction
+	/// Set number of vertices for auto generated vertices use in conjunction
 	/// with gl_VertexID.
 	/// @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	/// </summary>
@@ -4379,7 +4379,7 @@ public static class bgfx
 	public static extern void set_instance_data_from_dynamic_vertex_buffer(DynamicVertexBufferHandle _handle, uint32 _startVertex, uint32 _num);
 	
 	/// <summary>
-	/// Set number of instances for auto generated instances use in conjuction
+	/// Set number of instances for auto generated instances use in conjunction
 	/// with gl_InstanceID.
 	/// @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	/// </summary>

--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -3615,7 +3615,7 @@ public static partial class bgfx
 	
 	/// <summary>
 	/// Reserve matrices in internal matrix cache.
-	/// @attention Pointer returned can be modifed until `bgfx::frame` is called.
+	/// @attention Pointer returned can be modified until `bgfx::frame` is called.
 	/// </summary>
 	///
 	/// <param name="_transform">Pointer to `Transform` structure.</param>
@@ -3734,7 +3734,7 @@ public static partial class bgfx
 	public static extern unsafe void encoder_set_transient_vertex_buffer_with_layout(Encoder* _this, byte _stream, TransientVertexBuffer* _tvb, uint _startVertex, uint _numVertices, VertexLayoutHandle _layoutHandle);
 	
 	/// <summary>
-	/// Set number of vertices for auto generated vertices use in conjuction
+	/// Set number of vertices for auto generated vertices use in conjunction
 	/// with gl_VertexID.
 	/// @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	/// </summary>
@@ -3778,7 +3778,7 @@ public static partial class bgfx
 	public static extern unsafe void encoder_set_instance_data_from_dynamic_vertex_buffer(Encoder* _this, DynamicVertexBufferHandle _handle, uint _startVertex, uint _num);
 	
 	/// <summary>
-	/// Set number of instances for auto generated instances use in conjuction
+	/// Set number of instances for auto generated instances use in conjunction
 	/// with gl_InstanceID.
 	/// @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	/// </summary>
@@ -4163,7 +4163,7 @@ public static partial class bgfx
 	
 	/// <summary>
 	/// Reserve matrices in internal matrix cache.
-	/// @attention Pointer returned can be modifed until `bgfx::frame` is called.
+	/// @attention Pointer returned can be modified until `bgfx::frame` is called.
 	/// </summary>
 	///
 	/// <param name="_transform">Pointer to `Transform` structure.</param>
@@ -4292,7 +4292,7 @@ public static partial class bgfx
 	public static extern unsafe void set_transient_vertex_buffer_with_layout(byte _stream, TransientVertexBuffer* _tvb, uint _startVertex, uint _numVertices, VertexLayoutHandle _layoutHandle);
 	
 	/// <summary>
-	/// Set number of vertices for auto generated vertices use in conjuction
+	/// Set number of vertices for auto generated vertices use in conjunction
 	/// with gl_VertexID.
 	/// @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	/// </summary>
@@ -4336,7 +4336,7 @@ public static partial class bgfx
 	public static extern unsafe void set_instance_data_from_dynamic_vertex_buffer(DynamicVertexBufferHandle _handle, uint _startVertex, uint _num);
 	
 	/// <summary>
-	/// Set number of instances for auto generated instances use in conjuction
+	/// Set number of instances for auto generated instances use in conjunction
 	/// with gl_InstanceID.
 	/// @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	/// </summary>

--- a/bindings/d/funcs.d
+++ b/bindings/d/funcs.d
@@ -1329,7 +1329,7 @@ version(BindBgfx_Static)
 	
 	/**
 	 * Reserve matrices in internal matrix cache.
-	 * Attention: Pointer returned can be modifed until `bgfx::frame` is called.
+	 * Attention: Pointer returned can be modified until `bgfx::frame` is called.
 	 * Params:
 	 * _transform = Pointer to `Transform` structure.
 	 * _num = Number of matrices.
@@ -1432,7 +1432,7 @@ version(BindBgfx_Static)
 	void bgfx_encoder_set_transient_vertex_buffer_with_layout(bgfx_encoder_t* _this, byte _stream, const(bgfx_transient_vertex_buffer_t)* _tvb, uint _startVertex, uint _numVertices, bgfx_vertex_layout_handle_t _layoutHandle);
 	
 	/**
-	 * Set number of vertices for auto generated vertices use in conjuction
+	 * Set number of vertices for auto generated vertices use in conjunction
 	 * with gl_VertexID.
 	 * Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	 * Params:
@@ -1469,7 +1469,7 @@ version(BindBgfx_Static)
 	void bgfx_encoder_set_instance_data_from_dynamic_vertex_buffer(bgfx_encoder_t* _this, bgfx_dynamic_vertex_buffer_handle_t _handle, uint _startVertex, uint _num);
 	
 	/**
-	 * Set number of instances for auto generated instances use in conjuction
+	 * Set number of instances for auto generated instances use in conjunction
 	 * with gl_InstanceID.
 	 * Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	 */
@@ -1820,7 +1820,7 @@ version(BindBgfx_Static)
 	
 	/**
 	 * Reserve matrices in internal matrix cache.
-	 * Attention: Pointer returned can be modifed until `bgfx::frame` is called.
+	 * Attention: Pointer returned can be modified until `bgfx::frame` is called.
 	 * Params:
 	 * _transform = Pointer to `Transform` structure.
 	 * _num = Number of matrices.
@@ -1934,7 +1934,7 @@ version(BindBgfx_Static)
 	void bgfx_set_transient_vertex_buffer_with_layout(byte _stream, const(bgfx_transient_vertex_buffer_t)* _tvb, uint _startVertex, uint _numVertices, bgfx_vertex_layout_handle_t _layoutHandle);
 	
 	/**
-	 * Set number of vertices for auto generated vertices use in conjuction
+	 * Set number of vertices for auto generated vertices use in conjunction
 	 * with gl_VertexID.
 	 * Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	 * Params:
@@ -1971,7 +1971,7 @@ version(BindBgfx_Static)
 	void bgfx_set_instance_data_from_dynamic_vertex_buffer(bgfx_dynamic_vertex_buffer_handle_t _handle, uint _startVertex, uint _num);
 	
 	/**
-	 * Set number of instances for auto generated instances use in conjuction
+	 * Set number of instances for auto generated instances use in conjunction
 	 * with gl_InstanceID.
 	 * Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 	 */
@@ -3589,7 +3589,7 @@ else
 		
 		/**
 		 * Reserve matrices in internal matrix cache.
-		 * Attention: Pointer returned can be modifed until `bgfx::frame` is called.
+		 * Attention: Pointer returned can be modified until `bgfx::frame` is called.
 		 * Params:
 		 * _transform = Pointer to `Transform` structure.
 		 * _num = Number of matrices.
@@ -3703,7 +3703,7 @@ else
 		da_bgfx_encoder_set_transient_vertex_buffer_with_layout bgfx_encoder_set_transient_vertex_buffer_with_layout;
 		
 		/**
-		 * Set number of vertices for auto generated vertices use in conjuction
+		 * Set number of vertices for auto generated vertices use in conjunction
 		 * with gl_VertexID.
 		 * Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 		 * Params:
@@ -3744,7 +3744,7 @@ else
 		da_bgfx_encoder_set_instance_data_from_dynamic_vertex_buffer bgfx_encoder_set_instance_data_from_dynamic_vertex_buffer;
 		
 		/**
-		 * Set number of instances for auto generated instances use in conjuction
+		 * Set number of instances for auto generated instances use in conjunction
 		 * with gl_InstanceID.
 		 * Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 		 */
@@ -4125,7 +4125,7 @@ else
 		
 		/**
 		 * Reserve matrices in internal matrix cache.
-		 * Attention: Pointer returned can be modifed until `bgfx::frame` is called.
+		 * Attention: Pointer returned can be modified until `bgfx::frame` is called.
 		 * Params:
 		 * _transform = Pointer to `Transform` structure.
 		 * _num = Number of matrices.
@@ -4250,7 +4250,7 @@ else
 		da_bgfx_set_transient_vertex_buffer_with_layout bgfx_set_transient_vertex_buffer_with_layout;
 		
 		/**
-		 * Set number of vertices for auto generated vertices use in conjuction
+		 * Set number of vertices for auto generated vertices use in conjunction
 		 * with gl_VertexID.
 		 * Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 		 * Params:
@@ -4291,7 +4291,7 @@ else
 		da_bgfx_set_instance_data_from_dynamic_vertex_buffer bgfx_set_instance_data_from_dynamic_vertex_buffer;
 		
 		/**
-		 * Set number of instances for auto generated instances use in conjuction
+		 * Set number of instances for auto generated instances use in conjunction
 		 * with gl_InstanceID.
 		 * Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 		 */

--- a/bindings/d/types.d
+++ b/bindings/d/types.d
@@ -858,7 +858,7 @@ struct bgfx_init_t
 	 */
 	ushort deviceId;
 	ulong capabilities; /// Capabilities initialization mask (default: UINT64_MAX).
-	bool debug_; /// Enable device for debuging.
+	bool debug_; /// Enable device for debugging.
 	bool profile; /// Enable device for profiling.
 	bgfx_platform_data_t platformData; /// Platform data.
 	bgfx_resolution_t resolution; /// Backbuffer resolution and reset parameters. See: `bgfx::Resolution`.

--- a/examples/13-stencil/stencil.cpp
+++ b/examples/13-stencil/stencil.cpp
@@ -777,7 +777,7 @@ struct Mesh
 			// Submit
 			bgfx::submit(_id, _program);
 
-			// Keep track of submited view ids
+			// Keep track of submitted view ids
 			s_viewMask |= 1 << _id;
 		}
 	}

--- a/examples/14-shadowvolumes/shadowvolumes.cpp
+++ b/examples/14-shadowvolumes/shadowvolumes.cpp
@@ -548,7 +548,7 @@ void submit(bgfx::ViewId _id, bgfx::ProgramHandle _handle, int32_t _depth = 0)
 {
 	bgfx::submit(_id, _handle, _depth);
 
-	// Keep track of submited view ids.
+	// Keep track of submitted view ids.
 	s_viewMask |= 1 << _id;
 }
 

--- a/examples/23-vectordisplay/vectordisplay.h
+++ b/examples/23-vectordisplay/vectordisplay.h
@@ -64,10 +64,10 @@ public:
 	// Set the number of frames of decay/fade to apply to the scene.
 	bool setDecaySteps(int _steps);
 
-	// Set the brightness multipler applied on each decay frame after the first.
+	// Set the brightness multiplier applied on each decay frame after the first.
 	bool setDecay(float _decay);
 
-	// Set the brightness multipler applied on the first decay frame.
+	// Set the brightness multiplier applied on the first decay frame.
 	bool setInitialDecay(float _initialDecay);
 
 	// Set a 2d transformation for the display.

--- a/examples/30-picking/picking.cpp
+++ b/examples/30-picking/picking.cpp
@@ -54,7 +54,7 @@ public:
 			, 0
 			);
 
-		// ID buffer clears to black, which represnts clicking on nothing (background)
+		// ID buffer clears to black, which represents clicking on nothing (background)
 		bgfx::setViewClear(RENDER_PASS_ID
 			, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH
 			, 0x000000ff

--- a/examples/31-rsm/reflectiveshadowmap.cpp
+++ b/examples/31-rsm/reflectiveshadowmap.cpp
@@ -353,8 +353,8 @@ public:
 				, BGFX_TEXTURE_RT /* | BGFX_SAMPLER_COMPARE_LEQUAL*/
 				);  // Note I'm not setting BGFX_SAMPLER_COMPARE_LEQUAL.  Why?
 					// Normally a PCF shadow map such as this requires a compare.  However, this sample also
-					// reads from this texture in the lighting pass, and only uses the PCF capabilites in the
-					// combine pass, so the flag is disabled by default.
+					// reads from this texture in the lighting pass, and only uses the PCF capabilities in
+					// the combine pass, so the flag is disabled by default.
 
 		m_shadowBuffer = bgfx::createFrameBuffer(BX_COUNTOF(m_shadowBufferTex), m_shadowBufferTex, true);
 

--- a/examples/36-sky/sky.cpp
+++ b/examples/36-sky/sky.cpp
@@ -69,7 +69,7 @@ namespace
 		-0.49853f,   0.041556f,  1.057311f,
 	};
 
-	// Converts color repesentation from CIE XYZ to RGB color-space.
+	// Converts color representation from CIE XYZ to RGB color-space.
 	Color xyzToRgb(const Color& xyz)
 	{
 		Color rgb(bx::init::None);

--- a/examples/41-tess/tess.cpp
+++ b/examples/41-tess/tess.cpp
@@ -641,7 +641,7 @@ namespace
 		* Load the Terrain Program
 		*
 		* This program renders an adaptive terrain using the implicit subdivision
-		* technique discribed in GPU Zen 2.
+		* technique described in GPU Zen 2.
 		**/
 		void loadPrograms()
 		{

--- a/examples/42-bunnylod/progmesh.c
+++ b/examples/42-bunnylod/progmesh.c
@@ -495,7 +495,7 @@ Collapse(struct mesh *M, int uid, int vid) {
 static struct vertex *
 MinimumCostEdge(struct mesh *M) {
 	// Find the edge that when collapsed will affect model the least.
-	// This funtion actually returns a Vertex, the second vertex
+	// This function actually returns a Vertex, the second vertex
 	// of the edge (collapse candidate) is stored in the vertex data.
 	// Serious optimization opportunity here: this function currently
 	// does a sequential search through an unsorted Array :-(

--- a/examples/43-denoise/denoise.cpp
+++ b/examples/43-denoise/denoise.cpp
@@ -823,7 +823,7 @@ public:
 				ImGui::Combo("spatial sample extent", &m_spatialSampleType, "three\0five\0\0");
 				if (ImGui::IsItemHovered() )
 				{
-					ImGui::SetTooltip("select 3x3 or 5x5 filter kernal");
+					ImGui::SetTooltip("select 3x3 or 5x5 filter kernel");
 				}
 
 				ImGui::SliderFloat("sigma z", &m_sigmaDepth, 0.0f, 0.1f, "%.5f");
@@ -1061,7 +1061,7 @@ public:
 	// Shader uniforms
 	Uniforms m_uniforms;
 
-	// Uniforms to indentify texture samplers
+	// Uniforms to identify texture samplers
 	bgfx::UniformHandle s_albedo;
 	bgfx::UniformHandle s_color;
 	bgfx::UniformHandle s_normal;

--- a/examples/44-sss/screen_space_shadows.cpp
+++ b/examples/44-sss/screen_space_shadows.cpp
@@ -787,7 +787,7 @@ public:
 	// Shader uniforms
 	Uniforms m_uniforms;
 
-	// Uniforms to indentify texture samplers
+	// Uniforms to identify texture samplers
 	bgfx::UniformHandle s_albedo;
 	bgfx::UniformHandle s_color;
 	bgfx::UniformHandle s_normal;

--- a/examples/45-bokeh/bokeh.cpp
+++ b/examples/45-bokeh/bokeh.cpp
@@ -993,7 +993,7 @@ public:
 	PassUniforms m_uniforms;
 	ModelUniforms m_modelUniforms;
 
-	// Uniforms to indentify texture samplers
+	// Uniforms to identify texture samplers
 	bgfx::UniformHandle s_albedo;
 	bgfx::UniformHandle s_color;
 	bgfx::UniformHandle s_normal;

--- a/examples/46-fsr/app.cpp
+++ b/examples/46-fsr/app.cpp
@@ -179,7 +179,7 @@ namespace
 		// Shader uniforms
 		ModelUniforms m_modelUniforms;
 
-		// Uniforms to indentify texture samplers
+		// Uniforms to identify texture samplers
 		bgfx::UniformHandle s_albedo;
 		bgfx::UniformHandle s_color;
 		bgfx::UniformHandle s_normal;

--- a/examples/46-fsr/ffx_a.h
+++ b/examples/46-fsr/ffx_a.h
@@ -50,7 +50,7 @@
 // A_GLSL .... Using GLSL.
 // A_HLSL .... Using HLSL.
 // A_HLSL_6_2  Using HLSL 6.2 with new 'uint16_t' and related types (requires '-enable-16bit-types').
-// A_NO_16_BIT_CAST Don't use instructions that are not availabe in SPIR-V (needed for running A_HLSL_6_2 on Vulkan)
+// A_NO_16_BIT_CAST Don't use instructions that are not available in SPIR-V (needed for running A_HLSL_6_2 on Vulkan)
 // A_GCC ..... Using a GCC compatible compiler (else assume MSVC compatible compiler by default).
 // =======
 // A_BYTE .... Support 8-bit integer.
@@ -2118,7 +2118,7 @@
 //  (b.) For 8-bit  709, steps {0 to 20.7} are in the linear region (8% of the encoding range).
 // Also there is a slight step in the transition regions.
 // Precision of the coefficients in the spec being the likely cause.
-// Main usage case of the sRGB code is to do the linear->sRGB converstion in a compute shader before store.
+// Main usage case of the sRGB code is to do the linear->sRGB conversion in a compute shader before store.
 // This is to work around lack of hardware (typically only ROP does the conversion for free).
 // To "correct" the linear segment, would be to introduce error, because hardware decode of sRGB->linear is fixed (and free).
 // So this header keeps with the spec.

--- a/examples/46-fsr/ffx_fsr1.h
+++ b/examples/46-fsr/ffx_fsr1.h
@@ -68,7 +68,7 @@
 //
 //------------------------------------------------------------------------------------------------------------------------------
 // EASU provides a high quality spatial-only scaling at relatively low cost.
-// Meaning EASU is appropiate for laptops and other low-end GPUs.
+// Meaning EASU is appropriate for laptops and other low-end GPUs.
 // Quality from 1x to 4x area scaling is good.
 //------------------------------------------------------------------------------------------------------------------------------
 // The scalar uses a modified fast approximation to the standard lanczos(size=2) kernel.

--- a/examples/46-fsr/fsr.cpp
+++ b/examples/46-fsr/fsr.cpp
@@ -213,7 +213,7 @@ struct FsrResources
 	// Shader uniforms
 	Uniforms m_uniforms;
 
-	// Uniforms to indentify texture samplers
+	// Uniforms to identify texture samplers
 	bgfx::UniformHandle s_inputTexture = BGFX_INVALID_HANDLE;
 
 };

--- a/examples/common/font/font_manager.h
+++ b/examples/common/font/font_manager.h
@@ -181,7 +181,7 @@ public:
 	/// @remark the handle is required to be valid
 	const FontInfo& getFontInfo(FontHandle _handle) const;
 
-	/// Return the rendering informations about the glyph region. Load the
+	/// Return the rendering information about the glyph region. Load the
 	/// glyph from a TrueType font if possible
 	///
 	const GlyphInfo* getGlyphInfo(FontHandle _handle, CodePoint _codePoint);

--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -422,7 +422,7 @@ namespace bgfx
 		virtual ~CallbackI() = 0;
 
 		/// This callback is called on unrecoverable errors.
-		/// It's not safe to continue (Exluding _code `Fatal::DebugCheck`),
+		/// It's not safe to continue (Excluding _code `Fatal::DebugCheck`),
 		/// inform the user and terminate the application.
 		///
 		/// @param[in] _filePath File path where fatal message was generated.
@@ -665,7 +665,7 @@ namespace bgfx
 
 		uint64_t capabilities; //!< Capabilities initialization mask (default: UINT64_MAX).
 
-		bool debug;   //!< Enable device for debuging.
+		bool debug;   //!< Enable device for debugging.
 		bool profile; //!< Enable device for profiling.
 
 		/// Platform data.
@@ -1135,7 +1135,7 @@ namespace bgfx
 		/// @param[in] _num Number of matrices.
 		/// @returns Index into matrix cache.
 		///
-		/// @attention Pointer returned can be modifed until `bgfx::frame` is called.
+		/// @attention Pointer returned can be modified until `bgfx::frame` is called.
 		/// @attention C99 equivalent is `bgfx_encoder_alloc_transform`.
 		///
 		uint32_t allocTransform(
@@ -1329,7 +1329,7 @@ namespace bgfx
 			, VertexLayoutHandle _layoutHandle = BGFX_INVALID_HANDLE
 			);
 
-		/// Set number of vertices for auto generated vertices use in conjuction
+		/// Set number of vertices for auto generated vertices use in conjunction
 		/// with gl_VertexID.
 		///
 		/// @param[in] _numVertices Number of vertices.
@@ -1389,7 +1389,7 @@ namespace bgfx
 			, uint32_t _num
 			);
 
-		/// Set number of instances for auto generated instances use in conjuction
+		/// Set number of instances for auto generated instances use in conjunction
 		/// with gl_InstanceID.
 		///
 		/// @param[in] _numInstances Number of instances.
@@ -3586,7 +3586,7 @@ namespace bgfx
 	/// @param[in] _num Number of matrices.
 	/// @returns index into matrix cache.
 	///
-	/// @attention Pointer returned can be modifed until `bgfx::frame` is called.
+	/// @attention Pointer returned can be modified until `bgfx::frame` is called.
 	/// @attention C99 equivalent is `bgfx_alloc_transform`.
 	///
 	uint32_t allocTransform(
@@ -3780,7 +3780,7 @@ namespace bgfx
 		, VertexLayoutHandle _layoutHandle = BGFX_INVALID_HANDLE
 		);
 
-	/// Set number of vertices for auto generated vertices use in conjuction
+	/// Set number of vertices for auto generated vertices use in conjunction
 	/// with gl_VertexID.
 	///
 	/// @param[in] _numVertices Number of vertices.
@@ -3840,7 +3840,7 @@ namespace bgfx
 		, uint32_t _num
 		);
 
-	/// Set number of instances for auto generated instances use in conjuction
+	/// Set number of instances for auto generated instances use in conjunction
 	/// with gl_InstanceID.
 	///
 	/// @param[in] _numInstances Number of instances.

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -670,7 +670,7 @@ typedef struct bgfx_init_s
      */
     uint16_t             deviceId;
     uint64_t             capabilities;       /** Capabilities initialization mask (default: UINT64_MAX). */
-    bool                 debug;              /** Enable device for debuging.              */
+    bool                 debug;              /** Enable device for debugging.             */
     bool                 profile;            /** Enable device for profiling.             */
     bgfx_platform_data_t platformData;       /** Platform data.                           */
     bgfx_resolution_t    resolution;         /** Backbuffer resolution and reset parameters. See: `bgfx::Resolution`. */
@@ -2436,7 +2436,7 @@ BGFX_C_API void bgfx_encoder_set_transform_cached(bgfx_encoder_t* _this, uint32_
 
 /**
  * Reserve matrices in internal matrix cache.
- * @attention Pointer returned can be modifed until `bgfx::frame` is called.
+ * @attention Pointer returned can be modified until `bgfx::frame` is called.
  *
  * @param[out] _transform Pointer to `Transform` structure.
  * @param[in] _num Number of matrices.
@@ -2550,7 +2550,7 @@ BGFX_C_API void bgfx_encoder_set_transient_vertex_buffer(bgfx_encoder_t* _this, 
 BGFX_C_API void bgfx_encoder_set_transient_vertex_buffer_with_layout(bgfx_encoder_t* _this, uint8_t _stream, const bgfx_transient_vertex_buffer_t* _tvb, uint32_t _startVertex, uint32_t _numVertices, bgfx_vertex_layout_handle_t _layoutHandle);
 
 /**
- * Set number of vertices for auto generated vertices use in conjuction
+ * Set number of vertices for auto generated vertices use in conjunction
  * with gl_VertexID.
  * @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
  *
@@ -2591,7 +2591,7 @@ BGFX_C_API void bgfx_encoder_set_instance_data_from_vertex_buffer(bgfx_encoder_t
 BGFX_C_API void bgfx_encoder_set_instance_data_from_dynamic_vertex_buffer(bgfx_encoder_t* _this, bgfx_dynamic_vertex_buffer_handle_t _handle, uint32_t _startVertex, uint32_t _num);
 
 /**
- * Set number of instances for auto generated instances use in conjuction
+ * Set number of instances for auto generated instances use in conjunction
  * with gl_InstanceID.
  * @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
  *
@@ -2987,7 +2987,7 @@ BGFX_C_API void bgfx_set_transform_cached(uint32_t _cache, uint16_t _num);
 
 /**
  * Reserve matrices in internal matrix cache.
- * @attention Pointer returned can be modifed until `bgfx::frame` is called.
+ * @attention Pointer returned can be modified until `bgfx::frame` is called.
  *
  * @param[out] _transform Pointer to `Transform` structure.
  * @param[in] _num Number of matrices.
@@ -3114,7 +3114,7 @@ BGFX_C_API void bgfx_set_transient_vertex_buffer(uint8_t _stream, const bgfx_tra
 BGFX_C_API void bgfx_set_transient_vertex_buffer_with_layout(uint8_t _stream, const bgfx_transient_vertex_buffer_t* _tvb, uint32_t _startVertex, uint32_t _numVertices, bgfx_vertex_layout_handle_t _layoutHandle);
 
 /**
- * Set number of vertices for auto generated vertices use in conjuction
+ * Set number of vertices for auto generated vertices use in conjunction
  * with gl_VertexID.
  * @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
  *
@@ -3155,7 +3155,7 @@ BGFX_C_API void bgfx_set_instance_data_from_vertex_buffer(bgfx_vertex_buffer_han
 BGFX_C_API void bgfx_set_instance_data_from_dynamic_vertex_buffer(bgfx_dynamic_vertex_buffer_handle_t _handle, uint32_t _startVertex, uint32_t _num);
 
 /**
- * Set number of instances for auto generated instances use in conjuction
+ * Set number of instances for auto generated instances use in conjunction
  * with gl_InstanceID.
  * @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
  *

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -800,7 +800,7 @@ struct.Init { ctor }
 	.deviceId       "uint16_t"            --- Device id. If set to 0 it will select first device, or device with
 	                                      --- matching id.
 	.capabilities   "uint64_t"            --- Capabilities initialization mask (default: UINT64_MAX).
-	.debug          "bool"                --- Enable device for debuging.
+	.debug          "bool"                --- Enable device for debugging.
 	.profile        "bool"                --- Enable device for profiling.
 	.platformData   "PlatformData"        --- Platform data.
 	.resolution     "Resolution"          --- Backbuffer resolution and reset parameters. See: `bgfx::Resolution`.
@@ -2204,7 +2204,7 @@ func.Encoder.setTransform { cname = "set_transform_cached" }
 
 --- Reserve matrices in internal matrix cache.
 ---
---- @attention Pointer returned can be modifed until `bgfx::frame` is called.
+--- @attention Pointer returned can be modified until `bgfx::frame` is called.
 ---
 func.Encoder.allocTransform
 	"uint32_t"                      --- Index in matrix cache.
@@ -2333,7 +2333,7 @@ func.Encoder.setVertexBuffer { cname = "set_transient_vertex_buffer_with_layout"
 	                                             --- of vertex buffer will be used.
 	 { default = "BGFX_INVALID_HANDLE" }
 
---- Set number of vertices for auto generated vertices use in conjuction
+--- Set number of vertices for auto generated vertices use in conjunction
 --- with gl_VertexID.
 ---
 --- @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
@@ -2378,7 +2378,7 @@ func.Encoder.setInstanceDataBuffer { cname = "set_instance_data_from_dynamic_ver
 	.startVertex "uint32_t"                  --- First instance data.
 	.num         "uint32_t"                  --- Number of data instances.
 
---- Set number of instances for auto generated instances use in conjuction
+--- Set number of instances for auto generated instances use in conjunction
 --- with gl_InstanceID.
 ---
 --- @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
@@ -2757,7 +2757,7 @@ func.setTransform { cname = "set_transform_cached" }
 
 --- Reserve matrices in internal matrix cache.
 ---
---- @attention Pointer returned can be modifed until `bgfx::frame` is called.
+--- @attention Pointer returned can be modified until `bgfx::frame` is called.
 ---
 func.allocTransform
 	"uint32_t"                      --- Index in matrix cache.
@@ -2888,7 +2888,7 @@ func.setVertexBuffer { cname = "set_transient_vertex_buffer_with_layout" }
 	                                            --- of vertex buffer will be used.
 	 { default = "BGFX_INVALID_HANDLE" }
 
---- Set number of vertices for auto generated vertices use in conjuction
+--- Set number of vertices for auto generated vertices use in conjunction
 --- with gl_VertexID.
 ---
 --- @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.
@@ -2933,7 +2933,7 @@ func.setInstanceDataBuffer { cname = "set_instance_data_from_dynamic_vertex_buff
 	.startVertex "uint32_t"                  --- First instance data.
 	.num         "uint32_t"                  --- Number of data instances.
 
---- Set number of instances for auto generated instances use in conjuction
+--- Set number of instances for auto generated instances use in conjunction
 --- with gl_InstanceID.
 ---
 --- @attention Availability depends on: `BGFX_CAPS_VERTEX_ID`.

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -203,7 +203,7 @@ end
 if _OPTIONS["with-sdl"] then
 	if os.is("windows") then
 		if not os.getenv("SDL2_DIR") then
-			print("Set SDL2_DIR enviroment variable.")
+			print("Set SDL2_DIR environment variable.")
 		end
 	end
 end

--- a/src/glcontext_nsgl.mm
+++ b/src/glcontext_nsgl.mm
@@ -238,7 +238,7 @@ namespace bgfx { namespace gl
 			GLint interval = 0;
 			[glContext setValues:&interval forParameter:NSOpenGLCPSwapInterval];
 
-			// When initializing NSOpenGLView programatically (as we are), this sometimes doesn't
+			// When initializing NSOpenGLView programmatically (as we are), this sometimes doesn't
 			// get hooked up properly (especially when there are existing window elements). This ensures
 			// we are valid. Otherwise, you'll probably get a GL_INVALID_FRAMEBUFFER_OPERATION when
 			// trying to glClear() for the first time.

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4978,7 +4978,7 @@ VK_DESTROY
 
 		bx::read(&reader, m_size, &err);
 
-		// fill binding description with uniform informations
+		// fill binding description with uniform information
 		uint16_t bidx = 0;
 		if (m_size > 0)
 		{

--- a/src/shader_dxbc.cpp
+++ b/src/shader_dxbc.cpp
@@ -1153,7 +1153,7 @@ namespace bgfx
 				// 0       1       2       3
 				// 76543210765432107654321076543210
 				// ........        iiiii...........
-				//                 ^---------------- Interploation
+				//                 ^---------------- Interpolation
 
 				_instruction.interpolation = DxbcInterpolation::Enum( (token & UINT32_C(0x0000f800) ) >> 11);
 				break;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./3rdparty,*.ttf -L attribut,ba,clude,conly,indext,inout,lod,nclude,retur,utput`