### PR TITLE
bugfix and rename mergeIndices()

### DIFF
--- a/examples/42-bunnylod/bunnylod.cpp
+++ b/examples/42-bunnylod/bunnylod.cpp
@@ -65,15 +65,13 @@ public:
 		}
 	}
 
-	static void mergeIndices(uint32_t* _indices, uint32_t _num)
+	static void rearrangeIndices(uint32_t* _indices, uint32_t _num)
 	{
 		uint32_t target = 0;
 		for (uint32_t i = 0; i < _num; i++) {
 			uint32_t map = _indices[i];
-			while (_indices[map] != map)
-				map = _indices[map];
 			if (i != map) {
-				_indices[i] = map;
+				_indices[i] = _indices[map];
 			} else {
 				_indices[i] = target;
 				++target;
@@ -153,7 +151,7 @@ public:
 			m_cacheWeld = (uint32_t*)BX_ALLOC(entry::getAllocator(), numVertices * sizeof(uint32_t) );
 
 			m_totalVertices	= bgfx::weldVertices(m_cacheWeld, _mesh->m_layout, vbData, numVertices, true, 0.00001f);
-			mergeIndices(m_cacheWeld, numVertices);
+			rearrangeIndices(m_cacheWeld, numVertices);
 		}
 
 		const bgfx::Memory* vb = mergeVertices(


### PR DESCRIPTION
Sorry, there is still a bug in https://github.com/bkaradzic/bgfx/pull/2769 . Fixed it.

And rename mergeIndices() to rearrangeIndices() .

The details about `rearrangeIndices()` :

The original indices are

```
0 1 2 3 4 5 3 4 6
```

If `bgfx:weldVertices()` merge vertex 3 to 1, an 4 to 2 , the indices would be

```
0 1 2 1 2 5 1 2 6
```

`rearrangeIndices()` rearrange these indices to

```
0 1 2 1 2 3 1 2 4
```

(5 to 3, 6 to 4)


