### PR TITLE
Fix kerning for SDF scaled fonts in font_manager.cpp

### DIFF
--- a/examples/common/font/font_manager.cpp
+++ b/examples/common/font/font_manager.cpp
@@ -522,7 +522,9 @@ float FontManager::getKerning(FontHandle _handle, CodePoint _prevCodePoint, Code
 	if (isValid(cachedFont.masterFontHandle))
 	{
 		CachedFont& baseFont = m_cachedFonts[cachedFont.masterFontHandle.idx];
-		return baseFont.trueTypeFont->m_scale * stbtt_GetCodepointKernAdvance(&baseFont.trueTypeFont->m_font, _prevCodePoint, _codePoint);
+		return baseFont.trueTypeFont->m_scale 
+			* stbtt_GetCodepointKernAdvance(&baseFont.trueTypeFont->m_font, _prevCodePoint, _codePoint)
+			* cachedFont.fontInfo.scale;
 	}
 	else
 	{


### PR DESCRIPTION
Kerning is now also scaled with the scaled child font when using SDF fonts. In examples/common/font_manager.cpp kerning was not considering scale of the child font, always using kerning offset of the master font. When scaling SDF font down it visibly too large. 
Look at the pair "Yo" in "You" in example11 before the fix:
![Screenshot 2023-11-05 235149](https://github.com/bkaradzic/bgfx/assets/875308/113f877e-efef-4c5c-bbc1-d0503049121a)
After the fix
![Screenshot 2023-11-05 235209](https://github.com/bkaradzic/bgfx/assets/875308/1d12a518-c4d4-48e6-9267-0fb26b43ba1c)
