### PR TITLE
d3d12: fixes tri list primitive state change not ackd. after touch call

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -6640,6 +6640,9 @@ namespace bgfx { namespace d3d12
 				uint64_t changedFlags = currentState.m_stateFlags ^ draw.m_stateFlags;
 				currentState.m_stateFlags = newFlags;
 
+				if (0 != (BGFX_STATE_PT_MASK & changedFlags))
+					primIndex = uint8_t((newFlags&BGFX_STATE_PT_MASK)>>BGFX_STATE_PT_SHIFT);
+
 				const uint64_t newStencil = draw.m_stencil;
 				uint64_t changedStencil = (currentState.m_stencil ^ draw.m_stencil) & BGFX_STENCIL_FUNC_REF_MASK;
 				currentState.m_stencil = newStencil;


### PR DESCRIPTION


Suppose this is the draw call sequence in a frame:
- triangle strip
- touch (required to apply stencil changes for example)
- triangle list

Touch masks the change (as it's triangle list by default) by setting changedFlags, but not primIndex. When the triangle list is processed, the STATE_PT is already set to triangle list, so the test for changedFlags is skipped and primIndex stays with triangle strip.

The fix detects the change in the STATE_PT and updates primIndex.