### PR TITLE
Fix independent blend parameter on Vulkan, D3d11 and D3d12

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -5955,7 +5955,7 @@ namespace bgfx { namespace d3d11
 
 					currentBind.clear();
 
-					setBlendState(newFlags);
+					setBlendState(newFlags, draw.m_rgba);
 					setDepthStencilState(newFlags, packStencil(BGFX_STENCIL_DEFAULT, BGFX_STENCIL_DEFAULT) );
 
 					const uint64_t pt = newFlags&BGFX_STATE_PT_MASK;

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -2185,6 +2185,7 @@ namespace bgfx { namespace d3d12
 
 			const VertexLayout* layouts[1] = { &m_vertexLayouts[_blitter.m_vb->layoutHandle.idx] };
 			ID3D12PipelineState* pso = getPipelineState(state
+				, 0
 				, packStencil(BGFX_STENCIL_DEFAULT, BGFX_STENCIL_DEFAULT)
 				, 1
 				, layouts
@@ -3047,6 +3048,7 @@ namespace bgfx { namespace d3d12
 
 		ID3D12PipelineState* getPipelineState(
 			  uint64_t _state
+			, uint64_t _rgba
 			, uint64_t _stencil
 			, uint8_t _numStreams
 			, const VertexLayout** _layouts
@@ -3216,7 +3218,7 @@ namespace bgfx { namespace d3d12
 			desc.StreamOutput.NumStrides       = 0;
 			desc.StreamOutput.RasterizedStream = 0;
 
-			setBlendState(desc.BlendState, _state);
+			setBlendState(desc.BlendState, _state, _rgba);
 			desc.SampleMask = UINT32_MAX;
 			setRasterizerState(desc.RasterizerState, _state);
 			setDepthStencilState(desc.DepthStencilState, _state, _stencil);
@@ -6879,6 +6881,7 @@ namespace bgfx { namespace d3d12
 
 					ID3D12PipelineState* pso = getPipelineState(
 						  state
+						, draw.m_rgba
 						, draw.m_stencil
 						, numStreams
 						, layouts

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -2592,6 +2592,7 @@ VK_IMPORT_DEVICE
 
 			const VertexLayout* layout = &m_vertexLayouts[_blitter.m_vb->layoutHandle.idx];
 			VkPipeline pso = getPipeline(state
+				, 0
 				, packStencil(BGFX_STENCIL_DEFAULT, BGFX_STENCIL_DEFAULT)
 				, 1
 				, &layout
@@ -3525,7 +3526,7 @@ VK_IMPORT_DEVICE
 			return pipeline;
 		}
 
-		VkPipeline getPipeline(uint64_t _state, uint64_t _stencil, uint8_t _numStreams, const VertexLayout** _layouts, ProgramHandle _program, uint8_t _numInstanceData)
+		VkPipeline getPipeline(uint64_t _state, uint64_t _rgba, uint64_t _stencil, uint8_t _numStreams, const VertexLayout** _layouts, ProgramHandle _program, uint8_t _numInstanceData)
 		{
 			ProgramVK& program = m_program[_program.idx];
 
@@ -3597,7 +3598,7 @@ VK_IMPORT_DEVICE
 			VkPipelineColorBlendAttachmentState blendAttachmentState[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS];
 			VkPipelineColorBlendStateCreateInfo colorBlendState;
 			colorBlendState.pAttachments = blendAttachmentState;
-			setBlendState(colorBlendState, _state);
+			setBlendState(colorBlendState, _state, _rgba);
 
 			VkPipelineInputAssemblyStateCreateInfo inputAssemblyState;
 			inputAssemblyState.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
@@ -8549,6 +8550,7 @@ VK_DESTROY
 
 					const VkPipeline pipeline =
 						getPipeline(draw.m_stateFlags
+							, draw.m_rgba
 							, draw.m_stencil
 							, numStreams
 							, layouts


### PR DESCRIPTION
Hello,

I noticed the `_rgba` parameter from `setState` was not forwarded on some platforms.
This is needed when working with `BGFX_STATE_BLEND_INDEPENDENT`.

g.e:
```
bgfx::setState(
        state | BGFX_STATE_BLEND_INDEPENDENT,
	BGFX_STATE_BLEND_FUNC_RT_1(BGFX_STATE_BLEND_ZERO, BGFX_STATE_BLEND_SRC_COLOR)
	);

```