### PR TITLE
Write messages to a stream specified by the caller of compilerShader …

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -1071,8 +1071,10 @@ namespace bgfx
 		return word;
 	}
 
-	bool compileShader(const char* _varying, const char* _comment, char* _shader, uint32_t _shaderLen, Options& _options, bx::WriterI* _writer)
+	bool compileShader(const char* _varying, const char* _comment, char* _shader, uint32_t _shaderLen, Options& _options, bx::WriterI* _writer, bx::WriterI* _messages)
 	{
+		bx::Error messageErr;
+
 		uint32_t profile_id = 0;
 
 		const char* profile_opt = _options.profile.c_str();
@@ -1098,7 +1100,7 @@ namespace bgfx
 
 			if (profile_id == count)
 			{
-				bx::printf("Unknown profile: %s\n", profile_opt);
+				bx::write(_messages, &messageErr, "Unknown profile: %s\n", profile_opt);
 				return false;
 			}
 		}
@@ -1275,7 +1277,7 @@ namespace bgfx
 			break;
 
 		default:
-			bx::printf("Unknown type: %c?!", _options.shaderType);
+			bx::write(_messages, &messageErr, "Unknown type: %c?!", _options.shaderType);
 			return false;
 		}
 
@@ -1460,7 +1462,7 @@ namespace bgfx
 				if (bx::findIdentifierMatch(it->c_str(), s_allowedVertexShaderInputs).isEmpty() )
 				{
 					invalidShaderAttribute = true;
-					bx::printf(
+					bx::write(_messages, &messageErr,
 						  "Invalid vertex shader input attribute '%s'.\n"
 						  "\n"
 						  "Valid input attributes:\n"
@@ -1511,19 +1513,19 @@ namespace bgfx
 			}
 			else if (profile->lang == ShadingLang::Metal)
 			{
-				compiled = compileMetalShader(_options, BX_MAKEFOURCC('M', 'T', 'L', 0), input, _writer);
+				compiled = compileMetalShader(_options, BX_MAKEFOURCC('M', 'T', 'L', 0), input, _writer, _messages);
 			}
 			else if (profile->lang == ShadingLang::SpirV)
 			{
-				compiled = compileSPIRVShader(_options, profile->id, input, _writer);
+				compiled = compileSPIRVShader(_options, profile->id, input, _writer, _messages);
 			}
 			else if (profile->lang == ShadingLang::PSSL)
 			{
-				compiled = compilePSSLShader(_options, 0, input, _writer);
+				compiled = compilePSSLShader(_options, 0, input, _writer, _messages);
 			}
 			else
 			{
-				compiled = compileHLSLShader(_options, profile->id, input, _writer);
+				compiled = compileHLSLShader(_options, profile->id, input, _writer, _messages);
 			}
 		}
 		else if ('c' == _options.shaderType) // Compute
@@ -1531,7 +1533,7 @@ namespace bgfx
 			bx::StringView entry = bx::strFind(input, "void main()");
 			if (entry.isEmpty() )
 			{
-				bx::printf("Shader entry point 'void main()' is not found.\n");
+				bx::write(_messages, &messageErr, "Shader entry point 'void main()' is not found.\n");
 			}
 			else
 			{
@@ -1668,19 +1670,19 @@ namespace bgfx
 
 							if (profile->lang == ShadingLang::Metal)
 							{
-								compiled = compileMetalShader(_options, BX_MAKEFOURCC('M', 'T', 'L', 0), code, _writer);
+								compiled = compileMetalShader(_options, BX_MAKEFOURCC('M', 'T', 'L', 0), code, _writer, _messages);
 							}
 							else if (profile->lang == ShadingLang::SpirV)
 							{
-								compiled = compileSPIRVShader(_options, profile->id, code, _writer);
+								compiled = compileSPIRVShader(_options, profile->id, code, _writer, _messages);
 							}
 							else if (profile->lang == ShadingLang::PSSL)
 							{
-								compiled = compilePSSLShader(_options, 0, code, _writer);
+								compiled = compilePSSLShader(_options, 0, code, _writer, _messages);
 							}
 							else
 							{
-								compiled = compileHLSLShader(_options, profile->id, code, _writer);
+								compiled = compileHLSLShader(_options, profile->id, code, _writer, _messages);
 							}
 						}
 					}
@@ -1708,7 +1710,7 @@ namespace bgfx
 			bx::StringView entry = bx::strFind(shader, "void main()");
 			if (entry.isEmpty() )
 			{
-				bx::printf("Shader entry point 'void main()' is not found.\n");
+				bx::write(_messages, &messageErr, "Shader entry point 'void main()' is not found.\n");
 			}
 			else
 			{
@@ -1959,7 +1961,7 @@ namespace bgfx
 							}
 							else
 							{
-								bx::printf("gl_PrimitiveID builtin is not supported by D3D9 HLSL.\n");
+								bx::write(_messages, &messageErr, "gl_PrimitiveID builtin is not supported by D3D9 HLSL.\n");
 								return false;
 							}
 						}
@@ -2034,7 +2036,7 @@ namespace bgfx
 							}
 							else
 							{
-								bx::printf("gl_ViewportIndex builtin is not supported by D3D9 HLSL.\n");
+								bx::write(_messages, &messageErr, "gl_ViewportIndex builtin is not supported by D3D9 HLSL.\n");
 								return false;
 							}
 						}
@@ -2050,7 +2052,7 @@ namespace bgfx
 							}
 							else
 							{
-								bx::printf("gl_Layer builtin is not supported by D3D9 HLSL.\n");
+								bx::write(_messages, &messageErr, "gl_Layer builtin is not supported by D3D9 HLSL.\n");
 								return false;
 							}
 						}
@@ -2089,7 +2091,7 @@ namespace bgfx
 							}
 							else
 							{
-								bx::printf("gl_VertexID builtin is not supported by D3D9 HLSL.\n");
+								bx::write(_messages, &messageErr, "gl_VertexID builtin is not supported by D3D9 HLSL.\n");
 								return false;
 							}
 						}
@@ -2105,7 +2107,7 @@ namespace bgfx
 							}
 							else
 							{
-								bx::printf("gl_InstanceID builtin is not supported by D3D9 HLSL.\n");
+								bx::write(_messages, &messageErr, "gl_InstanceID builtin is not supported by D3D9 HLSL.\n");
 								return false;
 							}
 						}
@@ -2557,7 +2559,7 @@ namespace bgfx
 									glsl_profile |= 0x80000000;
 								}
 
-								compiled = compileGLSLShader(_options, glsl_profile, code, _writer);
+								compiled = compileGLSLShader(_options, glsl_profile, code, _writer, _messages);
 							}
 						}
 						else
@@ -2567,19 +2569,19 @@ namespace bgfx
 
 							if (profile->lang == ShadingLang::Metal)
 							{
-								compiled = compileMetalShader(_options, BX_MAKEFOURCC('M', 'T', 'L', 0), code, _writer);
+								compiled = compileMetalShader(_options, BX_MAKEFOURCC('M', 'T', 'L', 0), code, _writer, _messages);
 							}
 							else if (profile->lang == ShadingLang::SpirV)
 							{
-								compiled = compileSPIRVShader(_options, profile->id, code, _writer);
+								compiled = compileSPIRVShader(_options, profile->id, code, _writer, _messages);
 							}
 							else if (profile->lang == ShadingLang::PSSL)
 							{
-								compiled = compilePSSLShader(_options, 0, code, _writer);
+								compiled = compilePSSLShader(_options, 0, code, _writer, _messages);
 							}
 							else
 							{
-								compiled = compileHLSLShader(_options, profile->id, code, _writer);
+								compiled = compileHLSLShader(_options, profile->id, code, _writer, _messages);
 							}
 						}
 					}
@@ -2837,7 +2839,7 @@ namespace bgfx
 				}
 			}
 
-			compiled = compileShader(varying, commandLineComment.c_str(), data, size, options, consoleOut ? bx::getStdOut() : writer);
+			compiled = compileShader(varying, commandLineComment.c_str(), data, size, options, consoleOut ? bx::getStdOut() : writer, bx::getStdOut());
 
 			if (!consoleOut)
 			{

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -454,7 +454,7 @@ namespace bgfx
 		return UniformType::Count;
 	}
 
-	int32_t writef(bx::WriterI* _shaderWriter, const char* _format, ...)
+	int32_t writef(bx::WriterI* _writer, const char* _format, ...)
 	{
 		va_list argList;
 		va_start(argList, _format);
@@ -470,7 +470,7 @@ namespace bgfx
 			len = bx::vsnprintf(out, len, _format, argList);
 		}
 
-		len = bx::write(_shaderWriter, out, len, bx::ErrorAssert{});
+		len = bx::write(_writer, out, len, bx::ErrorAssert{});
 
 		va_end(argList);
 

--- a/tools/shaderc/shaderc.h
+++ b/tools/shaderc/shaderc.h
@@ -119,11 +119,11 @@ namespace bgfx
 	int32_t writef(bx::WriterI* _writer, const char* _format, ...);
 	void writeFile(const char* _filePath, const void* _data, int32_t _size);
 
-	bool compileGLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer);
-	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer);
-	bool compileMetalShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer);
-	bool compilePSSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer);
-	bool compileSPIRVShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer);
+	bool compileGLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages);
+	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages);
+	bool compileMetalShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages);
+	bool compilePSSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages);
+	bool compileSPIRVShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages);
 
 	const char* getPsslPreamble();
 

--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -8,9 +8,9 @@
 
 namespace bgfx { namespace glsl
 {
-	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
+	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _shaderWriter, bx::WriterI* _messageWriter)
 	{
-		bx::Error messageErr;
+		bx::ErrorAssert messageErr;
 
 		char ch = _options.shaderType;
 		const glslopt_shader_type type = ch == 'f'
@@ -55,7 +55,7 @@ namespace bgfx { namespace glsl
 			}
 
 			printCode(_code.c_str(), line, start, end, column);
-			bx::write(_messages, &messageErr, "Error: %s\n", log);
+			bx::write(_messageWriter, &messageErr, "Error: %s\n", log);
 			glslopt_shader_delete(shader);
 			glslopt_cleanup(ctx);
 			return false;
@@ -350,22 +350,22 @@ namespace bgfx { namespace glsl
 		bx::ErrorAssert err;
 
 		uint16_t count = (uint16_t)uniforms.size();
-		bx::write(_writer, count, &err);
+		bx::write(_shaderWriter, count, &err);
 
 		for (UniformArray::const_iterator it = uniforms.begin(); it != uniforms.end(); ++it)
 		{
 			const Uniform& un = *it;
 			uint8_t nameSize = (uint8_t)un.name.size();
-			bx::write(_writer, nameSize, &err);
-			bx::write(_writer, un.name.c_str(), nameSize, &err);
+			bx::write(_shaderWriter, nameSize, &err);
+			bx::write(_shaderWriter, un.name.c_str(), nameSize, &err);
 			uint8_t uniformType = uint8_t(un.type);
-			bx::write(_writer, uniformType, &err);
-			bx::write(_writer, un.num, &err);
-			bx::write(_writer, un.regIndex, &err);
-			bx::write(_writer, un.regCount, &err);
-			bx::write(_writer, un.texComponent, &err);
-			bx::write(_writer, un.texDimension, &err);
-			bx::write(_writer, un.texFormat, &err);
+			bx::write(_shaderWriter, uniformType, &err);
+			bx::write(_shaderWriter, un.num, &err);
+			bx::write(_shaderWriter, un.regIndex, &err);
+			bx::write(_shaderWriter, un.regCount, &err);
+			bx::write(_shaderWriter, un.texComponent, &err);
+			bx::write(_shaderWriter, un.texDimension, &err);
+			bx::write(_shaderWriter, un.texFormat, &err);
 
 			BX_TRACE("%s, %s, %d, %d, %d"
 				, un.name.c_str()
@@ -377,10 +377,10 @@ namespace bgfx { namespace glsl
 		}
 
 		uint32_t shaderSize = (uint32_t)bx::strLen(optimizedShader);
-		bx::write(_writer, shaderSize, &err);
-		bx::write(_writer, optimizedShader, shaderSize, &err);
+		bx::write(_shaderWriter, shaderSize, &err);
+		bx::write(_shaderWriter, optimizedShader, shaderSize, &err);
 		uint8_t nul = 0;
-		bx::write(_writer, nul, &err);
+		bx::write(_shaderWriter, nul, &err);
 
 		if (_options.disasm )
 		{
@@ -396,9 +396,9 @@ namespace bgfx { namespace glsl
 
 } // namespace glsl
 
-	bool compileGLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
+	bool compileGLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _shaderWriter, bx::WriterI* _messageWriter)
 	{
-		return glsl::compile(_options, _version, _code, _writer, _messages);
+		return glsl::compile(_options, _version, _code, _shaderWriter, _messageWriter);
 	}
 
 } // namespace bgfx

--- a/tools/shaderc/shaderc_glsl.cpp
+++ b/tools/shaderc/shaderc_glsl.cpp
@@ -8,8 +8,10 @@
 
 namespace bgfx { namespace glsl
 {
-	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer)
+	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
 	{
+		bx::Error messageErr;
+
 		char ch = _options.shaderType;
 		const glslopt_shader_type type = ch == 'f'
 			? kGlslOptShaderFragment
@@ -53,7 +55,7 @@ namespace bgfx { namespace glsl
 			}
 
 			printCode(_code.c_str(), line, start, end, column);
-			bx::printf("Error: %s\n", log);
+			bx::write(_messages, &messageErr, "Error: %s\n", log);
 			glslopt_shader_delete(shader);
 			glslopt_cleanup(ctx);
 			return false;
@@ -394,9 +396,9 @@ namespace bgfx { namespace glsl
 
 } // namespace glsl
 
-	bool compileGLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer)
+	bool compileGLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
 	{
-		return glsl::compile(_options, _version, _code, _writer);
+		return glsl::compile(_options, _version, _code, _writer, _messages);
 	}
 
 } // namespace bgfx

--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -80,7 +80,7 @@ namespace bgfx { namespace hlsl
 	static const D3DCompiler* s_compiler;
 	static void* s_d3dcompilerdll;
 
-	const D3DCompiler* load(bx::WriterI* _messages)
+	const D3DCompiler* load(bx::WriterI* _messageWriter)
 	{
 		bx::Error messageErr;
 
@@ -117,7 +117,7 @@ namespace bgfx { namespace hlsl
 			return compiler;
 		}
 
-		bx::write(_messages, &messageErr, "Error: Unable to open D3DCompiler_*.dll shader compiler.\n");
+		bx::write(_messageWriter, &messageErr, "Error: Unable to open D3DCompiler_*.dll shader compiler.\n");
 		return NULL;
 	}
 
@@ -278,9 +278,9 @@ namespace bgfx { namespace hlsl
 		return false;
 	}
 
-	bool getReflectionDataD3D9(ID3DBlob* _code, UniformArray& _uniforms, bx::WriterI* _messages)
+	bool getReflectionDataD3D9(ID3DBlob* _code, UniformArray& _uniforms, bx::WriterI* _messageWriter)
 	{
-		bx::Error messageErr;
+		bx::ErrorAssert messageErr;
 
 		// see reference for magic values: https://msdn.microsoft.com/en-us/library/ff552891(VS.85).aspx
 		const uint32_t D3DSIO_COMMENT = 0x0000FFFE;
@@ -315,7 +315,7 @@ namespace bgfx { namespace hlsl
 				uint32_t tableSize = (commentSize - 1) * 4;
 				if (tableSize < sizeof(CTHeader) || header->Size != sizeof(CTHeader) )
 				{
-					bx::write(_messages, &messageErr, "Error: Invalid constant table data\n");
+					bx::write(_messageWriter, &messageErr, "Error: Invalid constant table data\n");
 					return false;
 				}
 				break;
@@ -327,7 +327,7 @@ namespace bgfx { namespace hlsl
 
 		if (!header)
 		{
-			bx::write(_messages, &messageErr, "Error: Could not find constant table data\n");
+			bx::write(_messageWriter, &messageErr, "Error: Could not find constant table data\n");
 			return false;
 		}
 
@@ -385,7 +385,7 @@ namespace bgfx { namespace hlsl
 		return true;
 	}
 
-	bool getReflectionDataD3D11(ID3DBlob* _code, bool _vshader, UniformArray& _uniforms, uint8_t& _numAttrs, uint16_t* _attrs, uint16_t& _size, UniformNameList& unusedUniforms, bx::WriterI* _messages)
+	bool getReflectionDataD3D11(ID3DBlob* _code, bool _vshader, UniformArray& _uniforms, uint8_t& _numAttrs, uint16_t* _attrs, uint16_t& _size, UniformNameList& unusedUniforms, bx::WriterI* _messageWriter)
 	{
 		bx::Error messageErr;
 
@@ -397,7 +397,7 @@ namespace bgfx { namespace hlsl
 			);
 		if (FAILED(hr) )
 		{
-			bx::write(_messages, &messageErr, "Error: D3DReflect failed 0x%08x\n", (uint32_t)hr);
+			bx::write(_messageWriter, &messageErr, "Error: D3DReflect failed 0x%08x\n", (uint32_t)hr);
 			return false;
 		}
 
@@ -405,7 +405,7 @@ namespace bgfx { namespace hlsl
 		hr = reflect->GetDesc(&desc);
 		if (FAILED(hr) )
 		{
-			bx::write(_messages, &messageErr, "Error: ID3D11ShaderReflection::GetDesc failed 0x%08x\n", (uint32_t)hr);
+			bx::write(_messageWriter, &messageErr, "Error: ID3D11ShaderReflection::GetDesc failed 0x%08x\n", (uint32_t)hr);
 			return false;
 		}
 
@@ -559,7 +559,7 @@ namespace bgfx { namespace hlsl
 		return true;
 	}
 
-	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages, bool _firstPass)
+	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _shaderWriter, bx::WriterI* _messageWriter, bool _firstPass)
 	{
 		bx::Error messageErr;
 
@@ -567,7 +567,7 @@ namespace bgfx { namespace hlsl
 
 		if (profile[0] == '\0')
 		{
-			bx::write(_messages, &messageErr, "Error: Shader profile must be specified.\n");
+			bx::write(_messageWriter, &messageErr, "Error: Shader profile must be specified.\n");
 			return false;
 		}
 
@@ -575,7 +575,7 @@ namespace bgfx { namespace hlsl
 		profileAndType[0] = (_options.shaderType == 'f') ? 'p' : _options.shaderType;
 		bx::strCat(profileAndType, BX_COUNTOF(profileAndType), profile);
 
-		s_compiler = load(_messages);
+		s_compiler = load(_messageWriter);
 
 		bool result = false;
 		bool debug = _options.debugInformation;
@@ -668,7 +668,7 @@ namespace bgfx { namespace hlsl
 			}
 
 			printCode(_code.c_str(), line, start, end, column);
-			bx::write(_messages, &messageErr, "Error: D3DCompile failed 0x%08x %s\n", (uint32_t)hr, log);
+			bx::write(_messageWriter, &messageErr, "Error: D3DCompile failed 0x%08x %s\n", (uint32_t)hr, log);
 			errorMsg->Release();
 			return false;
 		}
@@ -680,18 +680,18 @@ namespace bgfx { namespace hlsl
 
 		if (_version < 400)
 		{
-			if (!getReflectionDataD3D9(code, uniforms, _messages) )
+			if (!getReflectionDataD3D9(code, uniforms, _messageWriter) )
 			{
-				bx::write(_messages, &messageErr, "Error: Unable to get D3D9 reflection data.\n");
+				bx::write(_messageWriter, &messageErr, "Error: Unable to get D3D9 reflection data.\n");
 				goto error;
 			}
 		}
 		else
 		{
 			UniformNameList unusedUniforms;
-			if (!getReflectionDataD3D11(code, profileAndType[0] == 'v', uniforms, numAttrs, attrs, size, unusedUniforms, _messages) )
+			if (!getReflectionDataD3D11(code, profileAndType[0] == 'v', uniforms, numAttrs, attrs, size, unusedUniforms, _messageWriter) )
 			{
-				bx::write(_messages, &messageErr, "Error: Unable to get D3D11 reflection data.\n");
+				bx::write(_messageWriter, &messageErr, "Error: Unable to get D3D11 reflection data.\n");
 				goto error;
 			}
 
@@ -740,29 +740,29 @@ namespace bgfx { namespace hlsl
 				}
 
 				// recompile with the unused uniforms converted to statics
-				return compile(_options, _version, output.c_str(), _writer, _messages, false);
+				return compile(_options, _version, output.c_str(), _shaderWriter, _messageWriter, false);
 			}
 		}
 
 		{
 			uint16_t count = (uint16_t)uniforms.size();
-			bx::write(_writer, count, &err);
+			bx::write(_shaderWriter, count, &err);
 
 			uint32_t fragmentBit = profileAndType[0] == 'p' ? kUniformFragmentBit : 0;
 			for (UniformArray::const_iterator it = uniforms.begin(); it != uniforms.end(); ++it)
 			{
 				const Uniform& un = *it;
 				uint8_t nameSize = (uint8_t)un.name.size();
-				bx::write(_writer, nameSize, &err);
-				bx::write(_writer, un.name.c_str(), nameSize, &err);
+				bx::write(_shaderWriter, nameSize, &err);
+				bx::write(_shaderWriter, un.name.c_str(), nameSize, &err);
 				uint8_t type = uint8_t(un.type | fragmentBit);
-				bx::write(_writer, type, &err);
-				bx::write(_writer, un.num, &err);
-				bx::write(_writer, un.regIndex, &err);
-				bx::write(_writer, un.regCount, &err);
-				bx::write(_writer, un.texComponent, &err);
-				bx::write(_writer, un.texDimension, &err);
-				bx::write(_writer, un.texFormat, &err);
+				bx::write(_shaderWriter, type, &err);
+				bx::write(_shaderWriter, un.num, &err);
+				bx::write(_shaderWriter, un.regIndex, &err);
+				bx::write(_shaderWriter, un.regCount, &err);
+				bx::write(_shaderWriter, un.texComponent, &err);
+				bx::write(_shaderWriter, un.texDimension, &err);
+				bx::write(_shaderWriter, un.texFormat, &err);
 
 				BX_TRACE("%s, %s, %d, %d, %d"
 					, un.name.c_str()
@@ -792,18 +792,18 @@ namespace bgfx { namespace hlsl
 
 		{
 			uint32_t shaderSize = uint32_t(code->GetBufferSize() );
-			bx::write(_writer, shaderSize, &err);
-			bx::write(_writer, code->GetBufferPointer(), shaderSize, &err);
+			bx::write(_shaderWriter, shaderSize, &err);
+			bx::write(_shaderWriter, code->GetBufferPointer(), shaderSize, &err);
 			uint8_t nul = 0;
-			bx::write(_writer, nul, &err);
+			bx::write(_shaderWriter, nul, &err);
 		}
 
 		if (_version >= 400)
 		{
-			bx::write(_writer, numAttrs, &err);
-			bx::write(_writer, attrs, numAttrs*sizeof(uint16_t), &err);
+			bx::write(_shaderWriter, numAttrs, &err);
+			bx::write(_shaderWriter, attrs, numAttrs*sizeof(uint16_t), &err);
 
-			bx::write(_writer, size, &err);
+			bx::write(_shaderWriter, size, &err);
 		}
 
 		if (_options.disasm )
@@ -840,9 +840,9 @@ namespace bgfx { namespace hlsl
 
 } // namespace hlsl
 
-	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
+	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _shaderWriter, bx::WriterI* _messageWriter)
 	{
-		return hlsl::compile(_options, _version, _code, _writer, _messages, true);
+		return hlsl::compile(_options, _version, _code, _shaderWriter, _messageWriter, true);
 	}
 
 } // namespace bgfx
@@ -851,11 +851,11 @@ namespace bgfx { namespace hlsl
 
 namespace bgfx
 {
-	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
+	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _shaderWriter, bx::WriterI* _messageWriter)
 	{
-		BX_UNUSED(_options, _version, _code, _writer);
+		BX_UNUSED(_options, _version, _code, _shaderWriter);
 		bx::Error messageErr;
-		bx::write(_messages, &messageErr, "HLSL compiler is not supported on this platform.\n");
+		bx::write(_messageWriter, &messageErr, "HLSL compiler is not supported on this platform.\n");
 		return false;
 	}
 

--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -80,8 +80,10 @@ namespace bgfx { namespace hlsl
 	static const D3DCompiler* s_compiler;
 	static void* s_d3dcompilerdll;
 
-	const D3DCompiler* load()
+	const D3DCompiler* load(bx::WriterI* _messages)
 	{
+		bx::Error messageErr;
+
 		for (uint32_t ii = 0; ii < BX_COUNTOF(s_d3dcompiler); ++ii)
 		{
 			const D3DCompiler* compiler = &s_d3dcompiler[ii];
@@ -115,7 +117,7 @@ namespace bgfx { namespace hlsl
 			return compiler;
 		}
 
-		bx::printf("Error: Unable to open D3DCompiler_*.dll shader compiler.\n");
+		bx::write(_messages, &messageErr, "Error: Unable to open D3DCompiler_*.dll shader compiler.\n");
 		return NULL;
 	}
 
@@ -276,8 +278,10 @@ namespace bgfx { namespace hlsl
 		return false;
 	}
 
-	bool getReflectionDataD3D9(ID3DBlob* _code, UniformArray& _uniforms)
+	bool getReflectionDataD3D9(ID3DBlob* _code, UniformArray& _uniforms, bx::WriterI* _messages)
 	{
+		bx::Error messageErr;
+
 		// see reference for magic values: https://msdn.microsoft.com/en-us/library/ff552891(VS.85).aspx
 		const uint32_t D3DSIO_COMMENT = 0x0000FFFE;
 		const uint32_t D3DSIO_END = 0x0000FFFF;
@@ -311,7 +315,7 @@ namespace bgfx { namespace hlsl
 				uint32_t tableSize = (commentSize - 1) * 4;
 				if (tableSize < sizeof(CTHeader) || header->Size != sizeof(CTHeader) )
 				{
-					bx::printf("Error: Invalid constant table data\n");
+					bx::write(_messages, &messageErr, "Error: Invalid constant table data\n");
 					return false;
 				}
 				break;
@@ -323,7 +327,7 @@ namespace bgfx { namespace hlsl
 
 		if (!header)
 		{
-			bx::printf("Error: Could not find constant table data\n");
+			bx::write(_messages, &messageErr, "Error: Could not find constant table data\n");
 			return false;
 		}
 
@@ -381,8 +385,10 @@ namespace bgfx { namespace hlsl
 		return true;
 	}
 
-	bool getReflectionDataD3D11(ID3DBlob* _code, bool _vshader, UniformArray& _uniforms, uint8_t& _numAttrs, uint16_t* _attrs, uint16_t& _size, UniformNameList& unusedUniforms)
+	bool getReflectionDataD3D11(ID3DBlob* _code, bool _vshader, UniformArray& _uniforms, uint8_t& _numAttrs, uint16_t* _attrs, uint16_t& _size, UniformNameList& unusedUniforms, bx::WriterI* _messages)
 	{
+		bx::Error messageErr;
+
 		ID3D11ShaderReflection* reflect = NULL;
 		HRESULT hr = D3DReflect(_code->GetBufferPointer()
 			, _code->GetBufferSize()
@@ -391,7 +397,7 @@ namespace bgfx { namespace hlsl
 			);
 		if (FAILED(hr) )
 		{
-			bx::printf("Error: D3DReflect failed 0x%08x\n", (uint32_t)hr);
+			bx::write(_messages, &messageErr, "Error: D3DReflect failed 0x%08x\n", (uint32_t)hr);
 			return false;
 		}
 
@@ -399,7 +405,7 @@ namespace bgfx { namespace hlsl
 		hr = reflect->GetDesc(&desc);
 		if (FAILED(hr) )
 		{
-			bx::printf("Error: ID3D11ShaderReflection::GetDesc failed 0x%08x\n", (uint32_t)hr);
+			bx::write(_messages, &messageErr, "Error: ID3D11ShaderReflection::GetDesc failed 0x%08x\n", (uint32_t)hr);
 			return false;
 		}
 
@@ -553,13 +559,15 @@ namespace bgfx { namespace hlsl
 		return true;
 	}
 
-	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bool _firstPass)
+	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages, bool _firstPass)
 	{
+		bx::Error messageErr;
+
 		const char* profile = _options.profile.c_str();
 
 		if (profile[0] == '\0')
 		{
-			bx::printf("Error: Shader profile must be specified.\n");
+			bx::write(_messages, &messageErr, "Error: Shader profile must be specified.\n");
 			return false;
 		}
 
@@ -567,7 +575,7 @@ namespace bgfx { namespace hlsl
 		profileAndType[0] = (_options.shaderType == 'f') ? 'p' : _options.shaderType;
 		bx::strCat(profileAndType, BX_COUNTOF(profileAndType), profile);
 
-		s_compiler = load();
+		s_compiler = load(_messages);
 
 		bool result = false;
 		bool debug = _options.debugInformation;
@@ -660,7 +668,7 @@ namespace bgfx { namespace hlsl
 			}
 
 			printCode(_code.c_str(), line, start, end, column);
-			bx::printf("Error: D3DCompile failed 0x%08x %s\n", (uint32_t)hr, log);
+			bx::write(_messages, &messageErr, "Error: D3DCompile failed 0x%08x %s\n", (uint32_t)hr, log);
 			errorMsg->Release();
 			return false;
 		}
@@ -672,18 +680,18 @@ namespace bgfx { namespace hlsl
 
 		if (_version < 400)
 		{
-			if (!getReflectionDataD3D9(code, uniforms) )
+			if (!getReflectionDataD3D9(code, uniforms, _messages) )
 			{
-				bx::printf("Error: Unable to get D3D9 reflection data.\n");
+				bx::write(_messages, &messageErr, "Error: Unable to get D3D9 reflection data.\n");
 				goto error;
 			}
 		}
 		else
 		{
 			UniformNameList unusedUniforms;
-			if (!getReflectionDataD3D11(code, profileAndType[0] == 'v', uniforms, numAttrs, attrs, size, unusedUniforms) )
+			if (!getReflectionDataD3D11(code, profileAndType[0] == 'v', uniforms, numAttrs, attrs, size, unusedUniforms, _messages) )
 			{
-				bx::printf("Error: Unable to get D3D11 reflection data.\n");
+				bx::write(_messages, &messageErr, "Error: Unable to get D3D11 reflection data.\n");
 				goto error;
 			}
 
@@ -732,7 +740,7 @@ namespace bgfx { namespace hlsl
 				}
 
 				// recompile with the unused uniforms converted to statics
-				return compile(_options, _version, output.c_str(), _writer, false);
+				return compile(_options, _version, output.c_str(), _writer, _messages, false);
 			}
 		}
 
@@ -832,9 +840,9 @@ namespace bgfx { namespace hlsl
 
 } // namespace hlsl
 
-	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer)
+	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
 	{
-		return hlsl::compile(_options, _version, _code, _writer, true);
+		return hlsl::compile(_options, _version, _code, _writer, _messages, true);
 	}
 
 } // namespace bgfx
@@ -843,10 +851,11 @@ namespace bgfx { namespace hlsl
 
 namespace bgfx
 {
-	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer)
+	bool compileHLSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
 	{
 		BX_UNUSED(_options, _version, _code, _writer);
-		bx::printf("HLSL compiler is not supported on this platform.\n");
+		bx::Error messageErr;
+		bx::write(_messages, &messageErr, "HLSL compiler is not supported on this platform.\n");
 		return false;
 	}
 

--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -225,14 +225,14 @@ namespace bgfx { namespace metal
 		"BgfxSampler2DMS",
 	};
 
-	static uint16_t writeUniformArray(bx::WriterI* _writer, const UniformArray& uniforms, bool isFragmentShader)
+	static uint16_t writeUniformArray(bx::WriterI* _shaderWriter, const UniformArray& uniforms, bool isFragmentShader)
 	{
 		uint16_t size = 0;
 
 		bx::ErrorAssert err;
 
 		uint16_t count = uint16_t(uniforms.size());
-		bx::write(_writer, count, &err);
+		bx::write(_shaderWriter, count, &err);
 
 		uint32_t fragmentBit = isFragmentShader ? kUniformFragmentBit : 0;
 		for (uint16_t ii = 0; ii < count; ++ii)
@@ -242,15 +242,15 @@ namespace bgfx { namespace metal
 			size += un.regCount*16;
 
 			uint8_t nameSize = (uint8_t)un.name.size();
-			bx::write(_writer, nameSize, &err);
-			bx::write(_writer, un.name.c_str(), nameSize, &err);
-			bx::write(_writer, uint8_t(un.type | fragmentBit), &err);
-			bx::write(_writer, un.num, &err);
-			bx::write(_writer, un.regIndex, &err);
-			bx::write(_writer, un.regCount, &err);
-			bx::write(_writer, un.texComponent, &err);
-			bx::write(_writer, un.texDimension, &err);
-			bx::write(_writer, un.texFormat, &err);
+			bx::write(_shaderWriter, nameSize, &err);
+			bx::write(_shaderWriter, un.name.c_str(), nameSize, &err);
+			bx::write(_shaderWriter, uint8_t(un.type | fragmentBit), &err);
+			bx::write(_shaderWriter, un.num, &err);
+			bx::write(_shaderWriter, un.regIndex, &err);
+			bx::write(_shaderWriter, un.regCount, &err);
+			bx::write(_shaderWriter, un.texComponent, &err);
+			bx::write(_shaderWriter, un.texDimension, &err);
+			bx::write(_shaderWriter, un.texFormat, &err);
 
 			BX_TRACE("%s, %s, %d, %d, %d"
 				, un.name.c_str()
@@ -263,18 +263,18 @@ namespace bgfx { namespace metal
 		return size;
 	}
 
-	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages, bool _firstPass)
+	static bool compile(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _shaderWriter, bx::WriterI* _messageWriter, bool _firstPass)
 	{
 		BX_UNUSED(_version);
 
-		bx::Error messageErr;
+		bx::ErrorAssert messageErr;
 
 		glslang::InitializeProcess();
 
 		EShLanguage stage = getLang(_options.shaderType);
 		if (EShLangCount == stage)
 		{
-			bx::write(_messages, &messageErr, "Error: Unknown shader type '%c'.\n", _options.shaderType);
+			bx::write(_messageWriter, &messageErr, "Error: Unknown shader type '%c'.\n", _options.shaderType);
 			return false;
 		}
 
@@ -340,7 +340,7 @@ namespace bgfx { namespace metal
 
 				printCode(_code.c_str(), line, start, end, column);
 
-				bx::write(_messages, &messageErr, "%s\n", log);
+				bx::write(_messageWriter, &messageErr, "%s\n", log);
 			}
 		}
 		else
@@ -356,7 +356,7 @@ namespace bgfx { namespace metal
 				const char* log = program->getInfoLog();
 				if (NULL != log)
 				{
-					bx::write(_messages, &messageErr, "%s\n", log);
+					bx::write(_messageWriter, &messageErr, "%s\n", log);
 				}
 			}
 			else
@@ -436,7 +436,7 @@ namespace bgfx { namespace metal
 					// recompile with the unused uniforms converted to statics
 					delete program;
 					delete shader;
-					return compile(_options, _version, output.c_str(), _writer, _messages, false);
+					return compile(_options, _version, output.c_str(), _shaderWriter, _messageWriter, false);
 				}
 
 				UniformArray uniforms;
@@ -500,14 +500,14 @@ namespace bgfx { namespace metal
 
 				spvtools::Optimizer opt(SPV_ENV_VULKAN_1_0);
 
-				auto print_msg_to_stderr = [_messages, &messageErr](
+				auto print_msg_to_stderr = [_messageWriter, &messageErr](
 					  spv_message_level_t
 					, const char*
 					, const spv_position_t&
 					, const char* m
 					)
 				{
-					bx::write(_messages, &messageErr, "Error: %s\n", m);
+					bx::write(_messageWriter, &messageErr, "Error: %s\n", m);
 				};
 
 				opt.SetMessageConsumer(print_msg_to_stderr);
@@ -556,7 +556,7 @@ namespace bgfx { namespace metal
 
 						uniforms.push_back(un);
 					}
-					uint16_t size = writeUniformArray( _writer, uniforms, _options.shaderType == 'f');
+					uint16_t size = writeUniformArray(_shaderWriter, uniforms, _options.shaderType == 'f');
 
 					bx::Error err;
 
@@ -644,42 +644,42 @@ namespace bgfx { namespace metal
 							for (int i = 0; i < 3; ++i)
 							{
 								uint16_t dim = (uint16_t)msl.get_execution_mode_argument(spv::ExecutionMode::ExecutionModeLocalSize, i);
-								bx::write(_writer, dim, &err);
+								bx::write(_shaderWriter, dim, &err);
 							}
 						}
 
 						uint32_t shaderSize = (uint32_t)source.size();
-						bx::write(_writer, shaderSize, &err);
-						bx::write(_writer, source.c_str(), shaderSize, &err);
+						bx::write(_shaderWriter, shaderSize, &err);
+						bx::write(_shaderWriter, source.c_str(), shaderSize, &err);
 						uint8_t nul = 0;
-						bx::write(_writer, nul, &err);
+						bx::write(_shaderWriter, nul, &err);
 					}
 					else
 					{
 						uint32_t shaderSize = (uint32_t)spirv.size() * sizeof(uint32_t);
-						bx::write(_writer, shaderSize, &err);
-						bx::write(_writer, spirv.data(), shaderSize, &err);
+						bx::write(_shaderWriter, shaderSize, &err);
+						bx::write(_shaderWriter, spirv.data(), shaderSize, &err);
 						uint8_t nul = 0;
-						bx::write(_writer, nul, &err);
+						bx::write(_shaderWriter, nul, &err);
 					}
 					//
 					const uint8_t numAttr = (uint8_t)program->getNumLiveAttributes();
-					bx::write(_writer, numAttr, &err);
+					bx::write(_shaderWriter, numAttr, &err);
 
 					for (uint8_t ii = 0; ii < numAttr; ++ii)
 					{
 						bgfx::Attrib::Enum attr = toAttribEnum(program->getAttributeName(ii) );
 						if (bgfx::Attrib::Count != attr)
 						{
-							bx::write(_writer, bgfx::attribToId(attr), &err);
+							bx::write(_shaderWriter, bgfx::attribToId(attr), &err);
 						}
 						else
 						{
-							bx::write(_writer, uint16_t(UINT16_MAX), &err);
+							bx::write(_shaderWriter, uint16_t(UINT16_MAX), &err);
 						}
 					}
 
-					bx::write(_writer, size, &err);
+					bx::write(_shaderWriter, size, &err);
 				}
 			}
 		}
@@ -694,9 +694,9 @@ namespace bgfx { namespace metal
 
 } // namespace metal
 
-	bool compileMetalShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
+	bool compileMetalShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _shaderWriter, bx::WriterI* _messageWriter)
 	{
-		return metal::compile(_options, _version, _code, _writer, _messages, true);
+		return metal::compile(_options, _version, _code, _shaderWriter, _messageWriter, true);
 	}
 
 } // namespace bgfx

--- a/tools/shaderc/shaderc_pssl.cpp
+++ b/tools/shaderc/shaderc_pssl.cpp
@@ -7,11 +7,11 @@
 
 namespace bgfx
 {
-	bool compilePSSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
+	bool compilePSSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _shaderWriter, bx::WriterI* _messageWriter)
 	{
-		BX_UNUSED(_options, _version, _code, _writer);
-		bx::Error messageErr;
-		bx::write(_messages, &messageErr, "PSSL compiler is not supported.\n");
+		BX_UNUSED(_options, _version, _code, _shaderWriter);
+		bx::ErrorAssert messageErr;
+		bx::write(_messageWriter, &messageErr, "PSSL compiler is not supported.\n");
 		return false;
 	}
 

--- a/tools/shaderc/shaderc_pssl.cpp
+++ b/tools/shaderc/shaderc_pssl.cpp
@@ -7,10 +7,11 @@
 
 namespace bgfx
 {
-	bool compilePSSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer)
+	bool compilePSSLShader(const Options& _options, uint32_t _version, const std::string& _code, bx::WriterI* _writer, bx::WriterI* _messages)
 	{
 		BX_UNUSED(_options, _version, _code, _writer);
-		bx::printf("PSSL compiler is not supported.\n");
+		bx::Error messageErr;
+		bx::write(_messages, &messageErr, "PSSL compiler is not supported.\n");
 		return false;
 	}
 


### PR DESCRIPTION
…rather than directly to stdOut, to allow tool writers to easily capture it.

I'm using shaderc as a library to compile my shaders on program load rather than as a standalone tool, and this is one of a few small things that will make that easier for me.

I'm happy to make any modifications you require for this to be merged.