### PR TITLE
shaderc HLSL profile switch fix

### DIFF
--- a/scripts/shader-embeded.mk
+++ b/scripts/shader-embeded.mk
@@ -30,11 +30,11 @@ vs_%.bin.h : vs_%.sc
 	-@cat "$(SHADER_TMP)" >> $(@)
 	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform linux   -p spirv       -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_spv
 	-@cat "$(SHADER_TMP)" >> $(@)
-	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p vs_3_0 -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx9
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p s_3_0 -O 3  -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx9
 	-@cat "$(SHADER_TMP)" >> $(@)
-	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p vs_4_0 -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform windows -p s_5_0 -O 3  -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
 	-@cat "$(SHADER_TMP)" >> $(@)
-	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform ios     -p metal  -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_mtl
+	-$(SILENT) $(SHADERC) $(VS_FLAGS) --platform ios     -p metal -O 3  -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_mtl
 	-@cat "$(SHADER_TMP)" >> $(@)
 	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
 	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
@@ -47,24 +47,24 @@ fs_%.bin.h : fs_%.sc
 	-@cat "$(SHADER_TMP)" >> $(@)
 	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform linux   -p spirv       -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_spv
 	-@cat "$(SHADER_TMP)" >> $(@)
-	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p ps_3_0 -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx9
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p s_3_0 -O 3  -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx9
 	-@cat "$(SHADER_TMP)" >> $(@)
-	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p ps_4_0 -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform windows -p s_5_0 -O 3  -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
 	-@cat "$(SHADER_TMP)" >> $(@)
-	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform ios     -p metal  -O 3 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_mtl
+	-$(SILENT) $(SHADERC) $(FS_FLAGS) --platform ios     -p metal -O 3  -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_mtl
 	-@cat "$(SHADER_TMP)" >> $(@)
 	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
 	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)
 
 cs_%.bin.h : cs_%.sc
 	@echo [$(<)]
-	 $(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux -p 430           -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_glsl
+	 $(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux   -p 430         -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_glsl
 	@cat "$(SHADER_TMP)" > $(@)
 	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform android                -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_essl
 	-@cat "$(SHADER_TMP)" >> $(@)
 	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform linux   -p spirv       -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_spv
 	-@cat "$(SHADER_TMP)" >> $(@)
-	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform windows -p cs_5_0 -O 1 -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
+	-$(SILENT) $(SHADERC) $(CS_FLAGS) --platform windows -p s_5_0 -O 1  -f $(<) -o "$(SHADER_TMP)" --bin2c $(basename $(<))_dx11
 	-@cat "$(SHADER_TMP)" >> $(@)
 	-@printf "extern const uint8_t* $(basename $(<))_pssl;\n" | tr -d '\015' >> $(@)
 	-@printf "extern const uint32_t $(basename $(<))_pssl_size;\n" | tr -d '\015' >> $(@)

--- a/scripts/shader.mk
+++ b/scripts/shader.mk
@@ -53,14 +53,14 @@ else
 ADDITIONAL_INCLUDES?=
 
 ifeq ($(TARGET), 0)
-VS_FLAGS=--platform windows -p vs_3_0 -O 3
-FS_FLAGS=--platform windows -p ps_3_0 -O 3
+VS_FLAGS=--platform windows -p s_3_0 -O 3
+FS_FLAGS=--platform windows -p s_3_0 -O 3
 SHADER_PATH=shaders/dx9
 else
 ifeq ($(TARGET), 1)
-VS_FLAGS=--platform windows -p vs_5_0 -O 3
-FS_FLAGS=--platform windows -p ps_5_0 -O 3
-CS_FLAGS=--platform windows -p cs_5_0 -O 1
+VS_FLAGS=--platform windows -p s_5_0 -O 3
+FS_FLAGS=--platform windows -p s_5_0 -O 3
+CS_FLAGS=--platform windows -p s_5_0 -O 1
 SHADER_PATH=shaders/dx11
 else
 ifeq ($(TARGET), 2)

--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -563,6 +563,16 @@ namespace bgfx { namespace hlsl
 			return false;
 		}
 
+		char profileAndType[100];
+		memset(profileAndType, 0, 100);
+		if (_options.shaderType == 'f') {
+			profileAndType[0] = 'p';
+		}
+		else {
+			profileAndType[0] = _options.shaderType;
+		}
+		strcat(profileAndType, profile);
+
 		s_compiler = load();
 
 		bool result = false;
@@ -618,7 +628,7 @@ namespace bgfx { namespace hlsl
 			, NULL
 			, NULL
 			, "main"
-			, profile
+			, profileAndType
 			, flags
 			, 0
 			, &code
@@ -677,7 +687,7 @@ namespace bgfx { namespace hlsl
 		else
 		{
 			UniformNameList unusedUniforms;
-			if (!getReflectionDataD3D11(code, profile[0] == 'v', uniforms, numAttrs, attrs, size, unusedUniforms) )
+			if (!getReflectionDataD3D11(code, profileAndType[0] == 'v', uniforms, numAttrs, attrs, size, unusedUniforms) )
 			{
 				bx::printf("Error: Unable to get D3D11 reflection data.\n");
 				goto error;
@@ -736,7 +746,7 @@ namespace bgfx { namespace hlsl
 			uint16_t count = (uint16_t)uniforms.size();
 			bx::write(_writer, count, &err);
 
-			uint32_t fragmentBit = profile[0] == 'p' ? kUniformFragmentBit : 0;
+			uint32_t fragmentBit = profileAndType[0] == 'p' ? kUniformFragmentBit : 0;
 			for (UniformArray::const_iterator it = uniforms.begin(); it != uniforms.end(); ++it)
 			{
 				const Uniform& un = *it;

--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -563,15 +563,9 @@ namespace bgfx { namespace hlsl
 			return false;
 		}
 
-		char profileAndType[100];
-		memset(profileAndType, 0, 100);
-		if (_options.shaderType == 'f') {
-			profileAndType[0] = 'p';
-		}
-		else {
-			profileAndType[0] = _options.shaderType;
-		}
-		strcat(profileAndType, profile);
+		char profileAndType[100] = {0};
+		profileAndType[0] = (_options.shaderType == 'f') ? 'p' : _options.shaderType;
+		bx::strCat(profileAndType, 100, profile);
 
 		s_compiler = load();
 


### PR DESCRIPTION
shaderc HLSL profile switch is fixed to accept s_3_0, s_4_0, s_5_0 instead of ps_.../vs_.../cs_..., why this fix is necessary?

1- Consistency: with other shader language profiles, e.g. for OpenGL or spirv we only need to specify the profile name (including version) but for hlsl and D3DCompile it was different and used to be like vs_5_0 or ps_5_0, which doesn't make sense IMO.

2- Redundant Info: The shader type (vertex, fragment, compute) is already specified via --type switch, why should we repeat the shader type info in both --profile and --type? (for hlsl only). The type can already be deduced from the --type switch and doesn't make sense to repeat it in --profile like vs_... ps_...  (the s_... should be enough)

3- This is what the shaderc.exe CLI tool help instructs :) it says for hlsl we should just specify s_3_0 to s_5_0, but in reality this will throw an error from D3DCompile as invalid shader target (D3DCompile expects vs, ps, cs).

4- For some build automation and also integration of shader source files with Visual Studio projects (as custom build tool) it is easier to have the hlsl shader profiles as s_... (without the type)