### PR TITLE
Fix typos

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -52,7 +52,7 @@ Download AndroidNDK:
 
  - https://developer.android.com/tools/sdk/ndk/index.html
 
-Set following enironment variables:
+Set following environment variables:
 
 ::
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -231,7 +231,7 @@ Shadow volumes.
 60Hz
 ^^^^
 
-Draw stress is CPU stress test to show what is the maximimum number of
+Draw stress is CPU stress test to show what is the maximum number of
 draw calls while maintaining 60Hz frame rate. bgfx currently has default
 limit of 64K draw calls per frame. You can increase this limit by
 changing ``BGFX_CONFIG_MAX_DRAW_CALLS``.
@@ -374,7 +374,7 @@ To test browsers in 60Hz mode following changes were made:
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default browsers are using vsync, and don't have option to turn it
-off programatically.
+off programmatically.
 
 +----------------+------------+------------+--------------------------+-------+----------+
 | CPU            | Renderer   | GPU        | Arch/Compiler/OS         | Dim   | Calls    |

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -169,7 +169,7 @@ device or OpenGL context.
 
 For more info see: :doc:`bgfx`.
 
-.. note:: You can use ``--with-sdl`` when runnning GENie to enable SDL2 integration with examples:
+.. note:: You can use ``--with-sdl`` when running GENie to enable SDL2 integration with examples:
           ``genie --with-sdl vs2012``
 
 .. note:: ``--with-glfw`` is also available, but it's just simple stub to be used to test GLFW

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -73,7 +73,7 @@ Some differences between bgfx's shaderc flavor of GLSL and vanilla GLSL:
    instead of using ``attribute/in`` and ``varying/in/out``.
    This file cannot include comments, and typically only one is necessary.
 -  ``$input/$output`` tokens corresponding to inputs and outputs defined in
-   ``varying.def.sc`` must be used at the begining of shader.
+   ``varying.def.sc`` must be used at the beginning of shader.
 
 For more info, see the `shader helper macros
 <https://github.com/bkaradzic/bgfx/blob/master/src/bgfx_shader.sh>`__.

--- a/examples/common/nanovg/nanovg.h
+++ b/examples/common/nanovg/nanovg.h
@@ -408,7 +408,7 @@ NVGpaint nvgBoxGradient(NVGcontext* ctx, float x, float y, float w, float h,
 NVGpaint nvgRadialGradient(NVGcontext* ctx, float cx, float cy, float inr, float outr,
 						   NVGcolor icol, NVGcolor ocol);
 
-// Creates and returns an image patter. Parameters (ox,oy) specify the left-top location of the image pattern,
+// Creates and returns an image pattern. Parameters (ox,oy) specify the left-top location of the image pattern,
 // (ex,ey) the size of one image, angle rotation around the top-left corner, image is handle to the image to render.
 // The gradient is transformed by the current transform when it is passed to nvgFillPaint() or nvgStrokePaint().
 NVGpaint nvgImagePattern(NVGcontext* ctx, float ox, float oy, float ex, float ey,

--- a/scripts/bindings-zig.lua
+++ b/scripts/bindings-zig.lua
@@ -407,7 +407,7 @@ function converter.funcs(params)
 		return
 	end
 
-	-- skipp for now, don't know how to handle variadic functions
+	-- skip for now, don't know how to handle variadic functions
 	if func.cname == "dbg_text_printf" or func.cname == "dbg_text_vprintf" then
 		return
 	end

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -1760,7 +1760,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 
 		void setFrameBuffer(RenderPassDescriptor _renderPassDescriptor, FrameBufferHandle _fbh, bool _msaa = true)
 		{
-			// reslove framebuffer
+			// resolve framebuffer
 			if (isValid(m_fbh) && m_fbh.idx != _fbh.idx)
 			{
 				FrameBufferMtl& frameBuffer = m_frameBuffers[m_fbh.idx];

--- a/src/shader_dxbc.cpp
+++ b/src/shader_dxbc.cpp
@@ -1235,7 +1235,7 @@ namespace bgfx
 				// 0       1       2       3
 				// 76543210765432107654321076543210
 				// ........        iiiii...........
-				//                 ^---------------- Interploation
+				//                 ^---------------- Interpolation
 
 				_instruction.interpolation = DxbcInterpolation::Enum( (token & UINT32_C(0x0000f800) ) >> 11);
 				break;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./3rdparty,*.ttf -L attribut,ba,clude,conly,indext,inout,lod,nclude,retur,struc,unknwn,utput`