### PR TITLE
shaderc: Document reserved sampler suffixes

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -71,6 +71,7 @@ Some differences between bgfx's shaderc flavor of GLSL and vanilla GLSL:
 -  ``bool/int`` uniforms are not allowed; all uniforms must be ``float``.
 -  Attributes and varyings can only be accessed from ``main()``.
 -  ``SAMPLER2D/3D/CUBE/etc.`` macros replace the ``sampler2D/3D/Cube/etc.`` tokens.
+- Sampler names should not end with ``Texture``, ``Sampler``, or ``SamplerComparison``.
 -  ``vec2/3/4_splat(<value>)`` replaces the ``vec2/3/4(<value>)`` constructor.
    ``vec2/3/4`` constructors with multiple values are still valid.
 -  ``mtxFromCols/mtxFromRows`` must be used for constructing matrices.
@@ -207,7 +208,7 @@ Options:
                             Can be 0–3.
   --Werror                  Treat warnings as errors.
 
-Building shaders
+Building Shaders
 ~~~~~~~~~~~~~~~~
 
 Shaders can be compiled for all renderers by using the ``shaderc`` tool.


### PR DESCRIPTION
`bgfx_shader.sc`'s sampler macros append suffixes to sampler identifiers internally:
```glsl
#		define SAMPLER2D(_name, _reg) \
			uniform SamplerState _name ## Sampler : REGISTER(s, _reg); \
			uniform Texture2D _name ## Texture : REGISTER(t, _reg); \
			static BgfxSampler2D _name = { _name ## Sampler, _name ## Texture }
#		define ISAMPLER2D(_name, _reg) \
			uniform Texture2D<ivec4> _name ## Texture : REGISTER(t, _reg); \
			static BgfxISampler2D _name = { _name ## Texture }
#		define USAMPLER2D(_name, _reg) \
			uniform Texture2D<uvec4> _name ## Texture : REGISTER(t, _reg); \
			static BgfxUSampler2D _name = { _name ## Texture }
//et cetera
```

This [has caused some confusion](https://discord.com/channels/712512073522872352/712512073522872355/1132718863063195739), because it was seemingly undocumented that using these suffixes in sampler identifiers would cause an assert error in bgfx's shader uniform loading code.