### PR TITLE
fix vulkan bind image with sampler bug

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3847,7 +3847,19 @@ VK_IMPORT_DEVICE
 								);
 
 							imageInfo[imageCount].imageLayout = texture.m_sampledLayout;
-							imageInfo[imageCount].sampler     = VK_NULL_HANDLE;
+							if (isImageDescriptor)
+							{
+								imageInfo[imageCount].sampler     = VK_NULL_HANDLE;
+							}
+							else
+							{
+								const uint32_t samplerFlags = 0 == (BGFX_SAMPLER_INTERNAL_DEFAULT & bind.m_samplerFlags)
+									? bind.m_samplerFlags
+									: (uint32_t)texture.m_flags
+									;
+								imageInfo[imageCount].sampler = getSampler(samplerFlags, texture.m_format, _palette);
+							}
+							
 							imageInfo[imageCount].imageView   = getCachedImageView(
 								  { bind.m_idx }
 								, bind.m_mip
@@ -3855,9 +3867,24 @@ VK_IMPORT_DEVICE
 								, type
 								);
 							wds[wdsCount].pImageInfo = &imageInfo[imageCount];
-							++imageCount;
-
 							++wdsCount;
+
+							if (!isImageDescriptor)
+							{
+								wds[wdsCount].sType            = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+								wds[wdsCount].pNext            = NULL;
+								wds[wdsCount].dstSet           = descriptorSet;
+								wds[wdsCount].dstBinding       = bindInfo.samplerBinding;
+								wds[wdsCount].dstArrayElement  = 0;
+								wds[wdsCount].descriptorCount  = 1;
+								wds[wdsCount].descriptorType   = VK_DESCRIPTOR_TYPE_SAMPLER;
+								wds[wdsCount].pImageInfo       = &imageInfo[imageCount];
+								wds[wdsCount].pBufferInfo      = NULL;
+								wds[wdsCount].pTexelBufferView = NULL;
+								++wdsCount;
+							}
+
+							++imageCount;
 						}
 						break;
 


### PR DESCRIPTION
I have a sampler2D used in shader, it declared like:

``` glsl
SAMPLER2D(s_color_input, 0);
```

In C++, I want to bind this sampler (_s_color_input_) to some mipmap level of a texture, so I use bgfx::setImage to specify which mipmap level I need.

``` C++
bgfx::TextureHandle tex = ...;
uint8_t mip = 2;
bgfx::setImage(0, tex, mip, bgfx::Access::Read);
```