### PR TITLE
Fix for #2822 -- points rendering error on Apple silicon

### DIFF
--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -638,6 +638,15 @@ namespace bgfx { namespace metal
 						}
 
 						std::string source = msl.compile();
+						
+						// fix https://github.com/bkaradzic/bgfx/issues/2822
+                        // insert struct member which declares point size, defaulted to 1
+                        auto findName = "xlatMtlMain_out\n{";
+                        auto pos = source.find(findName);
+                        if (pos != std::string::npos){
+                            pos += strlen(findName);
+                            source.insert(pos, "\n\tfloat bgfx_metal_pointSize [[point_size]] = 1;");
+                        }
 
 						if ('c' == _options.shaderType)
 						{

--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -641,11 +641,13 @@ namespace bgfx { namespace metal
 						
 						// fix https://github.com/bkaradzic/bgfx/issues/2822
                         // insert struct member which declares point size, defaulted to 1
-                        auto findName = "xlatMtlMain_out\n{";
-                        auto pos = source.find(findName);
-                        if (pos != std::string::npos){
-                            pos += strlen(findName);
-                            source.insert(pos, "\n\tfloat bgfx_metal_pointSize [[point_size]] = 1;");
+                        if (_options.shaderType == 'v'){
+                            auto findName = "xlatMtlMain_out\n{";
+                            auto pos = source.find(findName);
+                            if (pos != std::string::npos){
+                                pos += strlen(findName);
+                                source.insert(pos, "\n\tfloat bgfx_metal_pointSize [[point_size]] = 1;");
+                            }
                         }
 
 						if ('c' == _options.shaderType)


### PR DESCRIPTION
As documented in [MTLPrimitiveTypePoint](https://developer.apple.com/documentation/metal/mtlprimitivetype/point), not specifying the point size when using the points primitive type is undefined behavior, and results in broken output on Apple silicon devices.

This patch fixes #2822 by having shaderc always emit an extra member to `xlatMtlMain_out` in vertex shaders with a default value of 1. This ensures that a value for the `[[point_size]]` attribute is always present. For example, in `01-cubes`, the output structure becomes:
```cpp
struct xlatMtlMain_out
{
    float bgfx_metal_pointSize [[point_size]] = 1;
    float4 _entryPointOutput_v_color0 [[user(locn0)]];
    float4 gl_Position [[position]];
};
```
Shaders other than vertex are left untouched. Users do not need to change their shader source code to get the fix, they just need to rerun them through shaderc with this patch. The body of the vertex shader is also left untouched. 

Here is a screenshot of `01-cubes` running on Apple silicon, with the point size set to 5 so that it is easier to see:
<img width="1392" alt="pointsWorking2" src="https://user-images.githubusercontent.com/55766810/231010806-e6c49cb8-a562-4c89-ac20-4d45d18fad03.png">

