### PR TITLE
Fix texture conversion in the GL backend

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -5950,7 +5950,7 @@ namespace bgfx { namespace gl
 		const bool unpackRowLength = !!BGFX_CONFIG_RENDERER_OPENGL || s_extension[Extension::EXT_unpack_subimage].m_supported;
 		const bool compressed      = bimg::isCompressed(bimg::TextureFormat::Enum(m_requestedFormat) );
 		const bool convert         = false
-			|| (compressed && m_textureFormat != m_requestedFormat)
+			|| (!compressed && m_textureFormat != m_requestedFormat)
 			|| swizzle
 			;
 


### PR DESCRIPTION
The line as currently written disallows conversions (except swizzle) because `convert` can't be true if `compressed` isn't.