### PR TITLE
Fix D3D12 clear rect not being passed to `frameBuffer.clear`

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -3438,7 +3438,7 @@ namespace bgfx { namespace d3d12
 			if (isValid(m_fbh) )
 			{
 				FrameBufferD3D12& frameBuffer = m_frameBuffers[m_fbh.idx];
-				frameBuffer.clear(m_commandList, _clear, _palette);
+				frameBuffer.clear(m_commandList, _clear, _palette, _rect, _num);
 			}
 			else
 			{


### PR DESCRIPTION
The D3D12 `clear` function is not passing the given `_rect` to `frameBuffer.clear`. This unexpectedly causes the entire framebuffer to be cleared when `m_fbh` is valid and a rect is given.

This change fixes the issue by passing the given `_rect` and associated `_num` args to `frameBuffer.clear` when `m_fbh` is valid.
