### PR TITLE
Fix invalid boolean logic of texture validation

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4503,9 +4503,11 @@ namespace bgfx
 			{
 				++depth;
 
-				BGFX_ERROR_CHECK(true
-					&& 0 != (tr.m_flags & BGFX_TEXTURE_RT_MSAA_MASK)
-					&& 0 != (tr.m_flags & BGFX_TEXTURE_RT_WRITE_ONLY)
+				BGFX_ERROR_CHECK(
+					// if BGFX_TEXTURE_RT_MSAA_X2 or greater than BGFX_TEXTURE_RT_WRITE_ONLY is required
+					// if BGFX_TEXTURE_RT with no MSSA then WRITE_ONLY is not required.
+					(1 == ((tr.m_flags & BGFX_TEXTURE_RT_MSAA_MASK) >> BGFX_TEXTURE_RT_MSAA_SHIFT))
+					|| (0 != (tr.m_flags & BGFX_TEXTURE_RT_WRITE_ONLY))
 					, _err
 					, BGFX_ERROR_FRAME_BUFFER_VALIDATION
 					, "Frame buffer depth MSAA texture cannot be resolved. It must be created with `BGFX_TEXTURE_RT_WRITE_ONLY` flag."


### PR DESCRIPTION
I noticed that this https://github.com/bkaradzic/bgfx/commit/0363560934172853742390bf516ba2cbaa901968
broke https://github.com/bkaradzic/bgfx/blob/b5e7a4cccd8467d5f3c9d53ac220ecf8f0861b75/examples/16-shadowmaps/shadowmaps.cpp#L1750
which shouldn't be the case. The validation was meant for only multisample flags.
my boolean logic assumes that it must be BGFX_TEXTURE_RT in the flag or BGFX_TEXTURE_RT_MSAA_XX in the flag.