### PR TITLE
Fix D3D12 VBV reading size

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -4245,7 +4245,7 @@ namespace bgfx { namespace d3d12
 				D3D12_VERTEX_BUFFER_VIEW& vbv = _vbv[numStreams];
 				vbv.BufferLocation = vb.m_gpuVA + stream.m_startVertex * stride;
 				vbv.StrideInBytes  = layout.m_stride;
-				vbv.SizeInBytes    = vb.m_size;
+				vbv.SizeInBytes    = _outNumVertices * vbv.StrideInBytes;
 
 				_outNumVertices = bx::uint32_min(UINT32_MAX == _draw.m_numVertices
 					? vb.m_size/stride

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -4240,18 +4240,18 @@ namespace bgfx { namespace d3d12
 
 				const uint16_t layoutIdx = !isValid(vb.m_layoutHandle) ? stream.m_layoutHandle.idx : vb.m_layoutHandle.idx;
 				const VertexLayout& layout = s_renderD3D12->m_vertexLayouts[layoutIdx];
-				uint32_t stride = layout.m_stride;
-
-				D3D12_VERTEX_BUFFER_VIEW& vbv = _vbv[numStreams];
-				vbv.BufferLocation = vb.m_gpuVA + stream.m_startVertex * stride;
-				vbv.StrideInBytes  = layout.m_stride;
-				vbv.SizeInBytes    = _outNumVertices * vbv.StrideInBytes;
-
+				const uint32_t stride = layout.m_stride;
+				
 				_outNumVertices = bx::uint32_min(UINT32_MAX == _draw.m_numVertices
 					? vb.m_size/stride
 					: _draw.m_numVertices
 					, _outNumVertices
 					);
+
+				D3D12_VERTEX_BUFFER_VIEW& vbv = _vbv[numStreams];
+				vbv.BufferLocation = vb.m_gpuVA + stream.m_startVertex * stride;
+				vbv.StrideInBytes  = stride;
+				vbv.SizeInBytes    = _outNumVertices * stride;
 			}
 		}
 


### PR DESCRIPTION
When `stream.m_startVertex` is not 0 we target a position past the start of the buffer, so `BufferLocation + SizeInBytes` will be past the end of the buffer, which the debug layer will complaining about.

With this fix we're only creating a view for the part of the buffer we actually need to access.

It will be good if somebody with D3D12 experience can verify my assumptions here. Also, I'm not sure the same issue will be present in any other location, but I can confirm with this fix in place my game doesn't throw more validation errors (about this specifically, of course) and everything seems to work fine.