### PR TITLE
Update nanovg_bgfx.cpp, check Transient Vertex Buffer available size before allocating

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -762,12 +762,21 @@ namespace
 
 		if (gl->ncalls > 0)
 		{
+			int avail = bgfx::getAvailTransientVertexBuffer(gl->nverts, s_nvgLayout);
+			if (avail < gl->nverts)
+				{
+				gl->nverts = avail;
+				BX_WARN(true, "Vertex number truncated due to transient vertex buffer overflow");
+				if (gl->nverts < 2)
+					goto _cleanup;
+				}
 			bgfx::allocTransientVertexBuffer(&gl->tvb, gl->nverts, s_nvgLayout);
 
 			int allocated = gl->tvb.size/gl->tvb.stride;
 
 			if (allocated < gl->nverts)
 			{
+				// this branch should never be taken as we've already checked the transient vertex buffer size
 				gl->nverts = allocated;
 				BX_WARN(true, "Vertex number truncated due to transient vertex buffer overflow");
 			}
@@ -806,6 +815,7 @@ namespace
 		}
 
 		// Reset calls
+		_cleanup:
 		gl->nverts    = 0;
 		gl->npaths    = 0;
 		gl->ncalls    = 0;


### PR DESCRIPTION
Fix the transient vertex buffer's overflow assert being fired. Now if the tvb is overflowed a warning is emitted and the draw is skipped