### PR TITLE
Added INDEX32 caps support for d3d9 renderer

### DIFF
--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -729,7 +729,7 @@ namespace bgfx { namespace d3d9
 				| ( (m_caps.DevCaps2 & D3DDEVCAPS2_CAN_STRETCHRECT_FROM_TEXTURES) ? BGFX_CAPS_TEXTURE_BLIT : 0)
 				| BGFX_CAPS_TEXTURE_READ_BACK
 				| (m_occlusionQuerySupport ? BGFX_CAPS_OCCLUSION_QUERY : 0)
-				| ((m_caps.MaxVertexIndex >= (1<<16)) ? BGFX_CAPS_INDEX32 : 0)
+				| ((m_caps.MaxVertexIndex > UINT16_MAX) ? BGFX_CAPS_INDEX32 : 0)
 				);
 
 			m_caps.NumSimultaneousRTs = bx::uint32_min(m_caps.NumSimultaneousRTs, BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS);

--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -729,6 +729,7 @@ namespace bgfx { namespace d3d9
 				| ( (m_caps.DevCaps2 & D3DDEVCAPS2_CAN_STRETCHRECT_FROM_TEXTURES) ? BGFX_CAPS_TEXTURE_BLIT : 0)
 				| BGFX_CAPS_TEXTURE_READ_BACK
 				| (m_occlusionQuerySupport ? BGFX_CAPS_OCCLUSION_QUERY : 0)
+				| ((m_caps.MaxVertexIndex >= (1<<16)) ? BGFX_CAPS_INDEX32 : 0)
 				);
 
 			m_caps.NumSimultaneousRTs = bx::uint32_min(m_caps.NumSimultaneousRTs, BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS);


### PR DESCRIPTION
The d3d9 renderer fails on creation of index buffers with **32-bit indices are not supported. Use bgfx::getCaps to check BGFX_CAPS_INDEX32 backend renderer capabilities.** error since the BGFX_CAPS_INDEX32 caps is not handled in the d3d9 renderer path.
This PR has this issue fixed, the INDEX32 index buffers can now be created for d3d9 backend.