### PR TITLE
Resolve texture format correctly on D3D11/D3D12

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -4873,7 +4873,7 @@ namespace bgfx { namespace d3d11
 			for (uint32_t ii = _layer; ii < _numLayers; ++ii)
 			{
 				const UINT resource = _mip + (ii * m_numMips);
-				deviceCtx->ResolveSubresource(m_texture2d, resource, m_rt, resource, s_textureFormat[m_textureFormat].m_fmt);
+				deviceCtx->ResolveSubresource(m_texture2d, resource, m_rt, resource, s_textureFormat[m_textureFormat].m_fmtSrv);
 			}
 		}
 

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -5210,7 +5210,7 @@ namespace bgfx { namespace d3d12
 					, resource
 					, m_ptr
 					, resource
-					, s_textureFormat[m_textureFormat].m_fmt
+					, s_textureFormat[m_textureFormat].m_fmtSrv
 				);
 			}
 


### PR DESCRIPTION
This PR is all about ensuring the correct type is chosen when resolving on both D3D11/D3D12.

For eg. Depth textures when using `m_fmt` resolve to type `TYPELESS` while in fact they are of type `FLOAT` when using the `m_fmtSrv` parameter ( which I think was the intended one to be used since day 1 ).

A simple example to see this in action and to test it, is to use a framebuffer with a color and depth texture with flag `BGFX_TEXTURE_RT_MSAA_X16` set. 