### PR TITLE
Increase the buffer size if necessary before adding markers

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2378,6 +2378,7 @@ namespace bgfx
 
 		void setMarker(const char* _name)
 		{
+			UniformBuffer::update(&m_frame->m_uniformBuffer[m_uniformIdx]);
 			UniformBuffer* uniformBuffer = m_frame->m_uniformBuffer[m_uniformIdx];
 			uniformBuffer->writeMarker(_name);
 		}


### PR DESCRIPTION
Adding markers will sometimes crash because the buffer is too small for the new marker. The function that adds new markers does not try to increase the size of the buffer before adding the marker. This PR makes it so that the buffer will be increased in size if it is getting close to capacity, just like when adding a uniform.