### PR TITLE
CI: Point android ci to bkaradzic/bx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,9 +231,8 @@ jobs:
       - name: Checkout bx
         uses: actions/checkout@v3
         with:
-          repository: thedmd/bx
+          repository: bkaradzic/bx
           path: bx
-          ref: android-ndk-update
       - name: Checkout bimg
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This is follow up to previous `android-ndk-update` draft PR which was merged as-is.

CI was pointed to my repo/branch to test if actions run. This PR reverts that and point them back to `bkaradzic/bx`

@bkaradzic Can you amend last commit https://github.com/bkaradzic/bgfx/commit/04732d89e369844a8d5425210965faba380e0b4b to remove:
`CI: **DO NOT MERGE** pick bx/PR with android support update`?

It is why I kept it as a draft.