### PR TITLE
Fix resource register macro expansion in shaders

### DIFF
--- a/src/bgfx_shader.sh
+++ b/src/bgfx_shader.sh
@@ -52,7 +52,7 @@
 
 // To be able to patch the uav registers on the DXBC SPDB Chunk (D3D11 renderer) the whitespaces around
 // '_type[_reg]' are necessary. This only affects shaders with debug info (i.e., those that have the SPDB Chunk).
-#	if BGFX_SHADER_LANGUAGE_HLSL > 400
+#	if BGFX_SHADER_LANGUAGE_HLSL > 400 || BGFX_SHADER_LANGUAGE_PSSL || BGFX_SHADER_LANGUAGE_SPIRV || BGFX_SHADER_LANGUAGE_METAL
 #		define REGISTER(_type, _reg) register( _type[_reg] )
 #	else
 #		define REGISTER(_type, _reg) register(_type ## _reg)


### PR DESCRIPTION
Fixes issues with shader code like this:

```glsl
#define MY_SAMPLER 2
SAMPLER2D(s_texColor, MY_SAMPLER)
```

fcpp (C preprocessor used by shaderc) doesn't handle macro expansion with `##`, even with the usual shenanigans involving another macro doing the expansion. I've tried finding a fix in fcpp but wasn't very successful, hence this workaround.

Note that:
- the bug only affected shader targets (internally) using HLSL, ie. DX, Metal, VK
- the fix only works for DX with target SM > 3, ie. DX10 and up (no such limitation for Metal or VK)
- I verified with DX11/12/VK by modifying example 21-deferred shaders to use macros as above and recompiling