### PR TITLE
fix metal and vulkan renderer set image bug

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -4344,6 +4344,16 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 								{
 									TextureMtl& texture = m_textures[bind.m_idx];
 									m_computeCommandEncoder.setTexture(texture.getTextureMipLevel(bind.m_mip), stage);
+									if (Access::Read == bind.m_access)
+									{
+										uint32_t flags = bind.m_samplerFlags;
+										m_computeCommandEncoder.setSamplerState(
+											0 == (BGFX_SAMPLER_INTERNAL_DEFAULT & flags)
+											? getSamplerState(flags)
+											: texture.m_sampler
+											, stage
+											);
+									}
 								}
 								break;
 

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3812,22 +3812,6 @@ VK_IMPORT_DEVICE
 					{
 					case Binding::Image:
 						{
-							const bool isImageDescriptor = BindType::Image == bindInfo.type;
-
-							wds[wdsCount].sType            = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-							wds[wdsCount].pNext            = NULL;
-							wds[wdsCount].dstSet           = descriptorSet;
-							wds[wdsCount].dstBinding       = bindInfo.binding;
-							wds[wdsCount].dstArrayElement  = 0;
-							wds[wdsCount].descriptorCount  = 1;
-							wds[wdsCount].descriptorType   = isImageDescriptor
-								? VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
-								: VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
-								;
-							wds[wdsCount].pImageInfo       = NULL;
-							wds[wdsCount].pBufferInfo      = NULL;
-							wds[wdsCount].pTexelBufferView = NULL;
-
 							const TextureVK& texture = m_textures[bind.m_idx];
 
 							VkImageViewType type = texture.m_type;
@@ -3854,10 +3838,46 @@ VK_IMPORT_DEVICE
 								, 1
 								, type
 								);
-							wds[wdsCount].pImageInfo = &imageInfo[imageCount];
-							++imageCount;
 
+							const bool isImageDescriptor = BindType::Image == bindInfo.type;
+
+							wds[wdsCount].sType            = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+							wds[wdsCount].pNext            = NULL;
+							wds[wdsCount].dstSet           = descriptorSet;
+							wds[wdsCount].dstBinding       = bindInfo.binding;
+							wds[wdsCount].dstArrayElement  = 0;
+							wds[wdsCount].descriptorCount  = 1;
+							wds[wdsCount].descriptorType   = isImageDescriptor
+								? VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
+								: VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE
+								;
+							wds[wdsCount].pImageInfo       = &imageInfo[imageCount];
+							wds[wdsCount].pBufferInfo      = NULL;
+							wds[wdsCount].pTexelBufferView = NULL;
 							++wdsCount;
+
+							if (Access::Read  == bind.m_access)
+							{
+								const uint32_t samplerFlags = 0 == (BGFX_SAMPLER_INTERNAL_DEFAULT & bind.m_samplerFlags)
+															? bind.m_samplerFlags
+															: (uint32_t)texture.m_flags
+															;
+								imageInfo[imageCount].sampler  = getSampler(samplerFlags, texture.m_format, _palette);
+
+								wds[wdsCount].sType            = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+								wds[wdsCount].pNext            = NULL;
+								wds[wdsCount].dstSet           = descriptorSet;
+								wds[wdsCount].dstBinding       = bindInfo.samplerBinding;
+								wds[wdsCount].dstArrayElement  = 0;
+								wds[wdsCount].descriptorCount  = 1;
+								wds[wdsCount].descriptorType   = VK_DESCRIPTOR_TYPE_SAMPLER;
+								wds[wdsCount].pImageInfo       = &imageInfo[imageCount];
+								wds[wdsCount].pBufferInfo      = NULL;
+								wds[wdsCount].pTexelBufferView = NULL;
+								++wdsCount;
+							}
+
+							++imageCount;
 						}
 						break;
 


### PR DESCRIPTION
I have pulled a PR:
https://github.com/bkaradzic/bgfx/pull/3063

It try to fix set image without sampler state bug in vulkan.

After compare with D3D11 and D3D12, it should check the bind.m_access type, if it is Access::Read, the sampler state must be set.(I just follow D3D11 and D3D12 renderer, and try to make vulkan and metal renderer keep the same logic). The sampler state is needed both compute and render pipelines.

https://github.com/bkaradzic/bgfx/blob/master/src/renderer_d3d11.cpp#L5813
https://github.com/bkaradzic/bgfx/blob/master/src/renderer_d3d11.cpp#L6144

https://github.com/bkaradzic/bgfx/blob/master/src/renderer_d3d12.cpp#L6613
https://github.com/bkaradzic/bgfx/blob/master/src/renderer_d3d12.cpp#L6925


