### PR TITLE
Fixed duplicate import of functions on Linux using gles20

### DIFF
--- a/src/glimports.h
+++ b/src/glimports.h
@@ -580,6 +580,7 @@ GL_IMPORT_____x(true,  PFNGLBLENDEQUATIONSEPARATEIPROC,            glBlendEquati
 GL_IMPORT_____x(true,  PFNGLBLENDFUNCIPROC,                        glBlendFunci);
 GL_IMPORT_____x(true,  PFNGLBLENDFUNCSEPARATEIPROC,                glBlendFuncSeparatei);
 
+#if !BGFX_USE_GL_DYNAMIC_LIB
 GL_IMPORT______(true,  PFNGLDRAWBUFFERPROC,                        glDrawBuffer);
 GL_IMPORT______(true,  PFNGLREADBUFFERPROC,                        glReadBuffer);
 GL_IMPORT______(true,  PFNGLGENSAMPLERSPROC,                       glGenSamplers);
@@ -588,6 +589,7 @@ GL_IMPORT______(true,  PFNGLBINDSAMPLERPROC,                       glBindSampler
 GL_IMPORT______(true,  PFNGLSAMPLERPARAMETERFPROC,                 glSamplerParameterf);
 GL_IMPORT______(true,  PFNGLSAMPLERPARAMETERIPROC,                 glSamplerParameteri);
 GL_IMPORT______(true,  PFNGLSAMPLERPARAMETERFVPROC,                glSamplerParameterfv);
+#endif // !BGFX_USE_GL_DYNAMIC_LIB
 
 GL_IMPORT_____x(true,  PFNGLBINDBUFFERBASEPROC,                    glBindBufferBase);
 GL_IMPORT_____x(true,  PFNGLBINDBUFFERRANGEPROC,                   glBindBufferRange);


### PR DESCRIPTION
When compiling on Linux with BGFX_OPENGLES_VERSION=20 (or any version less then 30), duplicate import of certain functions occurs due to the active BGFX_USE_GL_DYNAMIC_LIB flag during the Linux build process.