### PR TITLE
egl: Fix narrowing warning/error

### DIFF
--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -224,7 +224,7 @@ EGL_IMPORT
 
 #	if BX_PLATFORM_ANDROID
 				EGL_DEPTH_SIZE, 16,
-				EGL_SAMPLES, msaaSamples,
+				EGL_SAMPLES, (EGLint)msaaSamples,
 #	else
 				EGL_DEPTH_SIZE, 24,
 #	endif // BX_PLATFORM_


### PR DESCRIPTION
Some platforms fail with a narrowing warning due to the implicit typecast here when cross-compiling to android