### PR TITLE
Larger debug text for retina display

### DIFF
--- a/bindings/bf/bgfx.bf
+++ b/bindings/bf/bgfx.bf
@@ -2114,6 +2114,7 @@ public static class bgfx
 		public uint32 reset;
 		public uint8 numBackBuffers;
 		public uint8 maxFrameLatency;
+		public uint8 scaleDebug;
 	}
 	
 	[CRepr]

--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -2093,6 +2093,7 @@ public static partial class bgfx
 		public uint reset;
 		public byte numBackBuffers;
 		public byte maxFrameLatency;
+		public byte scaleDebug;
 	}
 	
 	public unsafe struct Init

--- a/bindings/d/types.d
+++ b/bindings/d/types.d
@@ -18,7 +18,7 @@ enum expandEnum(EnumType, string fqnEnumType = EnumType.stringof) = (){
 
 extern(C) @nogc nothrow:
 
-enum uint BGFX_API_VERSION = 118;
+enum uint BGFX_API_VERSION = 119;
 
 alias bgfx_view_id_t = ushort;
 

--- a/bindings/d/types.d
+++ b/bindings/d/types.d
@@ -886,6 +886,7 @@ struct bgfx_resolution_t
 	uint reset; /// Reset parameters.
 	ubyte numBackBuffers; /// Number of back buffers.
 	ubyte maxFrameLatency; /// Maximum frame latency.
+	ubyte scaleDebug; /// Scale factor for debug view.
 }
 
 /// Configurable runtime limits parameters.

--- a/bindings/zig/bgfx.zig
+++ b/bindings/zig/bgfx.zig
@@ -1338,6 +1338,7 @@ pub const Caps = extern struct {
         reset: u32,
         numBackBuffers: u8,
         maxFrameLatency: u8,
+        scaleDebug: u8,
     };
 
 pub const Init = extern struct {

--- a/examples/00-helloworld/helloworld.cpp
+++ b/examples/00-helloworld/helloworld.cpp
@@ -90,9 +90,12 @@ public:
 
 			// Use debug font to print information about this example.
 			bgfx::dbgTextClear();
+
+			const bgfx::Stats* stats = bgfx::getStats();
+
 			bgfx::dbgTextImage(
-				  bx::max<uint16_t>(uint16_t(m_width /2/8 ), 20)-20
-				, bx::max<uint16_t>(uint16_t(m_height/2/16),  6)-6
+				  bx::max<uint16_t>(uint16_t(stats->textWidth/2), 20)-20
+				, bx::max<uint16_t>(uint16_t(stats->textHeight/2),  6)-6
 				, 40
 				, 12
 				, s_logo
@@ -103,7 +106,6 @@ public:
 			bgfx::dbgTextPrintf(80, 1, 0x0f, "\x1b[;0m    \x1b[;1m    \x1b[; 2m    \x1b[; 3m    \x1b[; 4m    \x1b[; 5m    \x1b[; 6m    \x1b[; 7m    \x1b[0m");
 			bgfx::dbgTextPrintf(80, 2, 0x0f, "\x1b[;8m    \x1b[;9m    \x1b[;10m    \x1b[;11m    \x1b[;12m    \x1b[;13m    \x1b[;14m    \x1b[;15m    \x1b[0m");
 
-			const bgfx::Stats* stats = bgfx::getStats();
 			bgfx::dbgTextPrintf(0, 2, 0x0f, "Backbuffer %dW x %dH in pixels, debug text %dW x %dH in characters."
 				, stats->width
 				, stats->height

--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -647,6 +647,7 @@ namespace bgfx
 		uint32_t reset;             //!< Reset parameters.
 		uint8_t  numBackBuffers;    //!< Number of back buffers.
 		uint8_t  maxFrameLatency;   //!< Maximum frame latency.
+		uint8_t  scaleDebug;        //!< Scale factor for debug view.
 	};
 
 	/// Initialization parameters used by `bgfx::init`.

--- a/include/bgfx/c99/bgfx.h
+++ b/include/bgfx/c99/bgfx.h
@@ -639,6 +639,7 @@ typedef struct bgfx_resolution_s
     uint32_t             reset;              /** Reset parameters.                        */
     uint8_t              numBackBuffers;     /** Number of back buffers.                  */
     uint8_t              maxFrameLatency;    /** Maximum frame latency.                   */
+    uint8_t              scaleDebug;         /** Scale factor for debug view.             */
 
 } bgfx_resolution_t;
 

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -15,7 +15,7 @@
 #ifndef BGFX_DEFINES_H_HEADER_GUARD
 #define BGFX_DEFINES_H_HEADER_GUARD
 
-#define BGFX_API_VERSION UINT32_C(118)
+#define BGFX_API_VERSION UINT32_C(119)
 
 /**
  * Color RGB/alpha/depth write. When it's not specified write will be disabled.

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -791,6 +791,7 @@ struct.Resolution { ctor }
 	.reset           "uint32_t"            --- Reset parameters.
 	.numBackBuffers  "uint8_t"             --- Number of back buffers.
 	.maxFrameLatency "uint8_t"             --- Maximum frame latency.
+	.scaleDebug      "uint8_t"             --- Scale factor for debug view.
 
 --- Configurable runtime limits parameters.
 struct.Limits { namespace = "Init" }

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -1,7 +1,7 @@
 -- vim: syntax=lua
 -- bgfx interface
 
-version(118)
+version(119)
 
 typedef "bool"
 typedef "char"

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -709,7 +709,7 @@ namespace bgfx
 
 		m_vb = s_ctx->createTransientVertexBuffer(numBatchVertices*m_layout.m_stride, &m_layout);
 		m_ib = s_ctx->createTransientIndexBuffer(numBatchIndices*2);
-		m_scale = scale;
+		m_scale = bx::max<uint8_t>(scale, 1);
 	}
 
 	void TextVideoMemBlitter::shutdown()
@@ -1895,7 +1895,7 @@ namespace bgfx
 		m_init.resolution.reset &= ~BGFX_RESET_INTERNAL_FORCE;
 		m_init.resolution.numBackBuffers  = bx::clamp<uint8_t>(_init.resolution.numBackBuffers, 2, BGFX_CONFIG_MAX_BACK_BUFFERS);
 		m_init.resolution.maxFrameLatency = bx::min<uint8_t>(_init.resolution.maxFrameLatency, BGFX_CONFIG_MAX_FRAME_LATENCY);
-		m_init.resolution.scaleDebug      = bx::max<uint8_t>(_init.resolution.scaleDebug, 1);
+		m_init.resolution.scaleDebug      = bx::clamp<uint8_t>(_init.resolution.scaleDebug, 1, BGFX_CONFIG_MAX_SCALE_DEBUG);
 		dump(m_init.resolution);
 
 		if (true

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -669,7 +669,7 @@ namespace bgfx
 	static const uint32_t numBatchVertices = numCharsPerBatch*4;
 	static const uint32_t numBatchIndices  = numCharsPerBatch*6;
 
-	void TextVideoMemBlitter::init()
+	void TextVideoMemBlitter::init(uint8_t scale)
 	{
 		BGFX_CHECK_API_THREAD();
 		m_layout
@@ -709,6 +709,7 @@ namespace bgfx
 
 		m_vb = s_ctx->createTransientVertexBuffer(numBatchVertices*m_layout.m_stride, &m_layout);
 		m_ib = s_ctx->createTransientIndexBuffer(numBatchIndices*2);
+		m_scale = scale;
 	}
 
 	void TextVideoMemBlitter::shutdown()
@@ -789,7 +790,8 @@ namespace bgfx
 		const float texelHeightHalf = RendererType::Direct3D9 == g_caps.rendererType ? texelHeight*0.5f : 0.0f;
 		const float utop       = (_mem.m_small ? 0.0f :  8.0f)*texelHeight + texelHeightHalf;
 		const float ubottom    = (_mem.m_small ? 8.0f : 24.0f)*texelHeight + texelHeightHalf;
-		const float fontHeight = (_mem.m_small ? 8.0f : 16.0f);
+		const float fontHeight = (_mem.m_small ? 8.0f : 16.0f)*_blitter.m_scale;
+		const float fontWidth  = 8.0f * _blitter.m_scale;
 
 		_renderCtx->blitSetup(_blitter);
 
@@ -828,10 +830,10 @@ namespace bgfx
 
 						Vertex vert[4] =
 						{
-							{ (xx  )*8.0f, (yy  )*fontHeight, 0.0f, fg, bg, (ch  )*8.0f*texelWidth - texelWidthHalf, utop },
-							{ (xx+1)*8.0f, (yy  )*fontHeight, 0.0f, fg, bg, (ch+1)*8.0f*texelWidth - texelWidthHalf, utop },
-							{ (xx+1)*8.0f, (yy+1)*fontHeight, 0.0f, fg, bg, (ch+1)*8.0f*texelWidth - texelWidthHalf, ubottom },
-							{ (xx  )*8.0f, (yy+1)*fontHeight, 0.0f, fg, bg, (ch  )*8.0f*texelWidth - texelWidthHalf, ubottom },
+							{ (xx  )*fontWidth, (yy  )*fontHeight, 0.0f, fg, bg, (ch  )*8.0f*texelWidth - texelWidthHalf, utop },
+							{ (xx+1)*fontWidth, (yy  )*fontHeight, 0.0f, fg, bg, (ch+1)*8.0f*texelWidth - texelWidthHalf, utop },
+							{ (xx+1)*fontWidth, (yy+1)*fontHeight, 0.0f, fg, bg, (ch+1)*8.0f*texelWidth - texelWidthHalf, ubottom },
+							{ (xx  )*fontWidth, (yy+1)*fontHeight, 0.0f, fg, bg, (ch  )*8.0f*texelWidth - texelWidthHalf, ubottom },
 						};
 
 						bx::memCopy(vertex, vert, sizeof(vert) );
@@ -1893,6 +1895,7 @@ namespace bgfx
 		m_init.resolution.reset &= ~BGFX_RESET_INTERNAL_FORCE;
 		m_init.resolution.numBackBuffers  = bx::clamp<uint8_t>(_init.resolution.numBackBuffers, 2, BGFX_CONFIG_MAX_BACK_BUFFERS);
 		m_init.resolution.maxFrameLatency = bx::min<uint8_t>(_init.resolution.maxFrameLatency, BGFX_CONFIG_MAX_FRAME_LATENCY);
+		m_init.resolution.scaleDebug      = bx::max<uint8_t>(_init.resolution.scaleDebug, 1);
 		dump(m_init.resolution);
 
 		if (true
@@ -2029,7 +2032,7 @@ namespace bgfx
 
 		dumpCaps();
 
-		m_textVideoMemBlitter.init();
+		m_textVideoMemBlitter.init(m_init.resolution.scaleDebug);
 		m_clearQuad.init();
 
 		m_submit->m_transientVb = createTransientVertexBuffer(_init.limits.transientVbSize);
@@ -3433,6 +3436,7 @@ namespace bgfx
 		, reset(BGFX_RESET_NONE)
 		, numBackBuffers(2)
 		, maxFrameLatency(0)
+		, scaleDebug(0)
 	{
 	}
 

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -757,7 +757,7 @@ namespace bgfx
 
 	struct TextVideoMemBlitter
 	{
-		void init();
+		void init(uint8_t scale);
 		void shutdown();
 
 		TextureHandle m_texture;
@@ -765,6 +765,7 @@ namespace bgfx
 		TransientIndexBuffer* m_ib;
 		VertexLayout m_layout;
 		ProgramHandle m_program;
+		uint8_t m_scale;
 	};
 
 	struct RendererContextI;
@@ -3249,7 +3250,7 @@ namespace bgfx
 		{
 			BGFX_MUTEX_SCOPE(m_resourceApiLock);
 
-			m_submit->m_textVideoMem->resize(_small, (uint16_t)m_init.resolution.width, (uint16_t)m_init.resolution.height);
+			m_submit->m_textVideoMem->resize(_small, (uint16_t)m_init.resolution.width / m_init.resolution.scaleDebug , (uint16_t)m_init.resolution.height / m_init.resolution.scaleDebug );
 			m_submit->m_textVideoMem->clear(_attr);
 		}
 

--- a/src/config.h
+++ b/src/config.h
@@ -381,6 +381,10 @@ BX_STATIC_ASSERT(bx::isPowerOf2(BGFX_CONFIG_MAX_VIEWS), "BGFX_CONFIG_MAX_VIEWS m
 #	define BGFX_CONFIG_MAX_FRAME_LATENCY 3
 #endif // BGFX_CONFIG_MAX_FRAME_LATENCY
 
+#ifndef BGFX_CONFIG_MAX_SCALE_DEBUG
+#   define BGFX_CONFIG_MAX_SCALE_DEBUG 4
+#endif // BGFX_CONFIG_MAX_SCALE_DEBUG
+
 #ifndef BGFX_CONFIG_PREFER_DISCRETE_GPU
 // On laptops with integrated and discrete GPU, prefer selection of discrete GPU.
 // nVidia and AMD, on Windows only.


### PR DESCRIPTION
It's hard to recognize the debug text on iPhone with retina display . See https://github.com/bkaradzic/bgfx/discussions/2863
This patch introduce `scaleDebug` in `Init::Resolution` strcuture, so we can scale the debug text 2x larger or more.