### PR TITLE
Fix D3D12 InputSlot when having streams w/ instances

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -2716,7 +2716,7 @@ namespace bgfx { namespace d3d12
 				}
 
 				bx::memCopy(curr, &inst, sizeof(D3D12_INPUT_ELEMENT_DESC) );
-				curr->InputSlot = 1;
+				curr->InputSlot = _numStreams;
 				curr->SemanticIndex = index;
 				curr->AlignedByteOffset = ii*16;
 			}


### PR DESCRIPTION
With D3D12, when using instances with more than 1 stream, the PSO creation fails because `InputSlot` for instances points to a non instanced input.

Repro with Example05 in this branch: https://github.com/CedricGuillemet/bgfx/tree/d3d12StreamInstanceError

Simple fix: change the input slot to be the first instance one.