### PR TITLE
A fix for certain cases where the unifom name could contain a `.`

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4796,7 +4796,7 @@ namespace bgfx
 			; ++ptr
 			)
 		{
-			result &= bx::isAlphaNum(*ptr) || '_' == *ptr;
+			result &= bx::isAlphaNum(*ptr) || '_' || '.' == *ptr;
 		}
 
 		BGFX_ERROR_CHECK(false


### PR DESCRIPTION
In some instances where one would have a structured buffer such as:
```
struct MyStructure
{
    mat4  Matrix;
};

...

BUFFER_RO( u_MyBuffer, MyStructure, * );
```

Then the uniform name generated would be:
```
BGFX Creating uniform (handle *) `u_MyBuffer.@data.Matrix`, num 1
```

This would fail the uniform name validation check, because of the `.` in the name.