### PR TITLE
Enable MSAA setting at context creation for Android

### DIFF
--- a/src/glcontext_eagl.h
+++ b/src/glcontext_eagl.h
@@ -20,10 +20,11 @@ namespace bgfx { namespace gl
 			, m_fbo(0)
 			, m_colorRbo(0)
 			, m_depthStencilRbo(0)
+			, m_msaaContext(false)
 		{
 		}
 
-		void create(uint32_t _width, uint32_t _height);
+		void create(uint32_t _width, uint32_t _height, uint32_t _flags);
 		void destroy();
 		void resize(uint32_t _width, uint32_t _height, uint32_t _flags);
 
@@ -51,6 +52,8 @@ namespace bgfx { namespace gl
 		GLuint m_fbo;
 		GLuint m_colorRbo;
 		GLuint m_depthStencilRbo;
+		// true when MSAA is handled by the context instead of using MSAA FBO
+		bool m_msaaContext;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_eagl.mm
+++ b/src/glcontext_eagl.mm
@@ -159,7 +159,7 @@ namespace bgfx { namespace gl
 		GLint m_height;
 	};
 
-	void GlContext::create(uint32_t _width, uint32_t _height)
+	void GlContext::create(uint32_t _width, uint32_t _height, uint32_t /*_flags*/)
 	{
 		s_opengles = bx::dlopen("/System/Library/Frameworks/OpenGLES.framework/OpenGLES");
 		BX_ASSERT(NULL != s_opengles, "OpenGLES dynamic library is not found!");

--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -155,7 +155,7 @@ EGL_IMPORT
 	static EGL_DISPMANX_WINDOW_T s_dispmanWindow;
 #	endif // BX_PLATFORM_RPI
 
-	void GlContext::create(uint32_t _width, uint32_t _height)
+	void GlContext::create(uint32_t _width, uint32_t _height, uint32_t _flags)
 	{
 #	if BX_PLATFORM_RPI
 		bcm_host_init();
@@ -207,6 +207,12 @@ EGL_IMPORT
 
 			const uint32_t gles = BGFX_CONFIG_RENDERER_OPENGLES;
 
+#if BX_PLATFORM_ANDROID
+			uint32_t msaa = (_flags&BGFX_RESET_MSAA_MASK)>>BGFX_RESET_MSAA_SHIFT;
+            uint32_t msaaSamples = msaa == 0 ? 0 : 1<<msaa;
+			m_msaaContext = true;
+#endif // BX_PLATFORM_ANDROID
+
 			EGLint attrs[] =
 			{
 				EGL_RENDERABLE_TYPE, (gles >= 30) ? EGL_OPENGL_ES3_BIT_KHR : EGL_OPENGL_ES2_BIT,
@@ -218,6 +224,7 @@ EGL_IMPORT
 
 #	if BX_PLATFORM_ANDROID
 				EGL_DEPTH_SIZE, 16,
+				EGL_SAMPLES, msaaSamples,
 #	else
 				EGL_DEPTH_SIZE, 24,
 #	endif // BX_PLATFORM_

--- a/src/glcontext_egl.h
+++ b/src/glcontext_egl.h
@@ -26,10 +26,11 @@ namespace bgfx { namespace gl
 			, m_context(NULL)
 			, m_display(NULL)
 			, m_surface(NULL)
+			, m_msaaContext(false)
 		{
 		}
 
-		void create(uint32_t _width, uint32_t _height);
+		void create(uint32_t _width, uint32_t _height, uint32_t _flags);
 		void destroy();
 		void resize(uint32_t _width, uint32_t _height, uint32_t _flags);
 
@@ -52,6 +53,8 @@ namespace bgfx { namespace gl
 		EGLContext m_context;
 		EGLDisplay m_display;
 		EGLSurface m_surface;
+		// true when MSAA is handled by the context instead of using MSAA FBO
+		bool m_msaaContext;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_glx.cpp
+++ b/src/glcontext_glx.cpp
@@ -89,7 +89,7 @@ namespace bgfx { namespace gl
 		return reinterpret_cast<ProtoT>( (void*)::glXGetProcAddress( (const GLubyte*)_name) );
 	}
 
-	void GlContext::create(uint32_t _width, uint32_t _height)
+	void GlContext::create(uint32_t _width, uint32_t _height, uint32_t /*_flags*/)
 	{
 		BX_UNUSED(_width, _height);
 

--- a/src/glcontext_glx.h
+++ b/src/glcontext_glx.h
@@ -23,10 +23,11 @@ namespace bgfx { namespace gl
 			, m_context(0)
 			, m_visualInfo(NULL)
 			, m_display(NULL)
+			, m_msaaContext(false)
 		{
 		}
 
-		void create(uint32_t _width, uint32_t _height);
+		void create(uint32_t _width, uint32_t _height, uint32_t _flags);
 		void destroy();
 		void resize(uint32_t _width, uint32_t _height, uint32_t _flags);
 
@@ -47,6 +48,8 @@ namespace bgfx { namespace gl
 		GLXContext m_context;
 		XVisualInfo* m_visualInfo;
 		::Display* m_display;
+		// true when MSAA is handled by the context instead of using MSAA FBO
+		bool m_msaaContext;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -63,7 +63,7 @@ namespace bgfx { namespace gl
 		char* m_canvas;
 	};
 
-	void GlContext::create(uint32_t _width, uint32_t _height)
+	void GlContext::create(uint32_t _width, uint32_t _height, uint32_t /*_flags*/)
 	{
 		// assert?
 		if (m_primary != NULL)

--- a/src/glcontext_html5.h
+++ b/src/glcontext_html5.h
@@ -17,10 +17,11 @@ namespace bgfx { namespace gl
 		GlContext()
 			: m_current(NULL)
 			, m_primary(NULL)
+			, m_msaaContext(false)
 		{
 		}
 
-		void create(uint32_t _width, uint32_t _height);
+		void create(uint32_t _width, uint32_t _height, uint32_t _flags);
 		void destroy();
 		void resize(uint32_t _width, uint32_t _height, uint32_t _flags);
 
@@ -39,6 +40,8 @@ namespace bgfx { namespace gl
 
         SwapChainGL* m_current;
 		SwapChainGL* m_primary;
+		// true when MSAA is handled by the context instead of using MSAA FBO
+		bool m_msaaContext;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_nsgl.h
+++ b/src/glcontext_nsgl.h
@@ -17,10 +17,11 @@ namespace bgfx { namespace gl
 		GlContext()
 			: m_context(NULL)
 			, m_view(NULL)
+			, m_msaaContext(false)
 		{
 		}
 
-		void create(uint32_t _width, uint32_t _height);
+		void create(uint32_t _width, uint32_t _height, uint32_t _flags);
 		void destroy();
 		void resize(uint32_t _width, uint32_t _height, uint32_t _flags);
 
@@ -39,6 +40,9 @@ namespace bgfx { namespace gl
 
 		void* m_context;
 		void* m_view;
+		// true when MSAA is handled by the context instead of using MSAA FBO
+		bool m_msaaContext;
+
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_nsgl.mm
+++ b/src/glcontext_nsgl.mm
@@ -156,7 +156,7 @@ namespace bgfx { namespace gl
 
 	static void* s_opengl = NULL;
 
-	void GlContext::create(uint32_t _width, uint32_t _height)
+	void GlContext::create(uint32_t _width, uint32_t _height, uint32_t /*_flags*/)
 	{
 		BX_UNUSED(_width, _height);
 

--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -108,7 +108,7 @@ namespace bgfx { namespace gl
 		return context;
 	}
 
-	void GlContext::create(uint32_t /*_width*/, uint32_t /*_height*/)
+	void GlContext::create(uint32_t /*_width*/, uint32_t /*_height*/, uint32_t /*_flags*/)
 	{
 		m_opengl32dll = bx::dlopen("opengl32.dll");
 		BGFX_FATAL(NULL != m_opengl32dll, Fatal::UnableToInitialize, "Failed to load opengl32.dll.");

--- a/src/glcontext_wgl.h
+++ b/src/glcontext_wgl.h
@@ -65,10 +65,11 @@ typedef void (APIENTRYP PFNGLSTENCILOPPROC) (GLenum fail, GLenum zfail, GLenum z
 			, m_opengl32dll(NULL)
 			, m_context(NULL)
 			, m_hdc(NULL)
+			, m_msaaContext(false)
 		{
 		}
 
-		void create(uint32_t _width, uint32_t _height);
+		void create(uint32_t _width, uint32_t _height, uint32_t _flags);
 		void destroy();
 		void resize(uint32_t _width, uint32_t _height, uint32_t _flags);
 
@@ -92,6 +93,8 @@ typedef void (APIENTRYP PFNGLSTENCILOPPROC) (GLenum fail, GLenum zfail, GLenum z
 		void* m_opengl32dll;
 		HGLRC m_context;
 		HDC m_hdc;
+		// true when MSAA is handled by the context instead of using MSAA FBO
+		bool m_msaaContext;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2219,7 +2219,7 @@ namespace bgfx { namespace gl
 			bx::memSet(m_uniforms, 0, sizeof(m_uniforms) );
 			bx::memSet(&m_resolution, 0, sizeof(m_resolution) );
 
-			setRenderContextSize(_init.resolution.width, _init.resolution.height);
+			setRenderContextSize(_init.resolution.width, _init.resolution.height, _init.resolution.reset);
 
 			m_vendor      = getGLString(GL_VENDOR);
 			m_renderer    = getGLString(GL_RENDERER);
@@ -3805,7 +3805,8 @@ namespace bgfx { namespace gl
 		void createMsaaFbo(uint32_t _width, uint32_t _height, uint32_t _msaa)
 		{
 			if (0 == m_msaaBackBufferFbo // iOS
-			&&  1 < _msaa)
+			&&  1 < _msaa
+			&& !m_glctx.m_msaaContext)
 			{
 				GLenum storageFormat = m_resolution.reset & BGFX_RESET_SRGB_BACKBUFFER
 					? GL_SRGB8_ALPHA8
@@ -4063,7 +4064,7 @@ namespace bgfx { namespace gl
 			{
 				if (!m_glctx.isValid() )
 				{
-					m_glctx.create(_width, _height);
+					m_glctx.create(_width, _height, _flags);
 
 #if BX_PLATFORM_IOS
 					// iOS: need to figure out how to deal with FBO created by context.


### PR DESCRIPTION
On many Android devices tested internally, enabled MSAA breaks rendering (glitches, crashes, no rendering at all ...)
But when enabled during context creation, things are fine.

This PR, enables MSAA at context creation for Android/EGL and enables a flag that doesn't create MSAA FBO and its resolve.