### PR TITLE
fix crash on iOS <16 and macOS <13

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -2336,8 +2336,20 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 					pso->m_rps = m_device.newRenderPipelineStateWithDescriptor(pd, MTLPipelineOptionBufferTypeInfo, &reflection);
 
 					if (NULL != reflection)
-					{
-						processArguments(pso, reflection.vertexBindings, reflection.fragmentBindings);
+                    {
+#if BX_PLATFORM_IOS
+                        if (@available(iOS 16, *)) {
+                            processArguments(pso, reflection.vertexBindings, reflection.fragmentBindings);
+                        } else {
+                            processArguments(pso, reflection.vertexArguments, reflection.fragmentArguments);
+                        }
+#elif BX_PLATFORM_OSX
+                        if (@available(macOS 13, *)) {
+                            processArguments(pso, reflection.vertexBindings, reflection.fragmentBindings);
+                        } else {
+                            processArguments(pso, reflection.vertexArguments, reflection.fragmentArguments);
+                        }
+#endif
 					}
 				}
 
@@ -2384,7 +2396,20 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 					, MTLPipelineOptionBufferTypeInfo
 					, &reflection
 					);
-				processArguments(pso, reflection.bindings, NULL);
+                
+#if BX_PLATFORM_IOS
+                        if (@available(iOS 16, *)) {
+                            processArguments(pso, reflection.bindings, NULL);
+                        } else {
+                            processArguments(pso, reflection.arguments, NULL);
+                        }
+#elif BX_PLATFORM_OSX
+                        if (@available(macOS 13, *)) {
+                            processArguments(pso, reflection.bindings, NULL);
+                        } else {
+                            processArguments(pso, reflection.arguments, NULL);
+                        }
+#endif
 
 				for (uint32_t ii = 0; ii < 3; ++ii)
 				{


### PR DESCRIPTION
- `MTLComputePipelineReflection.bindings` is only available from `iOS 16` and `macOS 13`, before that `MTLComputePipelineReflection.arguments` should be used
- Same issue with `MTLRenderPipelineReflection.vertexBindings` and `MTLRenderPipelineReflection.fragmentBindings`

Added availability check to fix it.
