### PR TITLE
Check nativeWindow pointer before dereferencing

### DIFF
--- a/src/dxgi.cpp
+++ b/src/dxgi.cpp
@@ -142,9 +142,9 @@ namespace bgfx
 	template<typename T>
 	static bool trySetSwapChain(IInspectable* nativeWindow, Dxgi::SwapChainI* swapChain, HRESULT* hr)
 	{
-		ISwapChainPanelNative* swapChainPanelNative;
+		ISwapChainPanelNative* swapChainPanelNative = NULL;
 
-		if (FAILED(nativeWindow->QueryInterface(__uuidof(T), (void**)&swapChainPanelNative))
+		if (NULL != nativeWindow && FAILED(nativeWindow->QueryInterface(__uuidof(T), (void**)&swapChainPanelNative))
 		||  NULL == swapChainPanelNative)
 		{
 			return false;


### PR DESCRIPTION
Fix access violation in headless mode during bgfx::shutdown(). This pointer is usually set by the SwapChainPanel which doesn't exist in headless mode.

Tested in local build of my project. It was simple enough I did not test with the example projects.