### PR TITLE
Small fix on soname defining on ldflags for Android examples.

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -366,6 +366,9 @@ function exampleProjectDefaults()
 	configuration { "android*" }
 		kind "ConsoleApp"
 		targetextension ".so"
+		linkoptions {
+			"-shared"
+		}
 		links {
 			"EGL",
 			"GLESv2",
@@ -373,12 +376,12 @@ function exampleProjectDefaults()
 
 	configuration { "android*", "Debug" }
 		linkoptions {
-			"-shared -Wl,-soname,lib" .. project().name .. "Debug.so"
+			"-Wl,-soname,lib" .. project().name .. "Debug.so"
 		}
 
 	configuration { "android*", "Release" }
 		linkoptions {
-			"-shared -Wl,-soname,lib" .. project().name .. "Release.so"
+			"-Wl,-soname,lib" .. project().name .. "Release.so"
 		}
 
 	configuration { "wasm*" }

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -366,12 +366,19 @@ function exampleProjectDefaults()
 	configuration { "android*" }
 		kind "ConsoleApp"
 		targetextension ".so"
-		linkoptions {
-			"-shared",
-		}
 		links {
 			"EGL",
 			"GLESv2",
+		}
+
+	configuration { "android*", "Debug" }
+		linkoptions {
+			"-shared -Wl,-soname,lib" .. project().name .. "Debug.so"
+		}
+
+	configuration { "android*", "Release" }
+		linkoptions {
+			"-shared -Wl,-soname,lib" .. project().name .. "Release.so"
 		}
 
 	configuration { "wasm*" }

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -367,7 +367,7 @@ function exampleProjectDefaults()
 		kind "ConsoleApp"
 		targetextension ".so"
 		linkoptions {
-			"-shared"
+			"-shared",
 		}
 		links {
 			"EGL",


### PR DESCRIPTION
The issue for this PR is tracked here,

https://github.com/bkaradzic/bgfx/issues/3183

This PR adds the correct SONAME for the target dynamic libraries for Android so the dynamic linker can search the default paths for shared libraries instead of a fixed path.

Below is the output from readelf showing correct embedding of SONAME.

> [garethf@fedora bgfx]$ ls -l .build/android-arm64/bin/*.so
-rwxr-xr-x. 1 garethf garethf  5469048 Oct 16 15:55 .build/android-arm64/bin/libbgfx-shared-libDebug.so
-rwxr-xr-x. 1 garethf garethf  7742072 Oct 16 15:56 .build/android-arm64/bin/libbgfx-shared-libRelease.so
-rwxr-xr-x. 1 garethf garethf 11408680 Oct 16 15:55 .build/android-arm64/bin/libexample-17-drawstressDebug.so
-rwxr-xr-x. 1 garethf garethf  2912776 Oct 16 15:56 .build/android-arm64/bin/libexample-17-drawstressRelease.so
-rwxr-xr-x. 1 garethf garethf  5692936 Oct 16 15:55 .build/android-arm64/bin/libexample-25-c99Debug.so
-rwxr-xr-x. 1 garethf garethf  1240888 Oct 16 15:56 .build/android-arm64/bin/libexample-25-c99Release.so
-rwxr-xr-x. 1 garethf garethf 15592688 Oct 16 15:55 .build/android-arm64/bin/libexamplesDebug.so
-rwxr-xr-x. 1 garethf garethf  3750264 Oct 16 15:57 .build/android-arm64/bin/libexamplesRelease.so
[garethf@fedora bgfx]$ readelf --dynamic .build/android-arm64/bin/*.so | grep SONAME
 0x000000000000000e (SONAME)             Library soname: [libbgfx-shared-libDebug.so]
 0x000000000000000e (SONAME)             Library soname: [libbgfx-shared-libRelease.so]
 0x000000000000000e (SONAME)             Library soname: [libexample-17-drawstressDebug.so]
 0x000000000000000e (SONAME)             Library soname: [libexample-17-drawstressRelease.so]
 0x000000000000000e (SONAME)             Library soname: [libexample-25-c99Debug.so]
 0x000000000000000e (SONAME)             Library soname: [libexample-25-c99Release.so]
 0x000000000000000e (SONAME)             Library soname: [libexamplesDebug.so]
 0x000000000000000e (SONAME)             Library soname: [libexamplesRelease.so]
[garethf@fedora bgfx]$ ls
