### PR TITLE
fix unused uniforms replace

### DIFF
--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -704,39 +704,52 @@ namespace bgfx { namespace hlsl
 				while (!reader.isDone() )
 				{
 					bx::StringView strLine = reader.next();
-					bool found = false;
-
-					for (UniformNameList::iterator it = unusedUniforms.begin(), itEnd = unusedUniforms.end(); it != itEnd; ++it)
+					std::string replaceOutput;
+					bx::StringView str = strFind(strLine, "uniform ");
+					if (!str.isEmpty())
 					{
-						bx::StringView str = strFind(strLine, "uniform ");
-						if (str.isEmpty() )
+						std::string lineToReplace(strLine.getPtr(), 0, strLine.getLength());
+						for (UniformNameList::iterator it = unusedUniforms.begin(); it != unusedUniforms.end();)
 						{
-							continue;
-						}
-
-						// matching lines like:  uniform u_name;
-						// we want to replace "uniform" with "static" so that it's no longer
-						// included in the uniform blob that the application must upload
-						// we can't just remove them, because unused functions might still reference
-						// them and cause a compile error when they're gone
-						if (!bx::findIdentifierMatch(strLine, it->c_str() ).isEmpty() )
-						{
-							output.append(strLine.getPtr(), str.getPtr() );
-							output += "static ";
-							output.append(str.getTerm(), strLine.getTerm() );
-							output += "\n";
-							found = true;
-
-							unusedUniforms.erase(it);
-							break;
+							// matching lines like:  uniform u_name;
+							// we want to replace "uniform" with "static" so that it's no longer
+							// included in the uniform blob that the application must upload
+							// we can't just remove them, because unused functions might still reference
+							// them and cause a compile error when they're gone
+							auto identifier = bx::findIdentifierMatch(strLine, it->c_str());
+							if (!identifier.isEmpty())
+							{
+								bx::StringView definePrefix = bx::StringView(strLine.getPtr(), identifier.getPtr());
+								bx::StringView semicolon = strRFind(definePrefix, ';');
+								if (!semicolon.isEmpty())
+								{
+									bx::StringView uniformDefine = bx::StringView(semicolon.getPtr(), strLine.getTerm());
+									str = strFind(uniformDefine, "uniform ");
+								}
+								replaceOutput.clear();
+								replaceOutput.append(strLine.getPtr(), str.getPtr());
+								replaceOutput += "static ";
+								replaceOutput.append(str.getTerm(), strLine.getTerm());
+								lineToReplace = replaceOutput;
+								strLine = bx::StringView(lineToReplace.c_str());
+								it = unusedUniforms.erase(it);
+							}
+							else
+							{
+								++it;
+							}
 						}
 					}
 
-					if (!found)
+					if (!replaceOutput.empty())
+					{
+						output.append(replaceOutput);
+					}
+					else
 					{
 						output.append(strLine.getPtr(), strLine.getTerm() );
-						output += "\n";
 					}
+					output += "\n";
 				}
 
 				// recompile with the unused uniforms converted to statics


### PR DESCRIPTION
when multi uniforms defined in one line and there are some unused uniforms in that line, like this:

...
uniform float4 cShadowSplits;
uniform float4 cUOffset; uniform float4 cVOffset; uniform float4 cMatDiffColor; uniform float4 cMatEmissiveColor;
uniform float4x4 cModel;
...

cMatDiffColor and cMatEmissiveColor are unused uniforms.