### PR TITLE
Remove alpha-premultiplied postprocess

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -3442,50 +3442,6 @@ namespace bgfx { namespace d3d11
 			}
 		}
 
-		void premultiplyBackBuffer(const ClearQuad& _clearQuad)
-		{
-			ID3D11DeviceContext* deviceCtx = m_deviceCtx;
-
-			uint64_t state = 0;
-			state |= BGFX_STATE_WRITE_RGB;
-			state |= BGFX_STATE_DEPTH_TEST_ALWAYS;
-			state |= BGFX_STATE_BLEND_FUNC_SEPARATE(BGFX_STATE_BLEND_DST_COLOR, BGFX_STATE_BLEND_DST_ALPHA, BGFX_STATE_BLEND_DST_ALPHA, BGFX_STATE_BLEND_ZERO);
-
-			uint64_t stencil = 0;
-
-			setBlendState(state);
-			setDepthStencilState(state, stencil);
-			setRasterizerState(state);
-
-			uint32_t numMrt = 1;
-			if (isValid(_clearQuad.m_program[numMrt-1]))
-			{
-				ProgramD3D11& program = m_program[_clearQuad.m_program[numMrt-1].idx];
-				m_currentProgram = &program;
-
-				const ShaderD3D11* vsh = program.m_vsh;
-				deviceCtx->VSSetShader(vsh->m_vertexShader, NULL, 0);
-				deviceCtx->VSSetConstantBuffers(0, 1, &vsh->m_buffer);
-
-				const ShaderD3D11* fsh = program.m_fsh;
-				deviceCtx->PSSetShader(fsh->m_pixelShader, NULL, 0);
-
-				VertexBufferD3D11& vb = m_vertexBuffers[_clearQuad.m_vb.idx];
-				const VertexLayout& layout = _clearQuad.m_layout;
-
-				const uint32_t stride = layout.m_stride;
-				const uint32_t offset = 0;
-
-				deviceCtx->IASetVertexBuffers(0, 1, &vb.m_ptr, &stride, &offset);
-				setInputLayout(layout, program, 0);
-
-				m_deviceCtx->OMSetRenderTargets(1, &m_backBufferColor, m_backBufferDepthStencil);
-
-				deviceCtx->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
-				deviceCtx->Draw(4, 0);
-			}
-		}
-
 		void clearQuad(ClearQuad& _clearQuad, const Rect& _rect, const Clear& _clear, const float _palette[][4])
 		{
 			uint32_t width;
@@ -6736,11 +6692,6 @@ namespace bgfx { namespace d3d11
 			blit(this, _textVideoMemBlitter, _render->m_textVideoMem);
 
 			BGFX_D3D11_PROFILER_END();
-		}
-
-		if (m_resolution.reset & BGFX_RESET_TRANSPARENT_BACKBUFFER)
-		{
-			premultiplyBackBuffer(_clearQuad);
 		}
 
 		m_deviceCtx->OMSetRenderTargets(1, s_zero.m_rtv, NULL);

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3631,7 +3631,6 @@ namespace bgfx { namespace gl
 		void submitBlit(BlitState& _bs, uint16_t _view);
 
 		void submit(Frame* _render, ClearQuad& _clearQuad, TextVideoMemBlitter& _textVideoMemBlitter) override;
-		void premultiplyBackBuffer(const ClearQuad& _clearQuad);
 		void blitSetup(TextVideoMemBlitter& _blitter) override
 		{
 			if (0 != m_vao)
@@ -7449,39 +7448,6 @@ namespace bgfx { namespace gl
 		}
 	}
 
-	void RendererContextGL::premultiplyBackBuffer(const ClearQuad& _clearQuad)
-	{
-		const uint32_t numMrt = 1;
-		if (isValid(_clearQuad.m_program[numMrt - 1]))
-		{
-			GL_CHECK(glDisable(GL_SCISSOR_TEST));
-			GL_CHECK(glDisable(GL_CULL_FACE));
-			GL_CHECK(glEnable(GL_BLEND));
-			GL_CHECK(glEnable(GL_BLEND));
-			GL_CHECK(glBlendFuncSeparate(GL_DST_COLOR, GL_DST_ALPHA, GL_DST_ALPHA, GL_ZERO));
-
-			GL_CHECK(glColorMask(true, true, true, false));
-			GL_CHECK(glDisable(GL_DEPTH_TEST));
-			GL_CHECK(glDisable(GL_STENCIL_TEST));
-
-			const VertexBufferGL& vb = m_vertexBuffers[_clearQuad.m_vb.idx];
-			const VertexLayout& layout = _clearQuad.m_layout;
-
-			GL_CHECK(glBindBuffer(GL_ARRAY_BUFFER, vb.m_id));
-
-			ProgramGL& program = m_program[_clearQuad.m_program[numMrt - 1].idx];
-			setProgram(program.m_id);
-			program.bindAttributesBegin();
-			program.bindAttributes(layout, 0);
-			program.bindAttributesEnd();
-
-			GL_CHECK(glDrawArrays(GL_TRIANGLE_STRIP
-				, 0
-				, 4
-			));
-		}
-	}
-
 	void RendererContextGL::submit(Frame* _render, ClearQuad& _clearQuad, TextVideoMemBlitter& _textVideoMemBlitter)
 	{
 		if (_render->m_capture)
@@ -8612,11 +8578,6 @@ namespace bgfx { namespace gl
 
 				profiler.end();
 			}
-		}
-
-		if (m_resolution.reset & BGFX_RESET_TRANSPARENT_BACKBUFFER)
-		{
-			premultiplyBackBuffer(_clearQuad);
 		}
 
 		BGFX_GL_PROFILER_END();


### PR DESCRIPTION
The alpha pre-multiplied post process was a mistake. Sorry for that.
The `BGFX_RESET_TRANSPARENT_BACKBUFFER` is still needed because of flag when using a swapChainPanel.