### PR TITLE
GL: Properly reset FBO after emulated blit

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -7182,7 +7182,7 @@ namespace bgfx { namespace gl
 					) );
 
 				GL_CHECK(glDeleteFramebuffers(1, &fbo) );
-				GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, 0) );
+				GL_CHECK(glBindFramebuffer(GL_FRAMEBUFFER, m_currentFbo) );
 			}
 		}
 	}


### PR DESCRIPTION
Rebind the previously bound FBO after rendering an emulated blit instead
of going back to the default FBO.