### PR TITLE
opengl: Implement texture swizzle mapping

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5839,6 +5839,34 @@ namespace bgfx { namespace gl
 				}
 			}
 
+			GLint mapping[4] = {
+				s_textureFormat[m_textureFormat].m_mapping[0],
+				s_textureFormat[m_textureFormat].m_mapping[1],
+				s_textureFormat[m_textureFormat].m_mapping[2],
+				s_textureFormat[m_textureFormat].m_mapping[3],
+			};
+			if (s_renderGL->m_textureSwizzleSupport
+			&& (-1 != mapping[0] || -1 != mapping[1] || -1 != mapping[2] || -1 != mapping[3]) )
+			{
+				if (-1 == mapping[0])
+				{
+					mapping[0] = GL_RED;
+				}
+				if (-1 == mapping[1])
+				{
+					mapping[1] = GL_GREEN;
+				}
+				if (-1 == mapping[2])
+				{
+					mapping[2] = GL_BLUE;
+				}
+				if (-1 == mapping[3])
+				{
+					mapping[3] = GL_ALPHA;
+				}
+				GL_CHECK(glTexParameteriv(m_target, GL_TEXTURE_SWIZZLE_RGBA, mapping));
+			}
+
 			if (NULL != temp)
 			{
 				BX_FREE(g_allocator, temp);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -287,7 +287,7 @@ namespace bgfx { namespace gl
 		{ GL_RGBA32I,                                  GL_ZERO,                                      RGBA_INTEGER,                                GL_RGBA_INTEGER,                             GL_INT,                          false, { $_, $_, $_, $_ } }, // RGBA32I
 		{ GL_RGBA32UI,                                 GL_ZERO,                                      RGBA_INTEGER,                                GL_RGBA_INTEGER,                             GL_UNSIGNED_INT,                 false, { $_, $_, $_, $_ } }, // RGBA32U
 		{ GL_RGBA32F,                                  GL_ZERO,                                      GL_RGBA,                                     GL_RGBA,                                     GL_FLOAT,                        false, { $_, $_, $_, $_ } }, // RGBA32F
-		{ GL_RGB565,                                   GL_ZERO,                                      GL_BGR,                                      GL_BGR,                                      GL_UNSIGNED_SHORT_5_6_5,         false, { $_, $_, $_, $_ } }, // R5G6B5
+		{ GL_RGB565,                                   GL_ZERO,                                      GL_RGB,                                      GL_RGB,                                      GL_UNSIGNED_SHORT_5_6_5,         false, { $_, $_, $_, $_ } }, // R5G6B5
 		{ GL_RGBA4,                                    GL_ZERO,                                      GL_RGBA,                                     GL_RGBA,                                     GL_UNSIGNED_SHORT_4_4_4_4_REV,   false, { $_, $_, $_, $_ } }, // RGBA4
 		{ GL_RGB5_A1,                                  GL_ZERO,                                      GL_RGBA,                                     GL_RGBA,                                     GL_UNSIGNED_SHORT_1_5_5_5_REV,   false, { $_, $_, $_, $_ } }, // RGB5A1
 		{ GL_RGB10_A2,                                 GL_ZERO,                                      GL_RGBA,                                     GL_RGBA,                                     GL_UNSIGNED_INT_2_10_10_10_REV,  false, { $_, $_, $_, $_ } }, // RGB10A2
@@ -2524,6 +2524,12 @@ namespace bgfx { namespace gl
 							setTextureFormatSrgb(TextureFormat::RGB8, GL_SRGB_EXT, GL_SRGB_EXT);
 						}
 
+						if (s_extension[Extension::EXT_texture_swizzle].m_supported)
+						{
+							s_textureFormat[TextureFormat::R5G6B5].m_mapping[0] = GL_BLUE;
+							s_textureFormat[TextureFormat::R5G6B5].m_mapping[2] = GL_RED;
+						}
+
 						if (s_extension[Extension::OES_texture_half_float].m_supported
 						||  s_extension[Extension::OES_texture_float     ].m_supported)
 						{
@@ -2565,6 +2571,11 @@ namespace bgfx { namespace gl
 						setTextureFormat(TextureFormat::D32F,  GL_DEPTH_COMPONENT32F, GL_DEPTH_COMPONENT, GL_FLOAT);
 						setTextureFormat(TextureFormat::D0S8,  GL_STENCIL_INDEX8, GL_STENCIL_INDEX, GL_UNSIGNED_BYTE); // Only works as renderbuffer, not as texture
 					}
+				}
+				else
+				{
+					setTextureFormat(TextureFormat::R5G6B5, GL_BGR,  GL_BGR,  GL_UNSIGNED_SHORT_5_6_5);
+					setTextureFormatSrgb(TextureFormat::R5G6B5, GL_ZERO,  GL_BGR);
 				}
 
 				if (BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL)

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -162,6 +162,10 @@ typedef uint64_t GLuint64;
 #	define GL_LUMINANCE 0x1909
 #endif // GL_LUMINANCE
 
+#ifndef GL_BGR
+#	define GL_BGR 0x80E0
+#endif // GL_BGR
+
 #ifndef GL_BGRA
 #	define GL_BGRA 0x80E1
 #endif // GL_BGRA


### PR DESCRIPTION
Currently none of the formats swizzle, but I'm prototyping the `B5G6R5` which would require swizzling R and B components due to GLES not having `GL_BGR` defined for internal formats.

I don't see any use for any of GL_TEXTURE_SWIZZLE_R, GL_TEXTURE_SWIZZLE_G, GL_TEXTURE_SWIZZLE_B, GL_TEXTURE_SWIZZLE_A so I didn't include any cases with them.