### PR TITLE
Fixed SPIRV uniform numbers.

### DIFF
--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -643,7 +643,7 @@ namespace bgfx { namespace spirv
 							continue;
 						}
 
-						un.num = 0;
+						un.num = program->getUniformArraySize(ii);
 						const uint32_t offset = program->getUniformBufferOffset(ii);
 						un.regIndex = uint16_t(offset);
 						un.regCount = uint16_t(program->getUniformArraySize(ii));


### PR DESCRIPTION
Uniform numbers of uniform array should not be fixed to 0.