### PR TITLE
Changed WGL_STENCIL_BITS_ARB to match what gets used in createContext

### DIFF
--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -201,7 +201,7 @@ namespace bgfx { namespace gl
 					WGL_ALPHA_BITS_ARB,     8,
 					WGL_COLOR_BITS_ARB,     32,
 					WGL_DEPTH_BITS_ARB,     24,
-					WGL_STENCIL_BITS_ARB,   0,
+					WGL_STENCIL_BITS_ARB,   8,
 
 					WGL_PIXEL_TYPE_ARB,     WGL_TYPE_RGBA_ARB,
 					WGL_SAMPLES_ARB,        0,


### PR DESCRIPTION
On Mesa, the pixel format would match the 0 stencil bits as requested. This change helps bring the pixel format to match what `createContext` would use. Issue can be easily reproduced by enabling Mesa software rasterization and running example-13-stencil, specifically the `Projection Shadows Scene`. 