### PR TITLE
emscripten/webgl2: fix sampler states not being set

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6158,8 +6158,8 @@ namespace bgfx { namespace gl
 		GL_CHECK(glActiveTexture(GL_TEXTURE0+_stage) );
 		GL_CHECK(glBindTexture(m_target, m_id) );
 
-		if (BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGLES)
-		&&  !s_renderGL->m_gles3)
+		if (BX_ENABLED(BX_PLATFORM_EMSCRIPTEN) || 
+		(BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGLES) && !s_renderGL->m_gles3))
 		{
 			// GLES2 doesn't have support for sampler object.
 			setSamplerState(flags, _palette[index]);


### PR DESCRIPTION
As a result of https://github.com/bkaradzic/bgfx/pull/2665, in Emscripten+WebGL2 sampler states were never being set.

WebGL+Emscripten would attempt to set sampler states via sampler objects in `RendererContextGL::setSamplerState` (because `m_gles3` is set to true *at runtime* if it gets a WebGL2 context), but `m_samplerObjectSupport` is set to false if `BX_PLATFORM_EMSCRIPTEN` is defined. 

So under Emscripten + a WebGL2 context (every modern browser) sampler states are simply not set at all, because first it's sent to `RendererContextGL::setSamplerState`, and then that function checks `m_samplerObjectSupport`, sees that it's false, and does nothing.

This fix makes emscripten use the old gles2/webgl1 sampler state pathway which is maybe not ideal but is the easiest fix.