### PR TITLE
Imgui fixes

### DIFF
--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -175,7 +175,7 @@ struct OcornutImguiContext
 
 						encoder->setState(state);
 						encoder->setTexture(0, s_tex, th);
-						encoder->setVertexBuffer(0, &tvb, 0, numVertices);
+						encoder->setVertexBuffer(0, &tvb, cmd->VtxOffset, numVertices);
 						encoder->setIndexBuffer(&tib, cmd->IdxOffset, cmd->ElemCount);
 						encoder->submit(m_viewId, program);
 					}
@@ -211,6 +211,8 @@ struct OcornutImguiContext
 		io.IniFilename = NULL;
 
 		setupStyle(true);
+
+		io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;
 
 #if USE_ENTRY
 		io.KeyMap[ImGuiKey_Tab]        = (int)entry::Key::Tab;

--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -117,7 +117,6 @@ struct OcornutImguiContext
 
 			bgfx::Encoder* encoder = bgfx::begin();
 
-			uint32_t offset = 0;
 			for (const ImDrawCmd* cmd = drawList->CmdBuffer.begin(), *cmdEnd = drawList->CmdBuffer.end(); cmd != cmdEnd; ++cmd)
 			{
 				if (cmd->UserCallback)
@@ -177,12 +176,10 @@ struct OcornutImguiContext
 						encoder->setState(state);
 						encoder->setTexture(0, s_tex, th);
 						encoder->setVertexBuffer(0, &tvb, 0, numVertices);
-						encoder->setIndexBuffer(&tib, offset, cmd->ElemCount);
+						encoder->setIndexBuffer(&tib, cmd->IdxOffset, cmd->ElemCount);
 						encoder->submit(m_viewId, program);
 					}
 				}
-
-				offset += cmd->ElemCount;
 			}
 
 			bgfx::end(encoder);

--- a/examples/common/imgui/imgui.cpp
+++ b/examples/common/imgui/imgui.cpp
@@ -400,6 +400,7 @@ struct OcornutImguiContext
 		io.KeyShift = 0 != (modifiers & (entry::Modifier::LeftShift | entry::Modifier::RightShift) );
 		io.KeyCtrl  = 0 != (modifiers & (entry::Modifier::LeftCtrl  | entry::Modifier::RightCtrl ) );
 		io.KeyAlt   = 0 != (modifiers & (entry::Modifier::LeftAlt   | entry::Modifier::RightAlt  ) );
+		io.KeySuper = 0 != (modifiers & (entry::Modifier::LeftMeta  | entry::Modifier::RightMeta ) );
 		for (int32_t ii = 0; ii < (int32_t)entry::Key::Count; ++ii)
 		{
 			io.KeysDown[ii] = inputGetKeyState(entry::Key::Enum(ii) );


### PR DESCRIPTION
A few minor fixes for the ImGui backend:

- Meta/Cmd/Super/Windows key modifier state is passed to ImGui (if entry is used)
- fixed a bug with incorrect index offset calculation, see https://github.com/ocornut/imgui/issues/4863
- added support for per-draw vertex offset, makes it possible to render > 65k vertices even with 16-bit index buffer (https://github.com/ocornut/imgui/issues/2591)