### PR TITLE
Added a new capability to check for PrimitiveID support

### DIFF
--- a/bindings/bf/bgfx.bf
+++ b/bindings/bf/bgfx.bf
@@ -1148,14 +1148,19 @@ public static class bgfx
 		VertexId               = 0x0000000008000000,
 	
 		/// <summary>
+		/// PrimitiveID is available in fragment shader.
+		/// </summary>
+		PrimitiveId            = 0x0000000010000000,
+	
+		/// <summary>
 		/// Viewport layer is available in vertex shader.
 		/// </summary>
-		ViewportLayerArray     = 0x0000000010000000,
+		ViewportLayerArray     = 0x0000000020000000,
 	
 		/// <summary>
 		/// Draw indirect with indirect count is supported.
 		/// </summary>
-		DrawIndirectCount      = 0x0000000020000000,
+		DrawIndirectCount      = 0x0000000040000000,
 	
 		/// <summary>
 		/// All texture compare modes are supported.

--- a/bindings/cs/bgfx.cs
+++ b/bindings/cs/bgfx.cs
@@ -1147,14 +1147,19 @@ public static partial class bgfx
 		VertexId               = 0x0000000008000000,
 	
 		/// <summary>
+		/// PrimitiveID is available in fragment shader.
+		/// </summary>
+		PrimitiveId            = 0x0000000010000000,
+	
+		/// <summary>
 		/// Viewport layer is available in vertex shader.
 		/// </summary>
-		ViewportLayerArray     = 0x0000000010000000,
+		ViewportLayerArray     = 0x0000000020000000,
 	
 		/// <summary>
 		/// Draw indirect with indirect count is supported.
 		/// </summary>
-		DrawIndirectCount      = 0x0000000020000000,
+		DrawIndirectCount      = 0x0000000040000000,
 	
 		/// <summary>
 		/// All texture compare modes are supported.

--- a/bindings/d/package.d
+++ b/bindings/d/package.d
@@ -10,7 +10,7 @@ import bindbc.bgfx.config;
 import bindbc.common.types: va_list;
 static import bgfx.fakeenum;
 
-enum uint apiVersion = 121;
+enum uint apiVersion = 122;
 
 alias ViewID = ushort;
 deprecated("Please use `ViewID` instead.") alias ViewId = ushort;
@@ -521,8 +521,9 @@ enum CapFlags: CapFlags_{
 	vertexAttribHalf        = 0x0000_0000_0200_0000, ///Vertex attribute half-float is supported.
 	vertexAttribUint10      = 0x0000_0000_0400_0000, ///Vertex attribute 10_10_10_2 is supported.
 	vertexID                = 0x0000_0000_0800_0000, ///Rendering with VertexID only is supported.
-	viewportLayerArray      = 0x0000_0000_1000_0000, ///Viewport layer is available in vertex shader.
-	drawIndirectCount       = 0x0000_0000_2000_0000, ///Draw indirect with indirect count is supported.
+	primitiveID             = 0x0000_0000_1000_0000, ///PrimitiveID is available in fragment shader.
+	viewportLayerArray      = 0x0000_0000_2000_0000, ///Viewport layer is available in vertex shader.
+	drawIndirectCount       = 0x0000_0000_4000_0000, ///Draw indirect with indirect count is supported.
 	textureCompareAll       = 0x0000_0000_0030_0000, ///All texture compare modes are supported.
 }
 

--- a/bindings/zig/bgfx.zig
+++ b/bindings/zig/bgfx.zig
@@ -708,11 +708,14 @@ pub const CapsFlags_VertexAttribUint10: CapsFlags     = 0x0000000004000000;
 /// Rendering with VertexID only is supported.
 pub const CapsFlags_VertexId: CapsFlags               = 0x0000000008000000;
 
+/// PrimitiveID is available in fragment shader.
+pub const CapsFlags_PrimitiveId: CapsFlags            = 0x0000000010000000;
+
 /// Viewport layer is available in vertex shader.
-pub const CapsFlags_ViewportLayerArray: CapsFlags     = 0x0000000010000000;
+pub const CapsFlags_ViewportLayerArray: CapsFlags     = 0x0000000020000000;
 
 /// Draw indirect with indirect count is supported.
-pub const CapsFlags_DrawIndirectCount: CapsFlags      = 0x0000000020000000;
+pub const CapsFlags_DrawIndirectCount: CapsFlags      = 0x0000000040000000;
 
 /// All texture compare modes are supported.
 pub const CapsFlags_TextureCompareAll: CapsFlags      = 0x0000000000300000;

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -15,7 +15,7 @@
 #ifndef BGFX_DEFINES_H_HEADER_GUARD
 #define BGFX_DEFINES_H_HEADER_GUARD
 
-#define BGFX_API_VERSION UINT32_C(121)
+#define BGFX_API_VERSION UINT32_C(122)
 
 /**
  * Color RGB/alpha/depth write. When it's not specified write will be disabled.
@@ -490,8 +490,9 @@
 #define BGFX_CAPS_VERTEX_ATTRIB_HALF              UINT64_C(0x0000000002000000) //!< Vertex attribute half-float is supported.
 #define BGFX_CAPS_VERTEX_ATTRIB_UINT10            UINT64_C(0x0000000004000000) //!< Vertex attribute 10_10_10_2 is supported.
 #define BGFX_CAPS_VERTEX_ID                       UINT64_C(0x0000000008000000) //!< Rendering with VertexID only is supported.
-#define BGFX_CAPS_VIEWPORT_LAYER_ARRAY            UINT64_C(0x0000000010000000) //!< Viewport layer is available in vertex shader.
-#define BGFX_CAPS_DRAW_INDIRECT_COUNT             UINT64_C(0x0000000020000000) //!< Draw indirect with indirect count is supported.
+#define BGFX_CAPS_PRIMITIVE_ID                    UINT64_C(0x0000000010000000) //!< PrimitiveID is available in fragment shader.
+#define BGFX_CAPS_VIEWPORT_LAYER_ARRAY            UINT64_C(0x0000000020000000) //!< Viewport layer is available in vertex shader.
+#define BGFX_CAPS_DRAW_INDIRECT_COUNT             UINT64_C(0x0000000040000000) //!< Draw indirect with indirect count is supported.
 /// All texture compare modes are supported.
 #define BGFX_CAPS_TEXTURE_COMPARE_ALL (0 \
 	| BGFX_CAPS_TEXTURE_COMPARE_RESERVED \

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -1,7 +1,7 @@
 -- vim: syntax=lua
 -- bgfx interface
 
-version(121)
+version(122)
 
 typedef "bool"
 typedef "char"
@@ -393,6 +393,7 @@ flag.Caps { bits = 64, base = 1, name = "Caps" }
 	.VertexAttribHalf       --- Vertex attribute half-float is supported.
 	.VertexAttribUint10     --- Vertex attribute 10_10_10_2 is supported.
 	.VertexId               --- Rendering with VertexID only is supported.
+	.PrimitiveId            --- PrimitiveID is available in fragment shader.
 	.ViewportLayerArray     --- Viewport layer is available in vertex shader.
 	.DrawIndirectCount      --- Draw indirect with indirect count is supported.
 	.TextureCompareAll      --- All texture compare modes are supported.

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1235,6 +1235,9 @@ namespace bgfx { namespace d3d11
 					| ((m_featureLevel >= D3D_FEATURE_LEVEL_11_1)
 						? BGFX_CAPS_IMAGE_RW
 						: 0)
+					| ((m_featureLevel >= D3D_FEATURE_LEVEL_11_0)
+						? BGFX_CAPS_PRIMITIVE_ID
+						: 0)
 					);
 
 				m_timerQuerySupport   = m_featureLevel >= D3D_FEATURE_LEVEL_10_0;

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1357,6 +1357,7 @@ namespace bgfx { namespace d3d12
 					| BGFX_CAPS_IMAGE_RW
 					| BGFX_CAPS_VIEWPORT_LAYER_ARRAY
 					| BGFX_CAPS_DRAW_INDIRECT_COUNT
+					| BGFX_CAPS_PRIMITIVE_ID
 					);
 				g_caps.limits.maxTextureSize     = D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION;
 				g_caps.limits.maxTextureLayers   = D3D12_REQ_TEXTURE2D_ARRAY_AXIS_DIMENSION;

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2897,6 +2897,13 @@ namespace bgfx { namespace gl
 					;
 
 				g_caps.supported |= false
+					|| BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGL >= 32)
+					|| (m_gles3 && !BX_ENABLED(BX_PLATFORM_EMSCRIPTEN) && BX_ENABLED(BGFX_CONFIG_RENDERER_OPENGLES >= 32) )
+					? BGFX_CAPS_PRIMITIVE_ID
+					: 0
+					;
+
+				g_caps.supported |= false
 					|| s_extension[Extension::ARB_texture_cube_map_array].m_supported
 					|| s_extension[Extension::EXT_texture_cube_map_array].m_supported
 					? BGFX_CAPS_TEXTURE_CUBE_ARRAY

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -632,6 +632,11 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 				| BGFX_CAPS_VERTEX_ID
 				);
 
+			g_caps.supported |= m_device.supportsFamily(MTLGPUFamilyApple7)
+				? BGFX_CAPS_PRIMITIVE_ID
+				: 0
+				;
+
 			// Reference(s):
 			// - Metal feature set tables
 			//   https://web.archive.org/web/20230330111145/https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -1570,6 +1570,7 @@ VK_IMPORT_INSTANCE
 				m_deviceFeatures.shaderClipDistance   = supportedFeatures.shaderClipDistance;
 				m_deviceFeatures.shaderCullDistance   = supportedFeatures.shaderCullDistance;
 				m_deviceFeatures.shaderResourceMinLod = supportedFeatures.shaderResourceMinLod;
+				m_deviceFeatures.geometryShader = supportedFeatures.geometryShader;
 
 				m_lineAASupport = true
 					&& s_extension[Extension::EXT_line_rasterization].m_supported
@@ -1608,6 +1609,7 @@ VK_IMPORT_INSTANCE
 					| BGFX_CAPS_VERTEX_ATTRIB_HALF
 					| BGFX_CAPS_VERTEX_ATTRIB_UINT10
 					| BGFX_CAPS_VERTEX_ID
+					| (m_deviceFeatures.geometryShader ? BGFX_CAPS_PRIMITIVE_ID : 0)
 					);
 
 				g_caps.supported |= 0

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -1853,7 +1853,12 @@ namespace bgfx
 						const bool hasFragCoord   = !bx::strFind(input, "gl_FragCoord").isEmpty() || profile->id >= 400;
 						const bool hasFragDepth   = !bx::strFind(input, "gl_FragDepth").isEmpty();
 						const bool hasFrontFacing = !bx::strFind(input, "gl_FrontFacing").isEmpty();
-						const bool hasPrimitiveId = !bx::strFind(input, "gl_PrimitiveID").isEmpty();
+						const bool hasPrimitiveId = !bx::strFind(input, "gl_PrimitiveID").isEmpty() && BGFX_CAPS_PRIMITIVE_ID;
+
+						if (!hasPrimitiveId)
+						{
+							preprocessor.writef("#define gl_PrimitiveID 0\n");
+						}
 
 						bool hasFragData[8] = {};
 						uint32_t numFragData = 0;


### PR DESCRIPTION
Added a new capability to check for PrimitiveID support for common backends.
Vulkan backend will generate a validation error if PrimitiveID is used in a fragment shader without enabling the geometry shader feature that this built-in is dependent on.
It's important to mention that this won't imply that BGFX supports geometry shaders in any way or form.