### PR TITLE
Removed redundant WaitForVBlank from d3d9 renderer

### DIFF
--- a/src/renderer_d3d9.cpp
+++ b/src/renderer_d3d9.cpp
@@ -1587,11 +1587,6 @@ namespace bgfx { namespace d3d9
 		{
 			if (NULL != m_swapChain)
 			{
-				if (NULL != m_deviceEx)
-				{
-					DX_CHECK(m_deviceEx->WaitForVBlank(0) );
-				}
-
 				for (uint32_t ii = 0, num = m_numWindows; ii < num; ++ii)
 				{
 					HRESULT hr = S_OK;


### PR DESCRIPTION
In D3D9 the wait for vertical sync is implicitly handled inside the device->Present and SwapChain->Present calls based on the value of PresentationInterval field of D3DPRESENT_PARAMTERS, so there is no need to explicitly call WaitForVBlank on flip.

P.S.: If the PresentationInterval field of D3DPRESENT_PARAMTERS is set correctly according to BGFX_RESET_VSYNC (i.e. to D3DPRESENT_INTERVAL_ONE) which is already done in d3d9 renderer, then there is no need to call WaitForVBlank.

Test/Proof: If you set the reset flag to BGFX_RESET_NONE on bgfx::init, for the d3d9 backend it will still keep syncing with monitor vsync which is not expected behavior, it should be unlocked from vsync like other gfx backends, this patch will fix this issue for BGFX_RESET_NONE on d3d9.