### PR TITLE
[GL] Fix sRGB framebuffer write

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3821,18 +3821,6 @@ namespace bgfx { namespace gl
 				m_needPresent |= true;
 
 				m_currentFbo = m_msaaBackBufferFbo;
-
-				if (m_srgbWriteControlSupport)
-				{
-					if (0 != (m_resolution.reset & BGFX_RESET_SRGB_BACKBUFFER) )
-					{
-						GL_CHECK(glEnable(GL_FRAMEBUFFER_SRGB) );
-					}
-					else
-					{
-						GL_CHECK(glDisable(GL_FRAMEBUFFER_SRGB) );
-					}
-				}
 			}
 			else
 			{
@@ -3850,6 +3838,26 @@ namespace bgfx { namespace gl
 				{
 					m_glctx.makeCurrent(NULL);
 					m_currentFbo = frameBuffer.m_fbo[0];
+				}
+			}
+
+			if (m_srgbWriteControlSupport)
+			{
+				if (0 == m_currentFbo)
+				{
+					if (0 != (m_resolution.reset & BGFX_RESET_SRGB_BACKBUFFER) )
+					{
+						GL_CHECK(glEnable(GL_FRAMEBUFFER_SRGB) );
+					}
+					else
+					{
+						GL_CHECK(glDisable(GL_FRAMEBUFFER_SRGB) );
+					}
+				}
+				else
+				{
+					// actual sRGB write/blending determined by FBO's color attachments format
+					GL_CHECK(glEnable(GL_FRAMEBUFFER_SRGB) );
 				}
 			}
 
@@ -8578,6 +8586,12 @@ namespace bgfx { namespace gl
 				captureElapsed += bx::getHPCounter();
 
 				profiler.end();
+			}
+
+			if (m_srgbWriteControlSupport)
+			{
+				// switch state back to default for cases when the on-screen draw is done externally
+				GL_CHECK(glDisable(GL_FRAMEBUFFER_SRGB) );
 			}
 		}
 


### PR DESCRIPTION
Context: GL (and GLES with [EXT_sRGB_write_control](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_sRGB_write_control.txt)) determine whether to perform sRGB writes based on both the format of the current surface / FBO attachment **and** the FRAMEBUFFER_SRGB flag.

The patch enables FRAMEBUFFER_SRGB for all FBOs, so that the sRGB mode is solely controlled by the texture format of the color attachments (e.g. RGBA8 vs SRGB8). This is in line with the behavior of the other backends, and GLES without EXT_sRGB_write_control (and in turn with WebGL 2).

_Note 1_: The "default" framebuffers (onscreen surfaces) are left as is, meaning they're controlled by the FRAMEBUFFER_SRGB flag, because after some experiments, it seems that drivers behave very erratically when asked for SRGB capable system surfaces (through the appropriate GLX/WGL/EGL extensions). They seem to ignore the spec and not care about the surface, enabling the sRGB mode just based on the FRAMEBUFFER_SRGB state. This is why the current behavior works for on-screen framebuffers. We're just fixing FBOs here.

_Note 2_: The extra part at the end of the frame where we reset the flag back to its default disabled state is not necessary and only meant to avoid breaking the compositing of apps integrating bgfx with another library (such as Qt or gtk). The performance impact of this additional call should be negligeable.