### PR TITLE
Fixes for shader texture array in GLES3

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6476,9 +6476,10 @@ namespace bgfx { namespace gl
 					if (m_type == GL_FRAGMENT_SHADER)
 					{
 						bx::write(&writer
-							, "#define varying       in\n"
-							  "#define texture2D     texture\n"
-							  "#define texture2DProj textureProj\n"
+							, "#define varying        in\n"
+							  "#define texture2D      texture\n"
+							  "#define texture2DArray texture\n"
+							  "#define texture2DProj  textureProj\n"
 							, &err
 							);
 

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -2372,6 +2372,11 @@ namespace bgfx
 										bx::stringPrintf(code, "precision highp int;\n");
 									}
 
+									if (glsl_profile >= 300)
+									{
+										bx::stringPrintf(code, "precision highp sampler2DArray;\n");
+									}
+
 									// Pretend that all extensions are available.
 									// This will be stripped later.
 									if (usesTextureLod)


### PR DESCRIPTION
On android with GLES3, shaders using texture2d arrays will complain that there is no precision for `sampler2DArray` and that `texture2DArray` does not exist.

Tested on Android Emulator with GLES3 and on Linux with OpenGL