### PR TITLE
shaderc update to support Vulkan 1.3 and SPIR-V 1.6 profile option

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -85,6 +85,7 @@ namespace bgfx
 	//       1.3      |       1.1      |      1311
 	//       1.4      |       1.1      |      1411
 	//       1.5      |       1.2      |      1512
+	//       1.6      |       1.3      |      1613
 
 	struct Profile
 	{
@@ -104,11 +105,12 @@ namespace bgfx
 		{  ShadingLang::HLSL,  500,    "s_5_0"      },
 		{  ShadingLang::Metal, 1000,   "metal"      },
 		{  ShadingLang::PSSL,  1000,   "pssl"       },
+		{  ShadingLang::SpirV, 1010,   "spirv"      },
+		{  ShadingLang::SpirV, 1010,   "spirv10-10" },
 		{  ShadingLang::SpirV, 1311,   "spirv13-11" },
 		{  ShadingLang::SpirV, 1411,   "spirv14-11" },
 		{  ShadingLang::SpirV, 1512,   "spirv15-12" },
-		{  ShadingLang::SpirV, 1010,   "spirv10-10" },
-		{  ShadingLang::SpirV, 1010,   "spirv"      },
+		{  ShadingLang::SpirV, 1613,   "spirv16-13" },
 		{  ShadingLang::GLSL,  120,    "120"        },
 		{  ShadingLang::GLSL,  130,    "130"        },
 		{  ShadingLang::GLSL,  140,    "140"        },

--- a/tools/shaderc/shaderc_spirv.cpp
+++ b/tools/shaderc/shaderc_spirv.cpp
@@ -385,6 +385,8 @@ namespace bgfx { namespace spirv
 				return SPV_ENV_VULKAN_1_1_SPIRV_1_4;
 			case 1512:
 				return SPV_ENV_VULKAN_1_2;
+			case 1613:
+				return SPV_ENV_VULKAN_1_3;
 			default:
 				BX_ASSERT(0, "Unknown SPIR-V version requested. Returning SPV_ENV_VULKAN_1_0 as default.");
 				return SPV_ENV_VULKAN_1_0;
@@ -402,6 +404,8 @@ namespace bgfx { namespace spirv
 				return glslang::EShTargetVulkan_1_1;
 			case 1512:
 				return glslang::EShTargetVulkan_1_2;
+			case 1613:
+				return glslang::EShTargetVulkan_1_3;
 			default:
 				BX_ASSERT(0, "Unknown SPIR-V version requested. Returning EShTargetVulkan_1_0 as default.");
 				return glslang::EShTargetVulkan_1_0;
@@ -420,6 +424,8 @@ namespace bgfx { namespace spirv
 				return glslang::EShTargetSpv_1_4;
 			case 1512:
 				return glslang::EShTargetSpv_1_5;
+			case 1613:
+				return glslang::EShTargetSpv_1_6;
 			default:
 				BX_ASSERT(0, "Unknown SPIR-V version requested. Returning EShTargetSpv_1_0 as default.");
 				return glslang::EShTargetSpv_1_0;


### PR DESCRIPTION
This fixes https://github.com/bkaradzic/bgfx/issues/3016

This change ~specifcally~ specifically:
- adds support for Vulkan 1.3 using SPIR-V 1.6 as a profile target
- moves ordering of help information of SPIR-V block
- updates the SPIR-V to Vulkan mapping documentation