### PR TITLE
Expose nvgCreateBgfxTexture() helper function

### DIFF
--- a/examples/common/nanovg/nanovg_bgfx.cpp
+++ b/examples/common/nanovg/nanovg_bgfx.cpp
@@ -58,11 +58,6 @@ namespace
 		NSVG_SHADER_IMG
 	};
 
-	// These are additional flags on top of NVGimageFlags.
-	enum NVGimageFlagsGL {
-		NVG_IMAGE_NODELETE = 1<<16, // Do not delete GL texture handle.
-	};
-
 	struct GLNVGtexture
 	{
 		bgfx::TextureHandle id;

--- a/examples/common/nanovg/nanovg_bgfx.h
+++ b/examples/common/nanovg/nanovg_bgfx.h
@@ -20,6 +20,11 @@ struct NVGLUframebuffer
   bgfx::ViewId viewId;
 };
 
+// These are additional flags on top of NVGimageFlags.
+enum NVGimageFlagsGL {
+	NVG_IMAGE_NODELETE = 1<<16, // Do not delete GL texture handle.
+};
+
 ///
 NVGcontext* nvgCreate(int32_t _edgeaa, bgfx::ViewId _viewId, bx::AllocatorI* _allocator);
 
@@ -75,5 +80,8 @@ void nvgluDeleteFramebuffer(NVGLUframebuffer* _framebuffer);
 
 ///
 void nvgluSetViewFramebuffer(bgfx::ViewId _viewId, NVGLUframebuffer* _framebuffer);
+
+///
+int nvgCreateBgfxTexture(struct NVGcontext *_ctx, bgfx::TextureHandle _id, int _width, int _height, int _flags);
 
 #endif // NANOVG_BGFX_H_HEADER_GUARD


### PR DESCRIPTION
The nvgCreateBgfxTexture() helper function is already implemented in the nanovg wrapper library, so its useful to expose this function to the user.

Also expose the NVG_IMAGE_NODELETE flag so this can be passed to the nvgCreateBgfxTexture() function, to indicate that the caller retains ownership of the bgfx texture.