### PR TITLE
pixelformats: Use "Alpha" instead of "Ignore Alpha"

### DIFF
--- a/examples/47-pixelformats/pixelformats.cpp
+++ b/examples/47-pixelformats/pixelformats.cpp
@@ -197,7 +197,7 @@ public:
 			}
 
 			ImGui::SetCursorScreenPos(previewPos);
-			ImGui::Image(texture, m_ignoreAlpha ? IMGUI_FLAGS_NONE : IMGUI_FLAGS_ALPHA_BLEND, 0, previewSize);
+			ImGui::Image(texture, m_useAlpha ? IMGUI_FLAGS_ALPHA_BLEND : IMGUI_FLAGS_NONE, 0, previewSize);
 		}
 		else
 		{
@@ -247,7 +247,7 @@ public:
 
 			ImGui::DragFloat("Preview Size", &m_previewSize, 1.0f, 10.0f, TEXTURE_SIZE);
 			ImGui::SameLine();
-			ImGui::Checkbox("Ignore Alpha", &m_ignoreAlpha);
+			ImGui::Checkbox("Alpha", &m_useAlpha);
 			ImGui::BeginTable("Formats", NUM_FORMATS_IN_ROW, ImGuiTableFlags_Borders | ImGuiTableFlags_SizingFixedFit);
 			for (int i = 0; i < NUM_FORMATS; ++i)
 			{
@@ -316,7 +316,7 @@ public:
 	uint32_t m_debug;
 	uint32_t m_reset;
 	float    m_previewSize = 50.0f;
-	bool     m_ignoreAlpha = false;
+	bool     m_useAlpha = true;
 	bimg::TextureFormat::Enum m_selectedFormat = bimg::TextureFormat::RGBA8;
 
 	bgfx::TextureHandle m_checkerboard = BGFX_INVALID_HANDLE;


### PR DESCRIPTION
Use positive logic for "alpha" in pixelformats example