### PR TITLE
Use num instead of regCount

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -3401,7 +3401,7 @@ namespace bgfx { namespace d3d11
 				case UniformType::Mat3|kUniformFragmentBit:
 					 {
 						 float* value = (float*)data;
-						 for (uint32_t ii = 0, count = num/3; ii < count; ++ii,  loc += 3*16, value += 9)
+						 for (uint32_t ii = 0, count = num; ii < count; ++ii,  loc += 3*16, value += 9)
 						 {
 							 Matrix4 mtx;
 							 mtx.un.val[ 0] = value[0];
@@ -3425,11 +3425,11 @@ namespace bgfx { namespace d3d11
 				case UniformType::Sampler | kUniformFragmentBit:
 				case UniformType::Vec4:
 				case UniformType::Vec4 | kUniformFragmentBit:
+					setShaderUniform(uint8_t(type), loc, data, num);
+					break;
 				case UniformType::Mat4:
 				case UniformType::Mat4 | kUniformFragmentBit:
-					{
-						setShaderUniform(uint8_t(type), loc, data, num);
-					}
+					setShaderUniform(uint8_t(type), loc, data, num * 4);
 					break;
 
 				case UniformType::End:
@@ -4147,6 +4147,7 @@ namespace bgfx { namespace d3d11
 
 				uint8_t num = 0;
 				bx::read(&reader, num, &err);
+				num  = bx::max<uint16_t>(1, num);
 
 				uint16_t regIndex = 0;
 				bx::read(&reader, regIndex, &err);
@@ -4190,7 +4191,7 @@ namespace bgfx { namespace d3d11
 						}
 
 						kind = "user";
-						m_constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), regIndex, info->m_handle, regCount);
+						m_constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), regIndex, info->m_handle, num);
 					}
 				}
 				else

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -3241,7 +3241,7 @@ namespace bgfx { namespace d3d12
 				case UniformType::Mat3|kUniformFragmentBit:
 					 {
 						 float* value = (float*)data;
-						 for (uint32_t ii = 0, count = num/3; ii < count; ++ii,  loc += 3*16, value += 9)
+						 for (uint32_t ii = 0, count = num; ii < count; ++ii,  loc += 3*16, value += 9)
 						 {
 							 Matrix4 mtx;
 							 mtx.un.val[ 0] = value[0];
@@ -3265,11 +3265,11 @@ namespace bgfx { namespace d3d12
 				case UniformType::Sampler | kUniformFragmentBit:
 				case UniformType::Vec4:
 				case UniformType::Vec4 | kUniformFragmentBit:
+					setShaderUniform(uint8_t(type), loc, data, num);
+					break;
 				case UniformType::Mat4:
 				case UniformType::Mat4 | kUniformFragmentBit:
-					{
-						setShaderUniform(uint8_t(type), loc, data, num);
-					}
+					setShaderUniform(uint8_t(type), loc, data, num * 4);
 					break;
 
 				case UniformType::End:
@@ -4622,6 +4622,7 @@ namespace bgfx { namespace d3d12
 
 				uint8_t num = 0;
 				bx::read(&reader, num, &err);
+				num  = bx::max<uint16_t>(1, num);
 
 				uint16_t regIndex = 0;
 				bx::read(&reader, regIndex, &err);
@@ -4665,7 +4666,7 @@ namespace bgfx { namespace d3d12
 						}
 
 						kind = "user";
-						m_constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), regIndex, info->m_handle, regCount);
+						m_constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), regIndex, info->m_handle, num);
 					}
 				}
 				else

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1906,18 +1906,18 @@ namespace bgfx { namespace d3d9
 					data = (const char*)m_uniforms[handle.idx];
 				}
 
-#define CASE_IMPLEMENT_UNIFORM(_uniform, _dxsuffix, _type) \
+#define CASE_IMPLEMENT_UNIFORM(_uniform, _dxsuffix, _type, _count) \
 				case UniformType::_uniform: \
 				{ \
 					_type* value = (_type*)data; \
-					DX_CHECK(device->SetVertexShaderConstant##_dxsuffix(loc, value, num) ); \
+					DX_CHECK(device->SetVertexShaderConstant##_dxsuffix(loc, value, num * _count) ); \
 				} \
 				break; \
 				\
 				case UniformType::_uniform|kUniformFragmentBit: \
 				{ \
 					_type* value = (_type*)data; \
-					DX_CHECK(device->SetPixelShaderConstant##_dxsuffix(loc, value, num) ); \
+					DX_CHECK(device->SetPixelShaderConstant##_dxsuffix(loc, value, num * _count) ); \
 				} \
 				break
 
@@ -1926,7 +1926,7 @@ namespace bgfx { namespace d3d9
 				case UniformType::Mat3:
 					{
 						float* value = (float*)data;
-						for (uint32_t ii = 0, count = num/3; ii < count; ++ii,  loc += 3, value += 9)
+						for (uint32_t ii = 0, count = num; ii < count; ++ii,  loc += 3, value += 9)
 						{
 							Matrix4 mtx;
 							mtx.un.val[ 0] = value[0];
@@ -1949,7 +1949,7 @@ namespace bgfx { namespace d3d9
 				case UniformType::Mat3|kUniformFragmentBit:
 					{
 						float* value = (float*)data;
-						for (uint32_t ii = 0, count = num/3; ii < count; ++ii, loc += 3, value += 9)
+						for (uint32_t ii = 0, count = num; ii < count; ++ii, loc += 3, value += 9)
 						{
 							Matrix4 mtx;
 							mtx.un.val[ 0] = value[0];
@@ -1969,9 +1969,9 @@ namespace bgfx { namespace d3d9
 					}
 					break;
 
-				CASE_IMPLEMENT_UNIFORM(Sampler, I, int);
-				CASE_IMPLEMENT_UNIFORM(Vec4,    F, float);
-				CASE_IMPLEMENT_UNIFORM(Mat4,    F, float);
+				CASE_IMPLEMENT_UNIFORM(Sampler, I, int, 1);
+				CASE_IMPLEMENT_UNIFORM(Vec4,    F, float, 1);
+				CASE_IMPLEMENT_UNIFORM(Mat4,    F, float, 4);
 
 				case UniformType::End:
 					break;
@@ -2456,6 +2456,7 @@ namespace bgfx { namespace d3d9
 
 				uint8_t num = 0;
 				bx::read(&reader, num, &err);
+				num  = bx::max<uint16_t>(1, num);
 
 				uint16_t regIndex = 0;
 				bx::read(&reader, regIndex, &err);
@@ -2499,7 +2500,7 @@ namespace bgfx { namespace d3d9
 						}
 
 						kind = "user";
-						m_constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), regIndex, info->m_handle, regCount);
+						m_constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), regIndex, info->m_handle, num);
 					}
 				}
 				else

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6262,6 +6262,7 @@ namespace bgfx { namespace gl
 
 			uint8_t num;
 			bx::read(&reader, num, &err);
+			num  = bx::max<uint16_t>(1, num);
 
 			uint16_t regIndex;
 			bx::read(&reader, regIndex, &err);

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4097,7 +4097,7 @@ VK_IMPORT_DEVICE
 				case UniformType::Mat3|kUniformFragmentBit:
 					 {
 						 float* value = (float*)data;
-						 for (uint32_t ii = 0, count = num/3; ii < count; ++ii,  loc += 3*16, value += 9)
+						 for (uint32_t ii = 0, count = num; ii < count; ++ii,  loc += 3*16, value += 9)
 						 {
 							 Matrix4 mtx;
 							 mtx.un.val[ 0] = value[0];
@@ -4124,11 +4124,11 @@ VK_IMPORT_DEVICE
 
 				case UniformType::Vec4:
 				case UniformType::Vec4 | kUniformFragmentBit:
+					setShaderUniform(uint8_t(type), loc, data, num);
+					break;
 				case UniformType::Mat4:
 				case UniformType::Mat4 | kUniformFragmentBit:
-					{
-						setShaderUniform(uint8_t(type), loc, data, num);
-					}
+					setShaderUniform(uint8_t(type), loc, data, num * 4);
 					break;
 
 				case UniformType::End:
@@ -4801,6 +4801,7 @@ VK_DESTROY
 
 				uint8_t num;
 				bx::read(&reader, num, &err);
+				num  = bx::max<uint16_t>(1, num);
 
 				uint16_t regIndex;
 				bx::read(&reader, regIndex, &err);
@@ -4933,7 +4934,7 @@ VK_DESTROY
 							}
 
 							kind = "user";
-							m_constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), regIndex, info->m_handle, regCount);
+							m_constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), regIndex, info->m_handle, num);
 						}
 					}
 				}

--- a/src/renderer_webgpu.cpp
+++ b/src/renderer_webgpu.cpp
@@ -1504,7 +1504,7 @@ namespace bgfx { namespace webgpu
 				case UniformType::Mat3|kUniformFragmentBit:
 					{
 						float* value = (float*)data;
-						for (uint32_t ii = 0, count = num/3; ii < count; ++ii,  loc += 3*16, value += 9)
+						for (uint32_t ii = 0, count = num; ii < count; ++ii,  loc += 3*16, value += 9)
 						{
 							Matrix4 mtx;
 							mtx.un.val[ 0] = value[0];
@@ -1528,11 +1528,11 @@ namespace bgfx { namespace webgpu
 				case UniformType::Sampler | kUniformFragmentBit:
 				case UniformType::Vec4:
 				case UniformType::Vec4 | kUniformFragmentBit:
+					setShaderUniform(uint8_t(type), loc, data, num);
+					break;
 				case UniformType::Mat4:
 				case UniformType::Mat4 | kUniformFragmentBit:
-					{
-						setShaderUniform(uint8_t(type), loc, data, num);
-					}
+					setShaderUniform(uint8_t(type), loc, data, num * 4);
 					break;
 				case UniformType::End:
 					break;
@@ -2549,6 +2549,7 @@ namespace bgfx { namespace webgpu
 
 				uint8_t num;
 				bx::read(&reader, num, &err);
+				num  = bx::max<uint16_t>(1, num);
 
 				uint16_t regIndex;
 				bx::read(&reader, regIndex, &err);
@@ -2680,7 +2681,7 @@ namespace bgfx { namespace webgpu
 					}
 
 					kind = "user";
-					m_constantBuffer->writeUniformHandle((UniformType::Enum)(type | fragmentBit), regIndex, info->m_handle, regCount);
+					m_constantBuffer->writeUniformHandle((UniformType::Enum)(type | fragmentBit), regIndex, info->m_handle, num);
 				}
 
 				BX_TRACE("\t%s: %s (%s), r.index %3d, r.count %2d, r.texComponent %1d, r.texDimension %1d"


### PR DESCRIPTION
See #2885

I think the `num` in `commit()` is the number of array rather than `regCount` :
```cpp
if (copy) {
	data = _uniformBuffer.read(g_uniformTypeSize[type]*num);  //  num is the number of array
}
```

But `num` in shader file could be 0. We need `num` is at least 1.
```cpp
	bx::read(&reader, num, &err);
	num  = bx::max<uint16_t>(1, num);
```