### PR TITLE
Added `textureCube` macro for GLSL  >= 130.

### DIFF
--- a/src/bgfx_shader.sh
+++ b/src/bgfx_shader.sh
@@ -608,6 +608,7 @@ vec4  mod(vec4  _a, vec4  _b) { return _a - _b * floor(_a / _b); }
 #		define texture2D(_sampler, _coord)      texture(_sampler, _coord)
 #		define texture2DArray(_sampler, _coord) texture(_sampler, _coord)
 #		define texture3D(_sampler, _coord)      texture(_sampler, _coord)
+#		define textureCube(_sampler, _coord)    texture(_sampler, _coord)
 #		define texture2DLod(_sampler, _coord, _lod)                textureLod(_sampler, _coord, _lod)
 #		define texture2DLodOffset(_sampler, _coord, _lod, _offset) textureLodOffset(_sampler, _coord, _lod, _offset)
 #	endif // BGFX_SHADER_LANGUAGE_GLSL >= 130


### PR DESCRIPTION
In order to sample a `SAMPLERCUBE`, `textureCube` in GLSL >= 130 requires extension `GL_NV_shadow_samplers_cube`. However, the all-purpose `texture` will sample it.

Change suggested by user `kib`, on the Discord channel, after a problem sampling a cube reported by myself and another user (pinsrq).