### PR TITLE
Compute kSortKeyViewNumBits automatically.

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -953,7 +953,7 @@ namespace bgfx
 	};
 
 	//
-	constexpr uint8_t  kSortKeyViewNumBits         = 10;
+	constexpr uint8_t  kSortKeyViewNumBits         = 31 - bx::uint32_cntlz(BGFX_CONFIG_MAX_VIEWS);
 	constexpr uint8_t  kSortKeyViewBitShift        = 64-kSortKeyViewNumBits;
 	constexpr uint64_t kSortKeyViewMask            = uint64_t(BGFX_CONFIG_MAX_VIEWS-1)<<kSortKeyViewBitShift;
 


### PR DESCRIPTION
Compute kSortKeyViewNumBits automatically via log2(BGFX_CONFIG_MAX_VIEWS), so that we could change BGFX_CONFIG_MAX_VIEWS to be above 2^10 = 1024 without changing the `bgfx` source code..

One possible problem with this approach is running out of bits, so maybe we could assert for that, I am not sure where to do it and how many bits we can use though.

Using `bx::uint32_cntlz` because `bx::log2` is not constexpr.

Tested on linux opengl2.1 with BGFX_CONFIG_MAX_VIEWS=4096, seems to work.