### PR TITLE
Add new nvgImportBgfxTexture() helper function 

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -1353,3 +1353,19 @@ int nvgCreateBgfxTexture(struct NVGcontext *_ctx,
     tex->type = NVG_TEXTURE_RGBA;
     return tex->id.idx;
 }
+
+int nvgImportBgfxTexture(struct NVGcontext *_ctx,
+                         bgfx::TextureHandle _id,
+                         int _width,
+                         int _height,
+                         int _flags) {
+    struct NVGparams *params = nvgInternalParams(_ctx);
+    struct GLNVGcontext *gl = (struct GLNVGcontext *)params->userPtr;
+    struct GLNVGtexture *tex = glnvg__allocTexture(gl);
+    tex->id = _id;
+    tex->width = _width;
+    tex->height = _height;
+    tex->flags = _flags | NVG_IMAGE_NODELETE;
+    tex->type = NVG_TEXTURE_RGBA;
+    return tex->id.idx;
+}

--- a/examples/common/nanovg/nanovg_bgfx.h
+++ b/examples/common/nanovg/nanovg_bgfx.h
@@ -79,4 +79,7 @@ void nvgluSetViewFramebuffer(bgfx::ViewId _viewId, NVGLUframebuffer* _framebuffe
 ///
 int nvgCreateBgfxTexture(struct NVGcontext *_ctx, bgfx::TextureHandle _id, int _width, int _height, int _flags);
 
+///
+int nvgImportBgfxTexture(struct NVGcontext *_ctx, bgfx::TextureHandle _id, int _width, int _height, int _flags);
+
 #endif // NANOVG_BGFX_H_HEADER_GUARD

--- a/examples/common/nanovg/nanovg_bgfx.h
+++ b/examples/common/nanovg/nanovg_bgfx.h
@@ -76,4 +76,7 @@ void nvgluDeleteFramebuffer(NVGLUframebuffer* _framebuffer);
 ///
 void nvgluSetViewFramebuffer(bgfx::ViewId _viewId, NVGLUframebuffer* _framebuffer);
 
+///
+int nvgCreateBgfxTexture(struct NVGcontext *_ctx, bgfx::TextureHandle _id, int _width, int _height, int _flags);
+
 #endif // NANOVG_BGFX_H_HEADER_GUARD


### PR DESCRIPTION
This is a minor update to the example nanovg wrapper library, to allow importing of existing BGFX textures into nanovg.