### PR TITLE
Update Apple platform naming in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Supported platforms:
 
  * Android (14+, ARM, x86, MIPS)
  * FreeBSD
- * iOS (iPhone, iPad, AppleTV)
+ * iOS/iPadOS/tvOS (iPhone, iPad, AppleTV)
  * Linux
  * MIPS Creator CI20
- * OSX (11+)
+ * macOS (11+)
  * PlayStation 4
  * RaspberryPi
  * UWP (Universal Windows, Xbox One)

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -83,7 +83,7 @@ Build
 -----
 
 bgfx uses `GENie - Project generator tool <https://github.com/bkaradzic/genie#genie---project-generator-tool>`__
-to generate project files for various platform. Binaries for Linux, OSX, and Windows are included in
+to generate project files for various platform. Binaries for Linux, macOS, and Windows are included in
 bx repository.
 
 General
@@ -174,7 +174,7 @@ Amalgamated Build
 For ease of integration to other build system bgfx library can be built
 with single .cpp file. It's only necessary to build
 `src/amalgamated.cpp <https://github.com/bkaradzic/bgfx/blob/master/src/amalgamated.cpp>`__
-(for OSX/iOS use
+(for macOS/iOS/iPadOS/tvOS use
 `src/amalgamated.mm <https://github.com/bkaradzic/bgfx/blob/master/src/amalgamated.mm>`__
 instead) inside different build system.
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -35,7 +35,7 @@ Encoder API can be obtained by calling ``bgfx::begin``. bgfx by default allows 8
 Customization
 -------------
 
-By default each platform has sane default values. For example on Windows default renderer is DirectX, on Linux it is OpenGL, and on OSX it's Metal. On Windows platform almost all rendering backends are available. For OpenGL ES on desktop you can find more information at:- `OpenGL ES 2.0 and EGL on desktop <http://www.g-truc.net/post-0457.html>`__
+By default each platform has sane default values. For example on Windows default renderer is DirectX, on Linux it is OpenGL, and on macOS it's Metal. On Windows platform almost all rendering backends are available. For OpenGL ES on desktop you can find more information at:- `OpenGL ES 2.0 and EGL on desktop <http://www.g-truc.net/post-0457.html>`__
 
 If you're targeting specific mobile hardware, you can find GLES support in their official SDKs: `Adreno
 SDK <http://developer.qualcomm.com/mobile-development/mobile-technologies/gaming-graphics-optimization-adreno/tools-and-resources>`__, `Mali SDK <http://www.malideveloper.com/>`__, `PowerVR SDK <http://www.imgtec.com/powervr/insider/sdkdownloads/>`__.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -36,10 +36,10 @@ Supported Platforms
 
 -  Android (14+, ARM, x86, MIPS)
 -  FreeBSD
--  iOS (iPhone, iPad, AppleTV)
+-  iOS/iPadOS/tvOS (iPhone, iPad, AppleTV)
 -  Linux
 -  MIPS Creator CI20
--  OSX (11+)
+-  macOS (11+)
 -  PlayStation 4
 -  RaspberryPi
 -  UWP (Universal Windows, Xbox One)
@@ -124,13 +124,13 @@ Other Debuggers and Profilers
 +-------------+-----------------+-------+--------+------+-------+------+------+-------+--------+
 | Name        | OS              | DX9   | DX11   | DX12 | Metal | GL   | GLES | Vulkan| Source |
 +=============+=================+=======+========+======+=======+======+======+=======+========+
-| APITrace    | Linux/OSX/Win   | |x|   | |x|    |      |       | |x|  | |x|  |       | |x|    |
+| APITrace    | Linux/macOS/Win | |x|   | |x|    |      |       | |x|  | |x|  |       | |x|    |
 +-------------+-----------------+-------+--------+------+-------+------+------+-------+--------+
 | CodeXL      | Linux/Win       |       |        |      |       | |x|  |      |       |        |
 +-------------+-----------------+-------+--------+------+-------+------+------+-------+--------+
 | Dissector   | Win             | |x|   |        |      |       |      |      |       | |x|    |
 +-------------+-----------------+-------+--------+------+-------+------+------+-------+--------+
-| IntelGPA    | Linux/OSX/Win   | |x|   | |x|    |      |       |      | |x|  |       |        |
+| IntelGPA    | Linux/macOS/Win | |x|   | |x|    |      |       |      | |x|  |       |        |
 +-------------+-----------------+-------+--------+------+-------+------+------+-------+--------+
 | Nsight      | Win             | |x|   | |x|    |      |       | |x|  |      |       |        |
 +-------------+-----------------+-------+--------+------+-------+------+------+-------+--------+
@@ -197,7 +197,7 @@ Contributors
 Chronological order:
 
  - Branimir Karadžić (`@bkaradzic <https://github.com/bkaradzic>`__)
- - Garett Bass (`@garettbass <https://github.com/garettbass>`__) - OSX port.
+ - Garett Bass (`@garettbass <https://github.com/garettbass>`__) - macOS port.
  - Jeremie Roy (`@jeremieroy <https://github.com/jeremieroy>`__) -
    `10-font <examples.html#font>`__,
    and `11-fontsdf <examples.html#fontsdf>`__ examples.
@@ -222,7 +222,7 @@ Chronological order:
  - Andre Weissflog (`@floooh <https://github.com/floooh>`__) - Alternative build system fips.
  - Andrew Johnson (`@ajohnson23 <https://github.com/ajohnson23>`__) - TeamCity build.
  - Tony McCrary (`@enleeten <https://github.com/enleeten>`__) - Java language API bindings.
- - Attila Kocsis (`@attilaz <https://github.com/attilaz>`__) - Metal rendering backend, various OSX
+ - Attila Kocsis (`@attilaz <https://github.com/attilaz>`__) - Metal rendering backend, various macOS
    and iOS improvements and bug fixes, `39-assao <examples.html#assao>`__ example.
  - Richard Gale (`@RichardGale <https://github.com/RichardGale>`__) - Emscripten entry input
    handling.


### PR DESCRIPTION
A minor change to reflect how Apple currently names their software:
• Since 2015 AppleTVs run "tvOS" and since 2019 iPads run "iPadOS", rather than both running iOS.
• Since 2016 Macs run "macOS" rather than "OSX". Since macOS's major version number is incremented for major updates the "X" (10 in Roman numerals) doesn't make sense anymore. "OSX (11+)" reads like a contradiction: "Mac OS version 10 (version 11)"