### PR TITLE
Add carbon lang package manager notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 Cross-platform, graphics API agnostic, "Bring Your Own Engine/Framework" style
 rendering library.
 
+### Notice: bgfx will most likely not be in the carbon lang package manager. However, one user (me who is writing this) will attempt to add it to the package manager and will maintain it.
+
 Supported rendering backends:
 
  * Direct3D 9


### PR DESCRIPTION
I added a notice to the readme explaining that bgfx will not likely be added to the carbon lang package manager (according to bkaradzic#2187 on discord) and explain that i will try to maintain and add bgfx to the package manager