### PR TITLE
Ensure bgfx::init() respects BGFX_RESET_FLIP_AFTER_RENDER

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1913,6 +1913,7 @@ namespace bgfx
 		m_flipped = true;
 		m_debug   = BGFX_DEBUG_NONE;
 		m_frameTimeLast = bx::getHPCounter();
+		m_flipAfterRender = !!(m_init.resolution.reset & BGFX_RESET_FLIP_AFTER_RENDER);
 
 		m_submit->create(_init.limits.minResourceCbSize);
 


### PR DESCRIPTION
This updates the behaviour of bgfx::init() to ensure that it checks for the BGFX_RESET_FLIP_AFTER_RENDER flag.