### PR TITLE
Supply frame number in view stats

### DIFF
--- a/bindings/bf/bgfx.bf
+++ b/bindings/bf/bgfx.bf
@@ -2184,6 +2184,7 @@ public static class bgfx
 		public int64 cpuTimeEnd;
 		public int64 gpuTimeBegin;
 		public int64 gpuTimeEnd;
+		public uint32 gpuFrameNum;
 	}
 	
 	[CRepr]
@@ -2209,6 +2210,7 @@ public static class bgfx
 		public uint32 numCompute;
 		public uint32 numBlit;
 		public uint32 maxGpuLatency;
+		public uint32 gpuFrameNum;
 		public uint16 numDynamicIndexBuffers;
 		public uint16 numDynamicVertexBuffers;
 		public uint16 numFrameBuffers;

--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -2152,6 +2152,7 @@ public static partial class bgfx
 		public long cpuTimeEnd;
 		public long gpuTimeBegin;
 		public long gpuTimeEnd;
+		public uint gpuFrameNum;
 	}
 	
 	public unsafe struct EncoderStats
@@ -2175,6 +2176,7 @@ public static partial class bgfx
 		public uint numCompute;
 		public uint numBlit;
 		public uint maxGpuLatency;
+		public uint gpuFrameNum;
 		public ushort numDynamicIndexBuffers;
 		public ushort numDynamicVertexBuffers;
 		public ushort numFrameBuffers;

--- a/bindings/d/types.d
+++ b/bindings/d/types.d
@@ -1029,6 +1029,7 @@ struct bgfx_view_stats_t
 	long cpuTimeEnd; /// CPU (submit) end time.
 	long gpuTimeBegin; /// GPU begin time.
 	long gpuTimeEnd; /// GPU end time.
+	uint gpuFrameNum; /// Frame which generated gpuTimeBegin, gpuTimeEnd.
 }
 
 /// Encoder stats.
@@ -1058,6 +1059,7 @@ struct bgfx_stats_t
 	uint numCompute; /// Number of compute calls submitted.
 	uint numBlit; /// Number of blit calls submitted.
 	uint maxGpuLatency; /// GPU driver latency.
+	uint gpuFrameNum; /// Frame which generated gpuTimeBegin, gpuTimeEnd.
 	ushort numDynamicIndexBuffers; /// Number of used dynamic index buffers.
 	ushort numDynamicVertexBuffers; /// Number of used dynamic vertex buffers.
 	ushort numFrameBuffers; /// Number of used frame buffers.

--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -942,12 +942,13 @@ namespace bgfx
 	///
 	struct ViewStats
 	{
-		char    name[256];      //!< View name.
-		ViewId  view;           //!< View id.
-		int64_t cpuTimeBegin;   //!< CPU (submit) begin time.
-		int64_t cpuTimeEnd;     //!< CPU (submit) end time.
-		int64_t gpuTimeBegin;   //!< GPU begin time.
-		int64_t gpuTimeEnd;     //!< GPU end time.
+		char     name[256];      //!< View name.
+		ViewId   view;           //!< View id.
+		int64_t  cpuTimeBegin;   //!< CPU (submit) begin time.
+		int64_t  cpuTimeEnd;     //!< CPU (submit) end time.
+		int64_t  gpuTimeBegin;   //!< GPU begin time.
+		int64_t  gpuTimeEnd;     //!< GPU end time.
+		uint32_t gpuFrameNum;    //!< Frame which generated gpuTimeBegin, gpuTimeEnd.
 	};
 
 	/// Encoder stats.
@@ -985,6 +986,7 @@ namespace bgfx
 		uint32_t numCompute;                //!< Number of compute calls submitted.
 		uint32_t numBlit;                   //!< Number of blit calls submitted.
 		uint32_t maxGpuLatency;             //!< GPU driver latency.
+		uint32_t gpuFrameNum;               //<! Frame which generated gpuTimeBegin, gpuTimeEnd.
 
 		uint16_t numDynamicIndexBuffers;    //!< Number of used dynamic index buffers.
 		uint16_t numDynamicVertexBuffers;   //!< Number of used dynamic vertex buffers.

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -825,6 +825,7 @@ typedef struct bgfx_view_stats_s
     int64_t              cpuTimeEnd;         /** CPU (submit) end time.                   */
     int64_t              gpuTimeBegin;       /** GPU begin time.                          */
     int64_t              gpuTimeEnd;         /** GPU end time.                            */
+    uint32_t             gpuFrameNum;        /** Frame which generated gpuTimeBegin, gpuTimeEnd. */
 
 } bgfx_view_stats_t;
 
@@ -860,6 +861,7 @@ typedef struct bgfx_stats_s
     uint32_t             numCompute;         /** Number of compute calls submitted.       */
     uint32_t             numBlit;            /** Number of blit calls submitted.          */
     uint32_t             maxGpuLatency;      /** GPU driver latency.                      */
+    uint32_t             gpuFrameNum;        /** Frame which generated gpuTimeBegin, gpuTimeEnd. */
     uint16_t             numDynamicIndexBuffers; /** Number of used dynamic index buffers.    */
     uint16_t             numDynamicVertexBuffers; /** Number of used dynamic vertex buffers.   */
     uint16_t             numFrameBuffers;    /** Number of used frame buffers.            */

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -909,6 +909,7 @@ struct.ViewStats
 	.cpuTimeEnd     "int64_t"   --- CPU (submit) end time.
 	.gpuTimeBegin   "int64_t"   --- GPU begin time.
 	.gpuTimeEnd     "int64_t"   --- GPU end time.
+	.gpuFrameNum    "uint32_t"  --- Frame which generated gpuTimeBegin, gpuTimeEnd.
 
 --- Encoder stats.
 struct.EncoderStats
@@ -936,6 +937,7 @@ struct.Stats
 	.numCompute              "uint32_t"      --- Number of compute calls submitted.
 	.numBlit                 "uint32_t"      --- Number of blit calls submitted.
 	.maxGpuLatency           "uint32_t"      --- GPU driver latency.
+	.gpuFrameNum             "uint32_t"      --- Frame which generated gpuTimeBegin, gpuTimeEnd.
 
 	.numDynamicIndexBuffers  "uint16_t"      --- Number of used dynamic index buffers.
 	.numDynamicVertexBuffers "uint16_t"      --- Number of used dynamic vertex buffers.

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1906,7 +1906,6 @@ namespace bgfx
 
 		m_exit    = false;
 		m_flipped = true;
-		m_frames  = 0;
 		m_debug   = BGFX_DEBUG_NONE;
 		m_frameTimeLast = bx::getHPCounter();
 
@@ -2308,6 +2307,8 @@ namespace bgfx
 
 		m_submit->m_capture = _capture;
 
+		uint32_t frameNum = m_submit->m_frameNum;
+
 		BGFX_PROFILER_SCOPE("bgfx/API thread frame", 0xff2040ff);
 		// wait for render thread to finish
 		renderSemWait();
@@ -2315,7 +2316,7 @@ namespace bgfx
 
 		m_encoder[0].begin(m_submit, 0);
 
-		return m_frames;
+		return frameNum;
 	}
 
 	void Context::frameNoRenderWait()
@@ -2358,8 +2359,8 @@ namespace bgfx
 			renderFrame();
 		}
 
-		m_frames++;
-		m_submit->start();
+		uint32_t nextFrameNum = m_render->m_frameNum + 1;
+		m_submit->start(nextFrameNum);
 
 		bx::memSet(m_seq, 0, sizeof(m_seq) );
 

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2072,6 +2072,7 @@ namespace bgfx
 		Frame()
 			: m_waitSubmit(0)
 			, m_waitRender(0)
+			, m_frameNum(0)
 			, m_capture(false)
 		{
 			SortKey term;
@@ -2105,7 +2106,7 @@ namespace bgfx
 			}
 
 			reset();
-			start();
+			start(0);
 			m_textVideoMem = BX_NEW(g_allocator, TextVideoMem);
 		}
 
@@ -2122,12 +2123,12 @@ namespace bgfx
 
 		void reset()
 		{
-			start();
+			start(0);
 			finish();
 			resetFreeHandles();
 		}
 
-		void start()
+		void start(uint32_t frameNum)
 		{
 			m_perfStats.transientVbUsed = m_vboffset;
 			m_perfStats.transientIbUsed = m_iboffset;
@@ -2141,6 +2142,7 @@ namespace bgfx
 			m_cmdPost.start();
 			m_capture = false;
 			m_numScreenShots = 0;
+			m_frameNum = frameNum;
 		}
 
 		void finish()
@@ -2348,6 +2350,8 @@ namespace bgfx
 
 		int64_t m_waitSubmit;
 		int64_t m_waitRender;
+
+		uint32_t m_frameNum;
 
 		bool m_capture;
 	};
@@ -4512,7 +4516,7 @@ namespace bgfx
 			cmdbuf.write(_handle);
 			cmdbuf.write(_data);
 			cmdbuf.write(_mip);
-			return m_frames + 2;
+			return m_submit->m_frameNum + 2;
 		}
 
 		void resizeTexture(TextureHandle _handle, uint16_t _width, uint16_t _height, uint8_t _numMips, uint16_t _numLayers)

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -501,7 +501,7 @@ namespace bgfx
 				ViewStats& viewStats = m_frame->m_perfStats.viewStats[m_numViews];
 				viewStats.cpuTimeBegin = bx::getHPCounter();
 
-				m_queryIdx = m_gpuTimer.begin(_view);
+				m_queryIdx = m_gpuTimer.begin(_view, m_frame->m_frameNum);
 
 				viewStats.view = ViewId(_view);
 				bx::strCopy(viewStats.name
@@ -524,6 +524,7 @@ namespace bgfx
 				viewStats.cpuTimeEnd = bx::getHPCounter();
 				viewStats.gpuTimeBegin = result.m_begin;
 				viewStats.gpuTimeEnd = result.m_end;
+				viewStats.gpuFrameNum = result.m_frameNum;
 
 				++m_numViews;
 				m_queryIdx = UINT32_MAX;

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -5397,7 +5397,6 @@ namespace bgfx { namespace d3d11
 
 	uint32_t TimerQueryD3D11::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
-		BX_UNUSED(_frameNum);
 		ID3D11DeviceContext* deviceCtx = s_renderD3D11->m_deviceCtx;
 
 		while (0 == m_control.reserve(1) )
@@ -5412,6 +5411,7 @@ namespace bgfx { namespace d3d11
 		Query& query = m_query[idx];
 		query.m_resultIdx = _resultIdx;
 		query.m_ready     = false;
+		query.m_frameNum  = _frameNum;
 
 		deviceCtx->Begin(query.m_disjoint);
 		deviceCtx->End(query.m_begin);
@@ -5468,6 +5468,7 @@ namespace bgfx { namespace d3d11
 
 				Result& result = m_result[query.m_resultIdx];
 				--result.m_pending;
+				result.m_frameNum = query.m_frameNum;
 
 				result.m_frequency = disjoint.Frequency;
 				result.m_begin     = timeBegin;

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -5395,8 +5395,9 @@ namespace bgfx { namespace d3d11
 		}
 	}
 
-	uint32_t TimerQueryD3D11::begin(uint32_t _resultIdx)
+	uint32_t TimerQueryD3D11::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
+		BX_UNUSED(_frameNum);
 		ID3D11DeviceContext* deviceCtx = s_renderD3D11->m_deviceCtx;
 
 		while (0 == m_control.reserve(1) )
@@ -5653,7 +5654,7 @@ namespace bgfx { namespace d3d11
 
 		if (m_timerQuerySupport)
 		{
-			frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS);
+			frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS, _render->m_frameNum);
 		}
 
 		if (0 < _render->m_iboffset)
@@ -6572,6 +6573,7 @@ namespace bgfx { namespace d3d11
 		perfStats.numCompute    = statsKeyType[1];
 		perfStats.numBlit       = _render->m_numBlitItems;
 		perfStats.maxGpuLatency = maxGpuLatency;
+		perfStats.gpuFrameNum   = result.m_frameNum;
 		bx::memCopy(perfStats.numPrims, statsNumPrimsRendered, sizeof(perfStats.numPrims) );
 		m_nvapi.getMemoryInfo(perfStats.gpuMemoryUsed, perfStats.gpuMemoryMax);
 

--- a/src/renderer_d3d11.h
+++ b/src/renderer_d3d11.h
@@ -371,7 +371,7 @@ namespace bgfx { namespace d3d11
 
 		void postReset();
 		void preReset();
-		uint32_t begin(uint32_t _resultIdx);
+		uint32_t begin(uint32_t _resultIdx, uint32_t _frameNum);
 		void end(uint32_t _idx);
 		bool update();
 
@@ -392,12 +392,14 @@ namespace bgfx { namespace d3d11
 				m_end       = 0;
 				m_frequency = 1;
 				m_pending   = 0;
+				m_frameNum  = 0;
 			}
 
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint64_t m_frequency;
 			uint32_t m_pending;
+			uint32_t m_frameNum; // TODO: implement (currently stays 0)
 		};
 
 		Result m_result[BGFX_CONFIG_MAX_VIEWS+1];

--- a/src/renderer_d3d11.h
+++ b/src/renderer_d3d11.h
@@ -381,6 +381,7 @@ namespace bgfx { namespace d3d11
 			ID3D11Query* m_begin;
 			ID3D11Query* m_end;
 			uint32_t     m_resultIdx;
+			uint32_t     m_frameNum;
 			bool         m_ready;
 		};
 
@@ -399,7 +400,7 @@ namespace bgfx { namespace d3d11
 			uint64_t m_end;
 			uint64_t m_frequency;
 			uint32_t m_pending;
-			uint32_t m_frameNum; // TODO: implement (currently stays 0)
+			uint32_t m_frameNum;
 		};
 
 		Result m_result[BGFX_CONFIG_MAX_VIEWS+1];

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -5694,8 +5694,6 @@ namespace bgfx { namespace d3d12
 
 	uint32_t TimerQueryD3D12::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
-		BX_UNUSED(_frameNum);
-
 		while (0 == m_control.reserve(1) )
 		{
 			m_control.consume(1);
@@ -5708,6 +5706,7 @@ namespace bgfx { namespace d3d12
 		Query& query = m_query[idx];
 		query.m_resultIdx = _resultIdx;
 		query.m_ready     = false;
+		query.m_frameNum  = _frameNum;
 
 		ID3D12GraphicsCommandList* commandList = s_renderD3D12->m_commandList;
 
@@ -5769,6 +5768,7 @@ namespace bgfx { namespace d3d12
 
 			Result& result = m_result[query.m_resultIdx];
 			--result.m_pending;
+			result.m_frameNum = query.m_frameNum;
 
 			uint32_t offset = idx * 2;
 			result.m_begin  = m_queryResult[offset+0];

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -5692,8 +5692,10 @@ namespace bgfx { namespace d3d12
 		DX_RELEASE(m_readback, 0);
 	}
 
-	uint32_t TimerQueryD3D12::begin(uint32_t _resultIdx)
+	uint32_t TimerQueryD3D12::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
+		BX_UNUSED(_frameNum);
+
 		while (0 == m_control.reserve(1) )
 		{
 			m_control.consume(1);
@@ -6002,7 +6004,7 @@ namespace bgfx { namespace d3d12
 		int64_t timeBegin = bx::getHPCounter();
 		int64_t captureElapsed = 0;
 
-		uint32_t frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS);
+		uint32_t frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS, _render->m_frameNum);
 
 		if (0 < _render->m_iboffset)
 		{
@@ -6876,6 +6878,7 @@ namespace bgfx { namespace d3d12
 		perfStats.numCompute    = statsKeyType[1];
 		perfStats.numBlit       = _render->m_numBlitItems;
 		perfStats.maxGpuLatency = maxGpuLatency;
+		perfStats.gpuFrameNum   = result.m_frameNum;
 		bx::memCopy(perfStats.numPrims, statsNumPrimsRendered, sizeof(perfStats.numPrims) );
 		perfStats.gpuMemoryMax  = -INT64_MAX;
 		perfStats.gpuMemoryUsed = -INT64_MAX;

--- a/src/renderer_d3d12.h
+++ b/src/renderer_d3d12.h
@@ -535,8 +535,9 @@ namespace bgfx { namespace d3d12
 		struct Query
 		{
 			uint32_t m_resultIdx;
-			bool     m_ready;
+			uint32_t m_frameNum;
 			uint64_t m_fence;
+			bool     m_ready;
 		};
 
 		struct Result
@@ -552,7 +553,7 @@ namespace bgfx { namespace d3d12
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint32_t m_pending;
-			uint32_t m_frameNum; // TODO: implement (currently stays 0)
+			uint32_t m_frameNum;
 		};
 
 		uint64_t m_frequency;

--- a/src/renderer_d3d12.h
+++ b/src/renderer_d3d12.h
@@ -528,7 +528,7 @@ namespace bgfx { namespace d3d12
 
 		void init();
 		void shutdown();
-		uint32_t begin(uint32_t _resultIdx);
+		uint32_t begin(uint32_t _resultIdx, uint32_t _frameNum);
 		void end(uint32_t _idx);
 		bool update();
 
@@ -543,14 +543,16 @@ namespace bgfx { namespace d3d12
 		{
 			void reset()
 			{
-				m_begin     = 0;
-				m_end       = 0;
-				m_pending   = 0;
+				m_begin    = 0;
+				m_end      = 0;
+				m_pending  = 0;
+				m_frameNum = 0;
 			}
 
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint32_t m_pending;
+			uint32_t m_frameNum; // TODO: implement (currently stays 0)
 		};
 
 		uint64_t m_frequency;

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -3537,8 +3537,10 @@ namespace bgfx { namespace d3d9
 		}
 	}
 
-	uint32_t TimerQueryD3D9::begin(uint32_t _resultIdx)
+	uint32_t TimerQueryD3D9::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
+		BX_UNUSED(_frameNum);
+
 		while (0 == m_control.reserve(1) )
 		{
 			update();
@@ -3751,7 +3753,7 @@ namespace bgfx { namespace d3d9
 		device->BeginScene();
 		if (m_timerQuerySupport)
 		{
-			frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS);
+			frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS, _render->m_frameNum);
 		}
 
 		if (0 < _render->m_iboffset)
@@ -4446,6 +4448,7 @@ namespace bgfx { namespace d3d9
 		perfStats.numCompute    = statsKeyType[1];
 		perfStats.numBlit       = _render->m_numBlitItems;
 		perfStats.maxGpuLatency = maxGpuLatency;
+		perfStats.gpuFrameNum   = result.m_frameNum;
 		bx::memCopy(perfStats.numPrims, statsNumPrimsRendered, sizeof(perfStats.numPrims) );
 		m_nvapi.getMemoryInfo(perfStats.gpuMemoryUsed, perfStats.gpuMemoryMax);
 

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -3539,8 +3539,6 @@ namespace bgfx { namespace d3d9
 
 	uint32_t TimerQueryD3D9::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
-		BX_UNUSED(_frameNum);
-
 		while (0 == m_control.reserve(1) )
 		{
 			update();
@@ -3553,6 +3551,7 @@ namespace bgfx { namespace d3d9
 		Query& query = m_query[idx];
 		query.m_resultIdx = _resultIdx;
 		query.m_ready     = false;
+		query.m_frameNum  = _frameNum;
 
 		query.m_disjoint->Issue(D3DISSUE_BEGIN);
 		query.m_begin->Issue(D3DISSUE_END);
@@ -3603,6 +3602,7 @@ namespace bgfx { namespace d3d9
 
 				Result& result = m_result[query.m_resultIdx];
 				--result.m_pending;
+				result.m_frameNum = query.m_frameNum;
 
 				result.m_frequency = freq;
 				result.m_begin     = timeBegin;

--- a/src/renderer_d3d9.h
+++ b/src/renderer_d3d9.h
@@ -457,6 +457,7 @@ namespace bgfx { namespace d3d9
 			IDirect3DQuery9* m_end;
 			IDirect3DQuery9* m_freq;
 			uint32_t         m_resultIdx;
+			uint32_t         m_frameNum;
 			bool             m_ready;
 		};
 
@@ -475,7 +476,7 @@ namespace bgfx { namespace d3d9
 			uint64_t m_end;
 			uint64_t m_frequency;
 			uint32_t m_pending;
-			uint32_t m_frameNum; // TODO: implement (currently stays 0)
+			uint32_t m_frameNum;
 		};
 
 		Result m_result[BGFX_CONFIG_MAX_VIEWS+1];

--- a/src/renderer_d3d9.h
+++ b/src/renderer_d3d9.h
@@ -446,7 +446,7 @@ namespace bgfx { namespace d3d9
 
 		void postReset();
 		void preReset();
-		uint32_t begin(uint32_t _resultIdx);
+		uint32_t begin(uint32_t _resultIdx, uint32_t _frameNum);
 		void end(uint32_t _idx);
 		bool update();
 
@@ -468,12 +468,14 @@ namespace bgfx { namespace d3d9
 				m_end       = 0;
 				m_frequency = 1;
 				m_pending   = 0;
+				m_frameNum  = 0;
 			}
 
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint64_t m_frequency;
 			uint32_t m_pending;
+			uint32_t m_frameNum; // TODO: implement (currently stays 0)
 		};
 
 		Result m_result[BGFX_CONFIG_MAX_VIEWS+1];

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -7524,7 +7524,7 @@ namespace bgfx { namespace gl
 		if (m_timerQuerySupport
 		&&  !BX_ENABLED(BX_PLATFORM_OSX) )
 		{
-			frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS);
+			frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS, _render->m_frameNum);
 		}
 
 		if (0 < _render->m_iboffset)
@@ -8618,6 +8618,7 @@ namespace bgfx { namespace gl
 		perfStats.numCompute    = statsKeyType[1];
 		perfStats.numBlit       = _render->m_numBlitItems;
 		perfStats.maxGpuLatency = maxGpuLatency;
+		perfStats.gpuFrameNum   = result.m_frameNum;
 		bx::memCopy(perfStats.numPrims, statsNumPrimsRendered, sizeof(perfStats.numPrims) );
 		perfStats.gpuMemoryMax  = -INT64_MAX;
 		perfStats.gpuMemoryUsed = -INT64_MAX;

--- a/src/renderer_gl.h
+++ b/src/renderer_gl.h
@@ -1529,6 +1529,7 @@ namespace bgfx { namespace gl
 			{
 				Query& query = m_query[ii];
 				query.m_ready = false;
+				query.m_frameNum = 0;
 				GL_CHECK(glGenQueries(1, &query.m_begin) );
 				GL_CHECK(glGenQueries(1, &query.m_end) );
 			}
@@ -1550,7 +1551,7 @@ namespace bgfx { namespace gl
 			}
 		}
 
-		uint32_t begin(uint32_t _resultIdx)
+		uint32_t begin(uint32_t _resultIdx, uint32_t _frameNum)
 		{
 			while (0 == m_control.reserve(1) )
 			{
@@ -1563,6 +1564,7 @@ namespace bgfx { namespace gl
 			const uint32_t idx = m_control.m_current;
 			Query& query = m_query[idx];
 			query.m_resultIdx = _resultIdx;
+			query.m_frameNum = _frameNum;
 			query.m_ready     = false;
 
 			GL_CHECK(glQueryCounter(query.m_begin
@@ -1611,6 +1613,7 @@ namespace bgfx { namespace gl
 
 					Result& result = m_result[query.m_resultIdx];
 					--result.m_pending;
+					result.m_frameNum = query.m_frameNum;
 
 					GL_CHECK(glGetQueryObjectui64v(query.m_begin
 						, GL_QUERY_RESULT
@@ -1633,14 +1636,16 @@ namespace bgfx { namespace gl
 		{
 			void reset()
 			{
-				m_begin   = 0;
-				m_end     = 0;
-				m_pending = 0;
+				m_begin    = 0;
+				m_end      = 0;
+				m_pending  = 0;
+				m_frameNum = 0;
 			}
 
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint32_t m_pending;
+			uint32_t m_frameNum;
 		};
 
 		struct Query
@@ -1648,6 +1653,7 @@ namespace bgfx { namespace gl
 			GLuint   m_begin;
 			GLuint   m_end;
 			uint32_t m_resultIdx;
+			uint32_t m_frameNum;
 			bool     m_ready;
 		};
 

--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -1133,7 +1133,7 @@ namespace bgfx { namespace mtl
 
 		void init();
 		void shutdown();
-		uint32_t begin(uint32_t _resultIdx);
+		uint32_t begin(uint32_t _resultIdx, uint32_t _frameNum);
 		void end(uint32_t _idx);
 		void addHandlers(CommandBuffer& _commandBuffer);
 		bool get();
@@ -1142,14 +1142,16 @@ namespace bgfx { namespace mtl
 		{
 			void reset()
 			{
-				m_begin     = 0;
-				m_end       = 0;
-				m_pending   = 0;
+				m_begin    = 0;
+				m_end      = 0;
+				m_pending  = 0;
+				m_frameNum = 0;
 			}
 
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint32_t m_pending;
+			uint32_t m_frameNum; // TODO: implement (currently stays 0)
 		};
 
 		uint64_t m_begin;

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3677,9 +3677,10 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 	{
 	}
 
-	uint32_t TimerQueryMtl::begin(uint32_t _resultIdx)
+	uint32_t TimerQueryMtl::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
 		BX_UNUSED(_resultIdx);
+		BX_UNUSED(_frameNum);
 		return 0;
 	}
 
@@ -4960,6 +4961,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 		perfStats.numCompute    = statsKeyType[1];
 		perfStats.numBlit       = _render->m_numBlitItems;
 		perfStats.maxGpuLatency = maxGpuLatency;
+		perfStats.gpuFrameNum   = 0; // TODO: take from TimerQueryMtl::Result
 		bx::memCopy(perfStats.numPrims, statsNumPrimsRendered, sizeof(perfStats.numPrims) );
 		perfStats.gpuMemoryMax  = -INT64_MAX;
 		perfStats.gpuMemoryUsed = -INT64_MAX;

--- a/src/renderer_noop.cpp
+++ b/src/renderer_noop.cpp
@@ -252,6 +252,7 @@ namespace bgfx { namespace noop
 			perfStats.gpuTimeBegin  = 0;
 			perfStats.gpuTimeEnd    = 0;
 			perfStats.gpuTimerFreq  = 1000000000;
+			perfStats.gpuFrameNum   = 0;
 
 			bx::memSet(perfStats.numPrims, 0, sizeof(perfStats.numPrims) );
 

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -5322,8 +5322,6 @@ VK_DESTROY
 
 	uint32_t TimerQueryVK::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
-		BX_UNUSED(_frameNum);
-
 		while (0 == m_control.reserve(1) )
 		{
 			m_control.consume(1);
@@ -5336,6 +5334,7 @@ VK_DESTROY
 		Query& query = m_query[idx];
 		query.m_resultIdx = _resultIdx;
 		query.m_ready     = false;
+		query.m_frameNum  = _frameNum;
 
 		const VkCommandBuffer commandBuffer = s_renderVK->m_commandBuffer;
 		const uint32_t offset = idx * 2 + 0;
@@ -5398,6 +5397,7 @@ VK_DESTROY
 
 			Result& result = m_result[query.m_resultIdx];
 			--result.m_pending;
+			result.m_frameNum = query.m_frameNum;
 
 			uint32_t offset = idx * 2;
 			result.m_begin  = m_queryResult[offset+0];

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -5320,8 +5320,10 @@ VK_DESTROY
 		vkDestroy(m_readbackMemory);
 	}
 
-	uint32_t TimerQueryVK::begin(uint32_t _resultIdx)
+	uint32_t TimerQueryVK::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
+		BX_UNUSED(_frameNum);
+
 		while (0 == m_control.reserve(1) )
 		{
 			m_control.consume(1);
@@ -8067,7 +8069,7 @@ VK_DESTROY
 
 		if (m_timerQuerySupport)
 		{
-			frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS);
+			frameQueryIdx = m_gpuTimer.begin(BGFX_CONFIG_MAX_VIEWS, _render->m_frameNum);
 		}
 
 		if (0 < _render->m_iboffset)
@@ -8897,6 +8899,7 @@ VK_DESTROY
 		perfStats.numCompute    = statsKeyType[1];
 		perfStats.numBlit       = _render->m_numBlitItems;
 		perfStats.maxGpuLatency = maxGpuLatency;
+		perfStats.gpuFrameNum   = result.m_frameNum;
 		bx::memCopy(perfStats.numPrims, statsNumPrimsRendered, sizeof(perfStats.numPrims) );
 		perfStats.gpuMemoryMax  = gpuMemoryAvailable;
 		perfStats.gpuMemoryUsed = gpuMemoryUsed;

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -521,7 +521,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 
 		VkResult init();
 		void shutdown();
-		uint32_t begin(uint32_t _resultIdx);
+		uint32_t begin(uint32_t _resultIdx, uint32_t _frameNum);
 		void end(uint32_t _idx);
 		bool update();
 
@@ -529,14 +529,16 @@ VK_DESTROY_FUNC(DescriptorSet);
 		{
 			void reset()
 			{
-				m_begin   = 0;
-				m_end     = 0;
-				m_pending = 0;
+				m_begin    = 0;
+				m_end      = 0;
+				m_pending  = 0;
+				m_frameNum = 0;
 			}
 
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint32_t m_pending;
+			uint32_t m_frameNum; // TODO: implement (currently stays 0)
 		};
 
 		struct Query

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -538,14 +538,15 @@ VK_DESTROY_FUNC(DescriptorSet);
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint32_t m_pending;
-			uint32_t m_frameNum; // TODO: implement (currently stays 0)
+			uint32_t m_frameNum;
 		};
 
 		struct Query
 		{
-			uint32_t  m_resultIdx;
-			bool      m_ready;
-			uint64_t  m_completed;
+			uint32_t m_resultIdx;
+			uint32_t m_frameNum;
+			uint64_t m_completed;
+			bool     m_ready;
 		};
 
 		uint64_t m_frequency;

--- a/src/renderer_webgpu.cpp
+++ b/src/renderer_webgpu.cpp
@@ -3987,9 +3987,10 @@ namespace bgfx { namespace webgpu
 	{
 	}
 
-	uint32_t TimerQueryWgpu::begin(uint32_t _resultIdx)
+	uint32_t TimerQueryWgpu::begin(uint32_t _resultIdx, uint32_t _frameNum)
 	{
 		BX_UNUSED(_resultIdx);
+		BX_UNUSED(_frameNum);
 		return 0;
 	}
 
@@ -4847,6 +4848,7 @@ namespace bgfx { namespace webgpu
 		perfStats.numCompute    = statsKeyType[1];
 		perfStats.numBlit       = _render->m_numBlitItems;
 		perfStats.maxGpuLatency = maxGpuLatency;
+		perfStats.gpuFrameNum   = result.m_frameNum;
 		bx::memCopy(perfStats.numPrims, statsNumPrimsRendered, sizeof(perfStats.numPrims) );
 		perfStats.gpuMemoryMax  = -INT64_MAX;
 		perfStats.gpuMemoryUsed = -INT64_MAX;

--- a/src/renderer_webgpu.h
+++ b/src/renderer_webgpu.h
@@ -509,7 +509,7 @@ namespace bgfx { namespace webgpu
 
 		void init();
 		void shutdown();
-		uint32_t begin(uint32_t _resultIdx);
+		uint32_t begin(uint32_t _resultIdx, uint32_t _frameNum);
 		void end(uint32_t _idx);
 		void addHandlers(wgpu::CommandBuffer& _commandBuffer);
 		bool get();
@@ -521,11 +521,13 @@ namespace bgfx { namespace webgpu
 				m_begin = 0;
 				m_end = 0;
 				m_pending = 0;
+				m_frameNum = 0;
 			}
 
 			uint64_t m_begin;
 			uint64_t m_end;
 			uint32_t m_pending;
+			uint32_t m_frameNum; // TODO: implement (currently stays 0)
 		};
 
 		uint64_t m_begin;


### PR DESCRIPTION
For review — only implemented in GL backend, currently.

The idea here is that when using ViewStats, there's currently no way to know which frame generated the timing data you get back. If you have spikey performance (drastically varying workloads), this means it is hard to correlate which workload took which amount of time.

With this change, the frame number is associated with the timer queries, and reported back in the final data to the user. So, the user can match it with the corresponding calls to `bgfx::submit()` that they sent. I have been using it with success locally. 

However, it still does not protect from the fact that timing data for a given view can get stomped — even though you send a workload on frame X, you may never get back stats for that view on that frame, if they were overwritten due to unlucky timing. But that's a separate issue. At least with this, you can trust the meaning of data you *do* get back.

Some questions:

* Is this something that you'd want in mainline? If so, I can work on adding it to the other backends.
  * If so, and since it's unlikely I can implement *all* backends (esp. Metal is tricky), should support be indicated with a Caps flag?
* I hand-edited the various IDL files. Not sure if that was correct, or there is a better process.
