### PR TITLE
fix image is not set in pipeline state object in metal renderer

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -2016,19 +2016,21 @@ namespace bgfx { namespace mtl
 						else if (arg.type == MTLArgumentTypeTexture)
 						{
 							const char* name = utf8String(arg.name);
-							const UniformRegInfo* info = s_renderMtl->m_uniformReg.find(name);
-							BX_WARN(NULL != info, "User defined uniform '%s' is not found, it won't be set.", name);
-
-							if (NULL != info)
+							if (arg.index >= BGFX_CONFIG_MAX_TEXTURE_SAMPLERS)
 							{
-								if (arg.index >= BGFX_CONFIG_MAX_TEXTURE_SAMPLERS)
+								BX_WARN(false, "Binding index is too large %d max is %d. User defined uniform '%s' won't be set.", int(arg.index), BGFX_CONFIG_MAX_TEXTURE_SAMPLERS - 1, name);
+							}
+							else
+							{
+								ps->m_bindingTypes[arg.index] = fragmentBit ? PipelineStateMtl::BindToFragmentShader : PipelineStateMtl::BindToVertexShader;
+								const UniformRegInfo* info = s_renderMtl->m_uniformReg.find(name);
+								if (info)
 								{
-									BX_WARN(false, "Binding index is too large %d max is %d. User defined uniform '%s' won't be set.", int(arg.index), BGFX_CONFIG_MAX_TEXTURE_SAMPLERS - 1, name);
+									BX_TRACE("texture %s %d index:%d", name, info->m_handle, uint32_t(arg.index) );
 								}
 								else
 								{
-									ps->m_bindingTypes[arg.index] = fragmentBit ? PipelineStateMtl::BindToFragmentShader : PipelineStateMtl::BindToVertexShader;
-									BX_TRACE("texture %s %d index:%d", name, info->m_handle, uint32_t(arg.index) );
+									BX_TRACE("image %s index:%d", name, info->m_handle, uint32_t(arg.index) );
 								}
 							}
 						}

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -2030,7 +2030,7 @@ namespace bgfx { namespace mtl
 								}
 								else
 								{
-									BX_TRACE("image %s index:%d", name, info->m_handle, uint32_t(arg.index) );
+									BX_TRACE("image %s index:%d", name, uint32_t(arg.index) );
 								}
 							}
 						}


### PR DESCRIPTION
If I declare an image in compute shader, that image will failed to set in the bind type of the pipeline state object:

https://github.com/bkaradzic/bgfx/blob/master/src/renderer_mtl.mm#L2022

because image object does not get from shader as uniforms. This check will cause 'ps->m_bindTypes' not be set.

I try to work around this by create an uniform with the same name as I declare in compute shader. But I think metal renderer should not assume the reflection argument type as 'MTLArgumentTypeTexture' must be texture.

This fix related to this issue:
https://github.com/bkaradzic/bgfx/issues/2778