### PR TITLE
Adds color preset macros to be used for debug text

### DIFF
--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -331,6 +331,20 @@
 #define BGFX_TEXTURE_RT_MASK                      UINT64_C(0x000000f000000000)
 
 /**
+ * VGA Color Presets.
+ *
+ */
+#define BGFX_COLOR_BLUE							  UINT8_C(1)
+#define BGFX_COLOR_RED							  UINT8_C(4)
+#define BGFX_COLOR_ORANGE						  UINT8_C(6)
+#define BGFX_COLOR_GREY  						  UINT8_C(8)
+#define BGFX_COLOR_GREEN						  UINT8_C(10)
+#define BGFX_COLOR_CYAN							  UINT8_C(11)
+#define BGFX_COLOR_MAGENTA						  UINT8_C(13)
+#define BGFX_COLOR_YELLOW  						  UINT8_C(14)
+#define BGFX_COLOR_WHITE						  UINT8_C(15)
+
+/**
  * Sampler flags.
  *
  */


### PR DESCRIPTION
Example use:

```
bgfx::dbgTextPrintf(1, 3, BGFX_COLOR_BLUE, "BLUE");
bgfx::dbgTextPrintf(1, 4, BGFX_COLOR_RED, "RED");
bgfx::dbgTextPrintf(1, 5, BGFX_COLOR_ORANGE, "ORANGE");
bgfx::dbgTextPrintf(1, 6, BGFX_COLOR_GREY, "GREY");
bgfx::dbgTextPrintf(1, 7, BGFX_COLOR_GREEN, "GREEN");
bgfx::dbgTextPrintf(1, 8, BGFX_COLOR_CYAN, "CYAN");
bgfx::dbgTextPrintf(1, 9, BGFX_COLOR_MAGENTA, "MAGENTA");
bgfx::dbgTextPrintf(1, 10, BGFX_COLOR_YELLOW, "YELLOW");
bgfx::dbgTextPrintf(1, 11, BGFX_COLOR_WHITE, "WHITE");
```