### PR TITLE
Add `Archive` steps to jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,11 @@ jobs:
           ".build\${{ matrix.bindir }}\bin\geometryc${{ matrix.config }}.exe" --version
           ".build\${{ matrix.bindir }}\bin\shaderc${{ matrix.config }}.exe" --version
           ".build\${{ matrix.bindir }}\bin\texturec${{ matrix.config }}.exe" --version
+      - name: Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: msvc-${{ matrix.config }}-${{ matrix.platform }}
+          path: bgfx/.build
   mingw:
     strategy:
       fail-fast: true
@@ -97,6 +102,11 @@ jobs:
           ".build\${{ matrix.bindir }}\bin\geometrycRelease.exe" --version
           ".build\${{ matrix.bindir }}\bin\shadercRelease.exe" --version
           ".build\${{ matrix.bindir }}\bin\texturecRelease.exe" --version
+      - name: Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw-${{ matrix.msystem }}
+          path: bgfx/.build
   linux:
     strategy:
       fail-fast: true
@@ -134,6 +144,11 @@ jobs:
           ".build/linux64_gcc/bin/geometryc${{ matrix.binsuffix}}" --version
           ".build/linux64_gcc/bin/shaderc${{ matrix.binsuffix}}" --version
           ".build/linux64_gcc/bin/texturec${{ matrix.binsuffix}}" --version
+      - name: Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-${{ matrix.config }}64
+          path: bgfx/.build
   wasm:
     strategy:
       fail-fast: true
@@ -170,6 +185,11 @@ jobs:
         run: |
           cd bgfx
           ls -lash ".build/wasm/bin"
+      - name: Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: wasm-${{ matrix.config }}
+          path: bgfx/.build
   osx:
     strategy:
       fail-fast: true
@@ -206,6 +226,11 @@ jobs:
           ".build/osx-x64/bin/geometryc${{ matrix.binsuffix}}" --version
           ".build/osx-x64/bin/shaderc${{ matrix.binsuffix}}" --version
           ".build/osx-x64/bin/texturec${{ matrix.binsuffix}}" --version
+      - name: Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: osx-x64-${{ matrix.config }}
+          path: bgfx/.build
   android:
     strategy:
       fail-fast: true
@@ -248,3 +273,8 @@ jobs:
         run: |
           cd bgfx
           ls -lash ".build/android-${{ matrix.platform }}/bin"
+      - name: Archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: android-${{ matrix.platform }}
+          path: bgfx/.build


### PR DESCRIPTION
This patch adds an `Archive` step to each platform job in order to expose build
artifacts to users. I wrote this patch for @Planimeter initially, as we
experiment with bgfx internally for _Planimeter Game Engine 3D_ and wanted
access to release binaries from GitHub.

bgfx currently does not publish releases. I have opted to not define a `Release`
step along with this patch, as it does not align with bgfx's current release
model. Instead, this patch simply uploads the `bgfx/.build` folder using
GitHub's own `actions/upload-artifact@v3` and artifacts may be downloaded from
the Actions tab in each workflow run.

Currently, during CI, these artifacts are thrown away.

See also:
- https://github.com/Planimeter/bgfx-artifacts
- https://github.com/Planimeter/bgfx-artifacts/actions/runs/3791445931
