### PR TITLE
Metal: Fix MSAA texture pointer not being freed

### DIFF
--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -976,6 +976,7 @@ namespace bgfx { namespace mtl
 			if (0 == (m_flags & BGFX_SAMPLER_INTERNAL_SHARED))
 			{
 				MTL_RELEASE(m_ptr);
+				MTL_RELEASE(m_ptrMsaa);
 			}
 			MTL_RELEASE(m_ptrStencil);
 			for (uint32_t ii = 0; ii < m_numMips; ++ii)


### PR DESCRIPTION
Texture::destroy only freed m_ptr, not m_ptrMsaa. This caused problems when texture IDs were reused, because a newly- created texture would sometimes have m_ptrMsaa.