### PR TITLE
Implemented exprimental support for dxc compiler (WIP)

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -3136,7 +3136,7 @@ namespace bgfx { namespace d3d12
 				bx::Error err;
 				read(&rd, dxbc, &err);
 
-				bool patchShader = !dxbc.shader.aon9;
+				bool patchShader = !dxbc.shader.aon9 && !dxbc.shader.dxil;
 				if (BX_ENABLED(BGFX_CONFIG_DEBUG)
 				&&  patchShader)
 				{

--- a/src/shader_dxbc.cpp
+++ b/src/shader_dxbc.cpp
@@ -1970,6 +1970,7 @@ namespace bgfx
 		size += bx::read(_reader, _dxbc.header, _err);
 		_dxbc.shader.shex = false;
 		_dxbc.shader.aon9 = false;
+		_dxbc.shader.dxil = false;
 
 		for (uint32_t ii = 0; ii < _dxbc.header.numChunks; ++ii)
 		{
@@ -2038,6 +2039,14 @@ namespace bgfx
 			case BX_MAKEFOURCC('P', 'S', 'O', '2'): // Pipeline State Object 2
 			case BX_MAKEFOURCC('X', 'N', 'A', 'P'): // ?
 			case BX_MAKEFOURCC('X', 'N', 'A', 'S'): // ?
+				size += chunkSize;
+				break;
+
+			// Detect if it's DXIL
+			case BX_MAKEFOURCC('H', 'A', 'S', 'H'):
+			case BX_MAKEFOURCC('P', 'S', 'V', '0'):
+			case BX_MAKEFOURCC('D', 'X', 'I', 'L'):
+				_dxbc.shader.dxil = true;
 				size += chunkSize;
 				break;
 

--- a/src/shader_dxbc.h
+++ b/src/shader_dxbc.h
@@ -703,6 +703,7 @@ namespace bgfx
 		stl::vector<uint8_t> byteCode;
 		bool shex;
 		bool aon9;
+		bool dxil;
 	};
 
 	struct DxbcSFI0

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -103,6 +103,7 @@ namespace bgfx
 		{  ShadingLang::HLSL,  300,    "s_3_0"      },
 		{  ShadingLang::HLSL,  400,    "s_4_0"      },
 		{  ShadingLang::HLSL,  500,    "s_5_0"      },
+		{  ShadingLang::HLSL,  610,    "s_6_1"      }, // This is a part of an ugly hack to enable SM6.1 barycentrics
 		{  ShadingLang::Metal, 1000,   "metal"      },
 		{  ShadingLang::PSSL,  1000,   "pssl"       },
 		{  ShadingLang::SpirV, 1010,   "spirv"      },


### PR DESCRIPTION
I have implemented using dxc compiler experimentally, those are currently implemented:

- [x] Loading the `dxcompiler.dll` and querying its functions
- [x] Compiling preprocessed HLSL shaders using provided arguments
- [x] Extracting shader reflection info
- [x] Stripping compiled blobs
- [ ] Patching DXIL (currently when DXIL is detected, patching is ignored)

Should use the same versions of `dxc.exe`, `dxcompiler.dll` and `dxil.dll` to prevent failures.

This could be a start for anyone to collaborate and enhance so this PR could reach maturity.