### PR TITLE
Fix toggling MSAA on Metal.

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3400,15 +3400,18 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 			m_backBufferStencil = s_renderMtl->m_device.newTextureWithDescriptor(desc);
 		}
 
+		if (NULL != m_backBufferColorMsaa)
+		{
+			release(m_backBufferColorMsaa);
+		}
+
 		if (sampleCount > 1)
 		{
-			if (NULL != m_backBufferColorMsaa)
-			{
-				release(m_backBufferColorMsaa);
-			}
-
 			desc.pixelFormat = m_metalLayer.pixelFormat;
 			m_backBufferColorMsaa = s_renderMtl->m_device.newTextureWithDescriptor(desc);
+		}
+		else {
+			m_backBufferColorMsaa = NULL;
 		}
 
 		bx::HashMurmur2A murmur;

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3403,15 +3403,13 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 		if (NULL != m_backBufferColorMsaa)
 		{
 			release(m_backBufferColorMsaa);
+			m_backBufferColorMsaa = NULL;
 		}
 
 		if (sampleCount > 1)
 		{
 			desc.pixelFormat = m_metalLayer.pixelFormat;
 			m_backBufferColorMsaa = s_renderMtl->m_device.newTextureWithDescriptor(desc);
-		}
-		else {
-			m_backBufferColorMsaa = NULL;
 		}
 
 		bx::HashMurmur2A murmur;


### PR DESCRIPTION
This is a fix for https://github.com/bkaradzic/bgfx/issues/3028.

m_backBufferColorMsaa was set when sampleCount > 1, but was never reset when sampleCount became 1 again.

Many other bits of code in the Metal renderer decide what to do by checking m_backBufferColorMsaa, so these would all do the wrong thing if you toggled MSAA on and then back off.

I don't know what I'm doing, I don't know Metal, please check carefully before merging. This is just what worked for me.