### PR TITLE
Updated D bindings: enums expanded; added some C++ pre-processor functions

### DIFF
--- a/bindings/d/types.d
+++ b/bindings/d/types.d
@@ -8,11 +8,44 @@ module bindbc.bgfx.types;
 
 public import core.stdc.stdarg : va_list;
 
+enum expandEnum(EnumType, string fqnEnumType = EnumType.stringof) = (){
+	string expandEnum;
+	foreach(m; __traits(allMembers, EnumType)){
+		expandEnum ~= "alias " ~ m ~ " = " ~ fqnEnumType ~ "." ~ m ~ ";";
+	}
+	return expandEnum;
+}();
+
 extern(C) @nogc nothrow:
 
 enum uint BGFX_API_VERSION = 115;
 
 alias bgfx_view_id_t = ushort;
+
+//NOTE: TEMPORARY fix to some missing preprocessor function-macros...
+static BGFX_STATE_BLEND_FUNC_SEPARATE(ulong _srcRGB, ulong _dstRGB, ulong _srcA, ulong _dstA){
+	return (0UL
+			| ( ( cast(ulong)_srcRGB | ( cast(ulong)_dstRGB<<4) )   )
+			| ( ( cast(ulong)_srcA   | ( cast(ulong)_dstA  <<4) )<<8)
+		);
+}
+
+/// Blend equation separate.
+static BGFX_STATE_BLEND_EQUATION_SEPARATE(ulong _equationRGB, ulong _equationA){ return ( cast(ulong)_equationRGB | (cast(ulong)_equationA<<3) ); }
+
+/// Blend function.
+static BGFX_STATE_BLEND_FUNC(ulong _src, ulong _dst){ return BGFX_STATE_BLEND_FUNC_SEPARATE(_src, _dst, _src, _dst); }
+
+/// Blend equation.
+static BGFX_STATE_BLEND_EQUATION(ulong _equation){ return BGFX_STATE_BLEND_EQUATION_SEPARATE(_equation, _equation); }
+
+/// Utility predefined blend modes.
+
+/// Additive blending.
+static BGFX_STATE_BLEND_ADD(){ return (0 | BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE)); }
+
+/// Alpha blend.
+static BGFX_STATE_BLEND_ALPHA(){ return (0 | BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_SRC_ALPHA, BGFX_STATE_BLEND_INV_SRC_ALPHA)); }
 
 /// Memory release callback.
 
@@ -424,6 +457,7 @@ enum bgfx_fatal_t
 
 	BGFX_FATAL_COUNT
 }
+mixin(expandEnum!bgfx_fatal_t);
 
 /// Renderer backend type enum.
 enum bgfx_renderer_type_t
@@ -443,6 +477,7 @@ enum bgfx_renderer_type_t
 
 	BGFX_RENDERER_TYPE_COUNT
 }
+mixin(expandEnum!bgfx_renderer_type_t);
 
 /// Access mode enum.
 enum bgfx_access_t
@@ -453,6 +488,7 @@ enum bgfx_access_t
 
 	BGFX_ACCESS_COUNT
 }
+mixin(expandEnum!bgfx_access_t);
 
 /// Vertex attribute enum.
 enum bgfx_attrib_t
@@ -478,6 +514,7 @@ enum bgfx_attrib_t
 
 	BGFX_ATTRIB_COUNT
 }
+mixin(expandEnum!bgfx_attrib_t);
 
 /// Vertex attribute type enum.
 enum bgfx_attrib_type_t
@@ -490,6 +527,7 @@ enum bgfx_attrib_type_t
 
 	BGFX_ATTRIB_TYPE_COUNT
 }
+mixin(expandEnum!bgfx_attrib_type_t);
 
 /**
  * Texture format enum.
@@ -595,6 +633,7 @@ enum bgfx_texture_format_t
 
 	BGFX_TEXTURE_FORMAT_COUNT
 }
+mixin(expandEnum!bgfx_texture_format_t);
 
 /// Uniform type enum.
 enum bgfx_uniform_type_t
@@ -607,6 +646,7 @@ enum bgfx_uniform_type_t
 
 	BGFX_UNIFORM_TYPE_COUNT
 }
+mixin(expandEnum!bgfx_uniform_type_t);
 
 /// Backbuffer ratio enum.
 enum bgfx_backbuffer_ratio_t
@@ -620,6 +660,7 @@ enum bgfx_backbuffer_ratio_t
 
 	BGFX_BACKBUFFER_RATIO_COUNT
 }
+mixin(expandEnum!bgfx_backbuffer_ratio_t);
 
 /// Occlusion query result.
 enum bgfx_occlusion_query_result_t
@@ -630,6 +671,7 @@ enum bgfx_occlusion_query_result_t
 
 	BGFX_OCCLUSION_QUERY_RESULT_COUNT
 }
+mixin(expandEnum!bgfx_occlusion_query_result_t);
 
 /// Primitive topology.
 enum bgfx_topology_t
@@ -642,6 +684,7 @@ enum bgfx_topology_t
 
 	BGFX_TOPOLOGY_COUNT
 }
+mixin(expandEnum!bgfx_topology_t);
 
 /// Topology conversion function.
 enum bgfx_topology_convert_t
@@ -654,6 +697,7 @@ enum bgfx_topology_convert_t
 
 	BGFX_TOPOLOGY_CONVERT_COUNT
 }
+mixin(expandEnum!bgfx_topology_convert_t);
 
 /// Topology sort order.
 enum bgfx_topology_sort_t
@@ -673,6 +717,7 @@ enum bgfx_topology_sort_t
 
 	BGFX_TOPOLOGY_SORT_COUNT
 }
+mixin(expandEnum!bgfx_topology_sort_t);
 
 /// View mode sets draw call sort order.
 enum bgfx_view_mode_t
@@ -684,6 +729,7 @@ enum bgfx_view_mode_t
 
 	BGFX_VIEW_MODE_COUNT
 }
+mixin(expandEnum!bgfx_view_mode_t);
 
 /// Render frame enum.
 enum bgfx_render_frame_t
@@ -695,6 +741,7 @@ enum bgfx_render_frame_t
 
 	BGFX_RENDER_FRAME_COUNT
 }
+mixin(expandEnum!bgfx_render_frame_t);
 
 /// GPU info.
 struct bgfx_caps_gpu_t

--- a/scripts/bindings-d.lua
+++ b/scripts/bindings-d.lua
@@ -12,11 +12,44 @@ module bindbc.bgfx.types;
 
 public import core.stdc.stdarg : va_list;
 
+enum expandEnum(EnumType, string fqnEnumType = EnumType.stringof) = (){
+	string expandEnum;
+	foreach(m; __traits(allMembers, EnumType)){
+		expandEnum ~= "alias " ~ m ~ " = " ~ fqnEnumType ~ "." ~ m ~ ";";
+	}
+	return expandEnum;
+}();
+
 extern(C) @nogc nothrow:
 
 $version
 
 alias bgfx_view_id_t = ushort;
+
+//NOTE: TEMPORARY fix to some missing preprocessor function-macros...
+static BGFX_STATE_BLEND_FUNC_SEPARATE(ulong _srcRGB, ulong _dstRGB, ulong _srcA, ulong _dstA){
+	return (0UL
+			| ( ( cast(ulong)_srcRGB | ( cast(ulong)_dstRGB<<4) )   )
+			| ( ( cast(ulong)_srcA   | ( cast(ulong)_dstA  <<4) )<<8)
+		);
+}
+
+/// Blend equation separate.
+static BGFX_STATE_BLEND_EQUATION_SEPARATE(ulong _equationRGB, ulong _equationA){ return ( cast(ulong)_equationRGB | (cast(ulong)_equationA<<3) ); }
+
+/// Blend function.
+static BGFX_STATE_BLEND_FUNC(ulong _src, ulong _dst){ return BGFX_STATE_BLEND_FUNC_SEPARATE(_src, _dst, _src, _dst); }
+
+/// Blend equation.
+static BGFX_STATE_BLEND_EQUATION(ulong _equation){ return BGFX_STATE_BLEND_EQUATION_SEPARATE(_equation, _equation); }
+
+/// Utility predefined blend modes.
+
+/// Additive blending.
+static BGFX_STATE_BLEND_ADD(){ return (0 | BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE)); }
+
+/// Alpha blend.
+static BGFX_STATE_BLEND_ALPHA(){ return (0 | BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_SRC_ALPHA, BGFX_STATE_BLEND_INV_SRC_ALPHA)); }
 
 $types
 ]]
@@ -231,6 +264,7 @@ function converter.types(typ)
 		--yield("\t" .. prefix .. "_COUNT = " .. #typ.enum)
 		yield("\t" .. prefix .. "_COUNT")
 		yield("}")
+		yield("mixin(expandEnum!" .. typ.cname .. ");")
 
 	elseif typ.bits ~= nil then
 		local prefix = "BGFX_" .. to_underscorecase(typ.name):upper()


### PR DESCRIPTION
Previously, using any typed enums meant also putting the enum type name:
`bgfx_texture_format_t.BGFX_TEXTURE_FORMAT_RGBA8`
The way the enums are named makes this redundant, so I've added a string mixin to remedy the issue. Thus, enums can now be used the same way as in C:
`BGFX_TEXTURE_FORMAT_RGBA8`

This method of manually adding pre-processor functions is temporary and should eventually be fully-automated. For now though, more people can easily use them.