### PR TITLE
D bindings: fix mangling error, use improved BindBC-Common API

### DIFF
--- a/bindings/d/package.d
+++ b/bindings/d/package.d
@@ -7,13 +7,12 @@ module bgfx;
 
 import bindbc.bgfx.config;
 
-import bindbc.common.types: va_list;
+import bindbc.common.types: c_int64, c_uint64, va_list;
 static import bgfx.fakeenum;
 
 enum uint apiVersion = 124;
 
 alias ViewID = ushort;
-deprecated("Please use `ViewID` instead.") alias ViewId = ushort;
 
 enum invalidHandle(T) = T(ushort.max);
 
@@ -1008,7 +1007,7 @@ extern(C++, "bgfx") struct Caps{
 	Supported functionality.
 	  @attention See `BGFX_CAPS_*` flags at https://bkaradzic.github.io/bgfx/bgfx.html#available-caps
 	*/
-	ulong supported;
+	c_uint64 supported;
 	ushort vendorID; ///Selected GPU vendor PCI id.
 	ushort deviceID; ///Selected GPU device id.
 	bool homogeneousDepth; ///True when NDC depth is in [-1, 1] range, otherwise its [0, 1].
@@ -1091,12 +1090,11 @@ extern(C++, "bgfx") struct Resolution{
 	ubyte maxFrameLatency; ///Maximum frame latency.
 	ubyte debugTextScale; ///Scale factor for debug text.
 	extern(D) mixin(joinFnBinds((){
-		string[][] ret;
-		ret ~= makeFnBinds([
-			[q{void}, q{this}, q{}, `C++`],
-		], true);
+		FnBind[] ret = [
+			{q{void}, q{this}, q{}, ext: `C++`},
+		];
 		return ret;
-	}(), typeof(this).stringof));
+	}()));
 }
 
 ///Initialization parameters used by `bgfx::init`.
@@ -1134,7 +1132,7 @@ extern(C++, "bgfx") struct Init{
 	matching ID.
 	*/
 	ushort deviceID;
-	ulong capabilities; ///Capabilities initialization mask (default: UINT64_MAX).
+	c_uint64 capabilities; ///Capabilities initialization mask (default: UINT64_MAX).
 	bool debug_; ///Enable device for debugging.
 	bool profile; ///Enable device for profiling.
 	PlatformData platformData; ///Platform data.
@@ -1154,12 +1152,11 @@ extern(C++, "bgfx") struct Init{
 	*/
 	void* allocator;
 	extern(D) mixin(joinFnBinds((){
-		string[][] ret;
-		ret ~= makeFnBinds([
-			[q{void}, q{this}, q{}, `C++`],
-		], true);
+		FnBind[] ret = [
+			{q{void}, q{this}, q{}, ext: `C++`},
+		];
 		return ret;
-	}(), typeof(this).stringof));
+	}()));
 }
 
 /**
@@ -1229,8 +1226,7 @@ extern(C++, "bgfx") struct Attachment{
 	ushort numLayers; ///Number of texture layer/slice(s) in array to use.
 	ubyte resolve; ///Resolve flags. See: `BGFX_RESOLVE_*`
 	extern(D) mixin(joinFnBinds((){
-		string[][] ret;
-		ret ~= makeFnBinds([
+		FnBind[] ret = [
 			/**
 			Init attachment.
 			Params:
@@ -1241,10 +1237,10 @@ extern(C++, "bgfx") struct Attachment{
 				mip = Mip level.
 				resolve = Resolve flags. See: `BGFX_RESOLVE_*`
 			*/
-			[q{void}, q{init}, q{TextureHandle handle, bgfx.fakeenum.Access.Enum access=Access.write, ushort layer=0, ushort numLayers=1, ushort mip=0, ubyte resolve=Resolve.autoGenMIPs}, `C++`],
-		], true);
+			{q{void}, q{init}, q{TextureHandle handle, bgfx.fakeenum.Access.Enum access=Access.write, ushort layer=0, ushort numLayers=1, ushort mip=0, ubyte resolve=Resolve.autoGenMIPs}, ext: `C++`},
+		];
 		return ret;
-	}(), typeof(this).stringof));
+	}()));
 }
 
 ///Transform data.
@@ -1257,17 +1253,17 @@ extern(C++, "bgfx") struct Transform{
 extern(C++, "bgfx") struct ViewStats{
 	char[256] name; ///View name.
 	ViewID view; ///View id.
-	long cpuTimeBegin; ///CPU (submit) begin time.
-	long cpuTimeEnd; ///CPU (submit) end time.
-	long gpuTimeBegin; ///GPU begin time.
-	long gpuTimeEnd; ///GPU end time.
+	c_int64 cpuTimeBegin; ///CPU (submit) begin time.
+	c_int64 cpuTimeEnd; ///CPU (submit) end time.
+	c_int64 gpuTimeBegin; ///GPU begin time.
+	c_int64 gpuTimeEnd; ///GPU end time.
 	uint gpuFrameNum; ///Frame which generated gpuTimeBegin, gpuTimeEnd.
 }
 
 ///Encoder stats.
 extern(C++, "bgfx") struct EncoderStats{
-	long cpuTimeBegin; ///Encoder thread CPU submit begin time.
-	long cpuTimeEnd; ///Encoder thread CPU submit end time.
+	c_int64 cpuTimeBegin; ///Encoder thread CPU submit begin time.
+	c_int64 cpuTimeEnd; ///Encoder thread CPU submit end time.
 }
 
 /**
@@ -1276,15 +1272,15 @@ Renderer statistics data.
 time frequencies define timestamps-per-second for that hardware.
 */
 extern(C++, "bgfx") struct Stats{
-	long cpuTimeFrame; ///CPU time between two `bgfx::frame` calls.
-	long cpuTimeBegin; ///Render thread CPU submit begin time.
-	long cpuTimeEnd; ///Render thread CPU submit end time.
-	long cpuTimerFreq; ///CPU timer frequency. Timestamps-per-second
-	long gpuTimeBegin; ///GPU frame begin time.
-	long gpuTimeEnd; ///GPU frame end time.
-	long gpuTimerFreq; ///GPU timer frequency.
-	long waitRender; ///Time spent waiting for render backend thread to finish issuing draw commands to underlying graphics API.
-	long waitSubmit; ///Time spent waiting for submit thread to advance to next frame.
+	c_int64 cpuTimeFrame; ///CPU time between two `bgfx::frame` calls.
+	c_int64 cpuTimeBegin; ///Render thread CPU submit begin time.
+	c_int64 cpuTimeEnd; ///Render thread CPU submit end time.
+	c_int64 cpuTimerFreq; ///CPU timer frequency. Timestamps-per-second
+	c_int64 gpuTimeBegin; ///GPU frame begin time.
+	c_int64 gpuTimeEnd; ///GPU frame end time.
+	c_int64 gpuTimerFreq; ///GPU timer frequency.
+	c_int64 waitRender; ///Time spent waiting for render backend thread to finish issuing draw commands to underlying graphics API.
+	c_int64 waitSubmit; ///Time spent waiting for submit thread to advance to next frame.
 	uint numDraw; ///Number of draw calls submitted.
 	uint numCompute; ///Number of compute calls submitted.
 	uint numBlit; ///Number of blit calls submitted.
@@ -1301,13 +1297,13 @@ extern(C++, "bgfx") struct Stats{
 	ushort numUniforms; ///Number of used uniforms.
 	ushort numVertexBuffers; ///Number of used vertex buffers.
 	ushort numVertexLayouts; ///Number of used vertex layouts.
-	long textureMemoryUsed; ///Estimate of texture memory used.
-	long rtMemoryUsed; ///Estimate of render target memory used.
+	c_int64 textureMemoryUsed; ///Estimate of texture memory used.
+	c_int64 rtMemoryUsed; ///Estimate of render target memory used.
 	int transientVBUsed; ///Amount of transient vertex buffer used.
 	int transientIBUsed; ///Amount of transient index buffer used.
 	uint[Topology.count] numPrims; ///Number of primitives rendered.
-	long gpuMemoryMax; ///Maximum available GPU memory for application.
-	long gpuMemoryUsed; ///Amount of GPU memory used by the application.
+	c_int64 gpuMemoryMax; ///Maximum available GPU memory for application.
+	c_int64 gpuMemoryUsed; ///Amount of GPU memory used by the application.
 	ushort width; ///Backbuffer width in pixels.
 	ushort height; ///Backbuffer height in pixels.
 	ushort textWidth; ///Debug text width in characters.
@@ -1325,16 +1321,15 @@ extern(C++, "bgfx") struct VertexLayout{
 	ushort[Attrib.count] offset; ///Attribute offsets.
 	ushort[Attrib.count] attributes; ///Used attributes.
 	extern(D) mixin(joinFnBinds((){
-		string[][] ret;
-		ret ~= makeFnBinds([
-			[q{void}, q{this}, q{}, `C++`],
+		FnBind[] ret = [
+			{q{void}, q{this}, q{}, ext: `C++`},
 			
 			/**
 			Start VertexLayout.
 			Params:
 				rendererType = Renderer backend type. See: `bgfx::RendererType`
 			*/
-			[q{VertexLayout*}, q{begin}, q{bgfx.fakeenum.RendererType.Enum rendererType=RendererType.noop}, `C++`],
+			{q{VertexLayout*}, q{begin}, q{bgfx.fakeenum.RendererType.Enum rendererType=RendererType.noop}, ext: `C++`},
 			
 			/**
 			Add attribute to VertexLayout.
@@ -1343,7 +1338,7 @@ extern(C++, "bgfx") struct VertexLayout{
 				attrib = Attribute semantics. See: `bgfx::Attrib`
 				num = Number of elements 1, 2, 3 or 4.
 				type = Element type.
-				normalized = When using fixed point AttribType (f.e. Uint8)
+				normalised = When using fixed point AttribType (f.e. Uint8)
 			value will be normalized for vertex shader usage. When normalized
 			is set to true, AttribType::Uint8 value in range 0-255 will be
 			in range 0.0-1.0 in vertex shader.
@@ -1351,7 +1346,7 @@ extern(C++, "bgfx") struct VertexLayout{
 			vertexConvert for AttribType::Uint8 and AttribType::Int16.
 			Unpacking code must be implemented inside vertex shader.
 			*/
-			[q{VertexLayout*}, q{add}, q{bgfx.fakeenum.Attrib.Enum attrib, ubyte num, bgfx.fakeenum.AttribType.Enum type, bool normalized=false, bool asInt=false}, `C++`],
+			{q{VertexLayout*}, q{add}, q{bgfx.fakeenum.Attrib.Enum attrib, ubyte num, bgfx.fakeenum.AttribType.Enum type, bool normalised=false, bool asInt=false}, ext: `C++`},
 			
 			/**
 			Decode attribute.
@@ -1359,25 +1354,25 @@ extern(C++, "bgfx") struct VertexLayout{
 				attrib = Attribute semantics. See: `bgfx::Attrib`
 				num = Number of elements.
 				type = Element type.
-				normalized = Attribute is normalized.
+				normalised = Attribute is normalized.
 				asInt = Attribute is packed as int.
 			*/
-			[q{void}, q{decode}, q{bgfx.fakeenum.Attrib.Enum attrib, ref ubyte num, ref bgfx.fakeenum.AttribType.Enum type, ref bool normalized, ref bool asInt}, `C++`, q{const}],
+			{q{void}, q{decode}, q{bgfx.fakeenum.Attrib.Enum attrib, ref ubyte num, ref bgfx.fakeenum.AttribType.Enum type, ref bool normalised, ref bool asInt}, ext: `C++`, memAttr: q{const}},
 			
 			/**
 			Skip `_num` bytes in vertex stream.
 			Params:
 				num = Number of bytes to skip.
 			*/
-			[q{VertexLayout*}, q{skip}, q{ubyte num}, `C++`],
+			{q{VertexLayout*}, q{skip}, q{ubyte num}, ext: `C++`},
 			
 			/**
 			End VertexLayout.
 			*/
-			[q{void}, q{end}, q{}, `C++`],
-		], true);
+			{q{void}, q{end}, q{}, ext: `C++`},
+		];
 		return ret;
-	}(), typeof(this).stringof));
+	}()));
 }
 
 /**
@@ -1386,15 +1381,14 @@ per thread should be used. Use `bgfx::begin()` to obtain an encoder for a thread
 */
 extern(C++, "bgfx") struct Encoder{
 	extern(D) mixin(joinFnBinds((){
-		string[][] ret;
-		ret ~= makeFnBinds([
+		FnBind[] ret = [
 			/**
 			Sets a debug marker. This allows you to group graphics calls together for easy browsing in
 			graphics debugging tools.
 			Params:
 				marker = Marker string.
 			*/
-			[q{void}, q{setMarker}, q{const(char)* marker}, `C++`],
+			{q{void}, q{setMarker}, q{const(char)* marker}, ext: `C++`},
 			
 			/**
 			Set render states for draw primitive.
@@ -1421,7 +1415,7 @@ extern(C++, "bgfx") struct Encoder{
 				rgba = Sets blend factor used by `BGFX_STATE_BLEND_FACTOR` and
 			  `BGFX_STATE_BLEND_INV_FACTOR` blend modes.
 			*/
-			[q{void}, q{setState}, q{ulong state, uint rgba=0}, `C++`],
+			{q{void}, q{setState}, q{c_uint64 state, uint rgba=0}, ext: `C++`},
 			
 			/**
 			Set condition for rendering.
@@ -1429,16 +1423,16 @@ extern(C++, "bgfx") struct Encoder{
 				handle = Occlusion query handle.
 				visible = Render if occlusion query is visible.
 			*/
-			[q{void}, q{setCondition}, q{OcclusionQueryHandle handle, bool visible}, `C++`],
+			{q{void}, q{setCondition}, q{OcclusionQueryHandle handle, bool visible}, ext: `C++`},
 			
 			/**
 			Set stencil test state.
 			Params:
-				fstencil = Front stencil state.
-				bstencil = Back stencil state. If back is set to `BGFX_STENCIL_NONE`
+				fStencil = Front stencil state.
+				bStencil = Back stencil state. If back is set to `BGFX_STENCIL_NONE`
 			_fstencil is applied to both front and back facing primitives.
 			*/
-			[q{void}, q{setStencil}, q{uint fstencil, uint bstencil=Stencil.none}, `C++`],
+			{q{void}, q{setStencil}, q{uint fStencil, uint bStencil=Stencil.none}, ext: `C++`},
 			
 			/**
 			Set scissor for draw primitive.
@@ -1450,7 +1444,7 @@ extern(C++, "bgfx") struct Encoder{
 				width = Width of view scissor region.
 				height = Height of view scissor region.
 			*/
-			[q{ushort}, q{setScissor}, q{ushort x, ushort y, ushort width, ushort height}, `C++`],
+			{q{ushort}, q{setScissor}, q{ushort x, ushort y, ushort width, ushort height}, ext: `C++`},
 			
 			/**
 			Set scissor from cache for draw primitive.
@@ -1459,7 +1453,7 @@ extern(C++, "bgfx") struct Encoder{
 			Params:
 				cache = Index in scissor cache.
 			*/
-			[q{void}, q{setScissor}, q{ushort cache=ushort.max}, `C++`],
+			{q{void}, q{setScissor}, q{ushort cache=ushort.max}, ext: `C++`},
 			
 			/**
 			Set model matrix for draw primitive. If it is not called,
@@ -1468,7 +1462,7 @@ extern(C++, "bgfx") struct Encoder{
 				mtx = Pointer to first matrix in array.
 				num = Number of matrices in array.
 			*/
-			[q{uint}, q{setTransform}, q{const(void)* mtx, ushort num=1}, `C++`],
+			{q{uint}, q{setTransform}, q{const(void)* mtx, ushort num=1}, ext: `C++`},
 			
 			/**
 			 Set model matrix from matrix cache for draw primitive.
@@ -1476,7 +1470,7 @@ extern(C++, "bgfx") struct Encoder{
 				cache = Index in matrix cache.
 				num = Number of matrices from cache.
 			*/
-			[q{void}, q{setTransform}, q{uint cache, ushort num=1}, `C++`],
+			{q{void}, q{setTransform}, q{uint cache, ushort num=1}, ext: `C++`},
 			
 			/**
 			Reserve matrices in internal matrix cache.
@@ -1485,7 +1479,7 @@ extern(C++, "bgfx") struct Encoder{
 				transform = Pointer to `Transform` structure.
 				num = Number of matrices.
 			*/
-			[q{uint}, q{allocTransform}, q{Transform* transform, ushort num}, `C++`],
+			{q{uint}, q{allocTransform}, q{Transform* transform, ushort num}, ext: `C++`},
 			
 			/**
 			Set shader uniform parameter for draw primitive.
@@ -1495,14 +1489,14 @@ extern(C++, "bgfx") struct Encoder{
 				num = Number of elements. Passing `UINT16_MAX` will
 			use the _num passed on uniform creation.
 			*/
-			[q{void}, q{setUniform}, q{UniformHandle handle, const(void)* value, ushort num=1}, `C++`],
+			{q{void}, q{setUniform}, q{UniformHandle handle, const(void)* value, ushort num=1}, ext: `C++`},
 			
 			/**
 			Set index buffer for draw primitive.
 			Params:
 				handle = Index buffer.
 			*/
-			[q{void}, q{setIndexBuffer}, q{IndexBufferHandle handle}, `C++`],
+			{q{void}, q{setIndexBuffer}, q{IndexBufferHandle handle}, ext: `C++`},
 			
 			/**
 			Set index buffer for draw primitive.
@@ -1511,14 +1505,14 @@ extern(C++, "bgfx") struct Encoder{
 				firstIndex = First index to render.
 				numIndices = Number of indices to render.
 			*/
-			[q{void}, q{setIndexBuffer}, q{IndexBufferHandle handle, uint firstIndex, uint numIndices}, `C++`],
+			{q{void}, q{setIndexBuffer}, q{IndexBufferHandle handle, uint firstIndex, uint numIndices}, ext: `C++`},
 			
 			/**
 			Set index buffer for draw primitive.
 			Params:
 				handle = Dynamic index buffer.
 			*/
-			[q{void}, q{setIndexBuffer}, q{DynamicIndexBufferHandle handle}, `C++`],
+			{q{void}, q{setIndexBuffer}, q{DynamicIndexBufferHandle handle}, ext: `C++`},
 			
 			/**
 			Set index buffer for draw primitive.
@@ -1527,14 +1521,14 @@ extern(C++, "bgfx") struct Encoder{
 				firstIndex = First index to render.
 				numIndices = Number of indices to render.
 			*/
-			[q{void}, q{setIndexBuffer}, q{DynamicIndexBufferHandle handle, uint firstIndex, uint numIndices}, `C++`],
+			{q{void}, q{setIndexBuffer}, q{DynamicIndexBufferHandle handle, uint firstIndex, uint numIndices}, ext: `C++`},
 			
 			/**
 			Set index buffer for draw primitive.
 			Params:
 				tib = Transient index buffer.
 			*/
-			[q{void}, q{setIndexBuffer}, q{const(TransientIndexBuffer)* tib}, `C++`],
+			{q{void}, q{setIndexBuffer}, q{const(TransientIndexBuffer)* tib}, ext: `C++`},
 			
 			/**
 			Set index buffer for draw primitive.
@@ -1543,7 +1537,7 @@ extern(C++, "bgfx") struct Encoder{
 				firstIndex = First index to render.
 				numIndices = Number of indices to render.
 			*/
-			[q{void}, q{setIndexBuffer}, q{const(TransientIndexBuffer)* tib, uint firstIndex, uint numIndices}, `C++`],
+			{q{void}, q{setIndexBuffer}, q{const(TransientIndexBuffer)* tib, uint firstIndex, uint numIndices}, ext: `C++`},
 			
 			/**
 			Set vertex buffer for draw primitive.
@@ -1551,7 +1545,7 @@ extern(C++, "bgfx") struct Encoder{
 				stream = Vertex stream.
 				handle = Vertex buffer.
 			*/
-			[q{void}, q{setVertexBuffer}, q{ubyte stream, VertexBufferHandle handle}, `C++`],
+			{q{void}, q{setVertexBuffer}, q{ubyte stream, VertexBufferHandle handle}, ext: `C++`},
 			
 			/**
 			Set vertex buffer for draw primitive.
@@ -1564,7 +1558,7 @@ extern(C++, "bgfx") struct Encoder{
 			handle is used, vertex layout used for creation
 			of vertex buffer will be used.
 			*/
-			[q{void}, q{setVertexBuffer}, q{ubyte stream, VertexBufferHandle handle, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, `C++`],
+			{q{void}, q{setVertexBuffer}, q{ubyte stream, VertexBufferHandle handle, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, ext: `C++`},
 			
 			/**
 			Set vertex buffer for draw primitive.
@@ -1572,8 +1566,8 @@ extern(C++, "bgfx") struct Encoder{
 				stream = Vertex stream.
 				handle = Dynamic vertex buffer.
 			*/
-			[q{void}, q{setVertexBuffer}, q{ubyte stream, DynamicVertexBufferHandle handle}, `C++`],
-			[q{void}, q{setVertexBuffer}, q{ubyte stream, DynamicVertexBufferHandle handle, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, `C++`],
+			{q{void}, q{setVertexBuffer}, q{ubyte stream, DynamicVertexBufferHandle handle}, ext: `C++`},
+			{q{void}, q{setVertexBuffer}, q{ubyte stream, DynamicVertexBufferHandle handle, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, ext: `C++`},
 			
 			/**
 			Set vertex buffer for draw primitive.
@@ -1581,7 +1575,7 @@ extern(C++, "bgfx") struct Encoder{
 				stream = Vertex stream.
 				tvb = Transient vertex buffer.
 			*/
-			[q{void}, q{setVertexBuffer}, q{ubyte stream, const(TransientVertexBuffer)* tvb}, `C++`],
+			{q{void}, q{setVertexBuffer}, q{ubyte stream, const(TransientVertexBuffer)* tvb}, ext: `C++`},
 			
 			/**
 			Set vertex buffer for draw primitive.
@@ -1594,7 +1588,7 @@ extern(C++, "bgfx") struct Encoder{
 			handle is used, vertex layout used for creation
 			of vertex buffer will be used.
 			*/
-			[q{void}, q{setVertexBuffer}, q{ubyte stream, const(TransientVertexBuffer)* tvb, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, `C++`],
+			{q{void}, q{setVertexBuffer}, q{ubyte stream, const(TransientVertexBuffer)* tvb, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, ext: `C++`},
 			
 			/**
 			Set number of vertices for auto generated vertices use in conjunction
@@ -1603,14 +1597,14 @@ extern(C++, "bgfx") struct Encoder{
 			Params:
 				numVertices = Number of vertices.
 			*/
-			[q{void}, q{setVertexCount}, q{uint numVertices}, `C++`],
+			{q{void}, q{setVertexCount}, q{uint numVertices}, ext: `C++`},
 			
 			/**
 			Set instance data buffer for draw primitive.
 			Params:
 				idb = Transient instance data buffer.
 			*/
-			[q{void}, q{setInstanceDataBuffer}, q{const(InstanceDataBuffer)* idb}, `C++`],
+			{q{void}, q{setInstanceDataBuffer}, q{const(InstanceDataBuffer)* idb}, ext: `C++`},
 			
 			/**
 			Set instance data buffer for draw primitive.
@@ -1619,7 +1613,7 @@ extern(C++, "bgfx") struct Encoder{
 				start = First instance data.
 				num = Number of data instances.
 			*/
-			[q{void}, q{setInstanceDataBuffer}, q{const(InstanceDataBuffer)* idb, uint start, uint num}, `C++`],
+			{q{void}, q{setInstanceDataBuffer}, q{const(InstanceDataBuffer)* idb, uint start, uint num}, ext: `C++`},
 			
 			/**
 			Set instance data buffer for draw primitive.
@@ -1628,7 +1622,7 @@ extern(C++, "bgfx") struct Encoder{
 				startVertex = First instance data.
 				num = Number of data instances.
 			*/
-			[q{void}, q{setInstanceDataBuffer}, q{VertexBufferHandle handle, uint startVertex, uint num}, `C++`],
+			{q{void}, q{setInstanceDataBuffer}, q{VertexBufferHandle handle, uint startVertex, uint num}, ext: `C++`},
 			
 			/**
 			Set instance data buffer for draw primitive.
@@ -1637,14 +1631,14 @@ extern(C++, "bgfx") struct Encoder{
 				startVertex = First instance data.
 				num = Number of data instances.
 			*/
-			[q{void}, q{setInstanceDataBuffer}, q{DynamicVertexBufferHandle handle, uint startVertex, uint num}, `C++`],
+			{q{void}, q{setInstanceDataBuffer}, q{DynamicVertexBufferHandle handle, uint startVertex, uint num}, ext: `C++`},
 			
 			/**
 			Set number of instances for auto generated instances use in conjunction
 			with gl_InstanceID.
 			Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 			*/
-			[q{void}, q{setInstanceCount}, q{uint numInstances}, `C++`],
+			{q{void}, q{setInstanceCount}, q{uint numInstances}, ext: `C++`},
 			
 			/**
 			Set texture stage for draw primitive.
@@ -1659,7 +1653,7 @@ extern(C++, "bgfx") struct Encoder{
 			  - `BGFX_SAMPLER_[MIN/MAG/MIP]_[POINT/ANISOTROPIC]` - Point or anisotropic
 			    sampling.
 			*/
-			[q{void}, q{setTexture}, q{ubyte stage, UniformHandle sampler, TextureHandle handle, uint flags=uint.max}, `C++`],
+			{q{void}, q{setTexture}, q{ubyte stage, UniformHandle sampler, TextureHandle handle, uint flags=uint.max}, ext: `C++`},
 			
 			/**
 			Submit an empty primitive for rendering. Uniforms and draw state
@@ -1671,7 +1665,7 @@ extern(C++, "bgfx") struct Encoder{
 			Params:
 				id = View id.
 			*/
-			[q{void}, q{touch}, q{ViewID id}, `C++`],
+			{q{void}, q{touch}, q{ViewID id}, ext: `C++`},
 			
 			/**
 			Submit primitive for rendering.
@@ -1681,7 +1675,7 @@ extern(C++, "bgfx") struct Encoder{
 				depth = Depth for sorting.
 				flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 			*/
-			[q{void}, q{submit}, q{ViewID id, ProgramHandle program, uint depth=0, ubyte flags=Discard.all}, `C++`],
+			{q{void}, q{submit}, q{ViewID id, ProgramHandle program, uint depth=0, ubyte flags=Discard.all}, ext: `C++`},
 			
 			/**
 			Submit primitive with occlusion query for rendering.
@@ -1692,7 +1686,7 @@ extern(C++, "bgfx") struct Encoder{
 				depth = Depth for sorting.
 				flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 			*/
-			[q{void}, q{submit}, q{ViewID id, ProgramHandle program, OcclusionQueryHandle occlusionQuery, uint depth=0, ubyte flags=Discard.all}, `C++`],
+			{q{void}, q{submit}, q{ViewID id, ProgramHandle program, OcclusionQueryHandle occlusionQuery, uint depth=0, ubyte flags=Discard.all}, ext: `C++`},
 			
 			/**
 			Submit primitive for rendering with index and instance data info from
@@ -1707,7 +1701,7 @@ extern(C++, "bgfx") struct Encoder{
 				depth = Depth for sorting.
 				flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 			*/
-			[q{void}, q{submit}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start=0, ushort num=1, uint depth=0, ubyte flags=Discard.all}, `C++`],
+			{q{void}, q{submit}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start=0, ushort num=1, uint depth=0, ubyte flags=Discard.all}, ext: `C++`},
 			
 			/**
 			Submit primitive for rendering with index and instance data info and
@@ -1725,7 +1719,7 @@ extern(C++, "bgfx") struct Encoder{
 				depth = Depth for sorting.
 				flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 			*/
-			[q{void}, q{submit}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start, IndexBufferHandle numHandle, uint numIndex=0, ushort numMax=ushort.max, uint depth=0, ubyte flags=Discard.all}, `C++`],
+			{q{void}, q{submit}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start, IndexBufferHandle numHandle, uint numIndex=0, ushort numMax=ushort.max, uint depth=0, ubyte flags=Discard.all}, ext: `C++`},
 			
 			/**
 			Set compute index buffer.
@@ -1734,7 +1728,7 @@ extern(C++, "bgfx") struct Encoder{
 				handle = Index buffer handle.
 				access = Buffer access. See `Access::Enum`.
 			*/
-			[q{void}, q{setBuffer}, q{ubyte stage, IndexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++`],
+			{q{void}, q{setBuffer}, q{ubyte stage, IndexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++`},
 			
 			/**
 			Set compute vertex buffer.
@@ -1743,7 +1737,7 @@ extern(C++, "bgfx") struct Encoder{
 				handle = Vertex buffer handle.
 				access = Buffer access. See `Access::Enum`.
 			*/
-			[q{void}, q{setBuffer}, q{ubyte stage, VertexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++`],
+			{q{void}, q{setBuffer}, q{ubyte stage, VertexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++`},
 			
 			/**
 			Set compute dynamic index buffer.
@@ -1752,7 +1746,7 @@ extern(C++, "bgfx") struct Encoder{
 				handle = Dynamic index buffer handle.
 				access = Buffer access. See `Access::Enum`.
 			*/
-			[q{void}, q{setBuffer}, q{ubyte stage, DynamicIndexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++`],
+			{q{void}, q{setBuffer}, q{ubyte stage, DynamicIndexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++`},
 			
 			/**
 			Set compute dynamic vertex buffer.
@@ -1761,7 +1755,7 @@ extern(C++, "bgfx") struct Encoder{
 				handle = Dynamic vertex buffer handle.
 				access = Buffer access. See `Access::Enum`.
 			*/
-			[q{void}, q{setBuffer}, q{ubyte stage, DynamicVertexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++`],
+			{q{void}, q{setBuffer}, q{ubyte stage, DynamicVertexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++`},
 			
 			/**
 			Set compute indirect buffer.
@@ -1770,7 +1764,7 @@ extern(C++, "bgfx") struct Encoder{
 				handle = Indirect buffer handle.
 				access = Buffer access. See `Access::Enum`.
 			*/
-			[q{void}, q{setBuffer}, q{ubyte stage, IndirectBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++`],
+			{q{void}, q{setBuffer}, q{ubyte stage, IndirectBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++`},
 			
 			/**
 			Set compute image from texture.
@@ -1781,7 +1775,7 @@ extern(C++, "bgfx") struct Encoder{
 				access = Image access. See `Access::Enum`.
 				format = Texture format. See: `TextureFormat::Enum`.
 			*/
-			[q{void}, q{setImage}, q{ubyte stage, TextureHandle handle, ubyte mip, bgfx.fakeenum.Access.Enum access, bgfx.fakeenum.TextureFormat.Enum format=TextureFormat.count}, `C++`],
+			{q{void}, q{setImage}, q{ubyte stage, TextureHandle handle, ubyte mip, bgfx.fakeenum.Access.Enum access, bgfx.fakeenum.TextureFormat.Enum format=TextureFormat.count}, ext: `C++`},
 			
 			/**
 			Dispatch compute.
@@ -1793,7 +1787,7 @@ extern(C++, "bgfx") struct Encoder{
 				numZ = Number of groups Z.
 				flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 			*/
-			[q{void}, q{dispatch}, q{ViewID id, ProgramHandle program, uint numX=1, uint numY=1, uint numZ=1, ubyte flags=Discard.all}, `C++`],
+			{q{void}, q{dispatch}, q{ViewID id, ProgramHandle program, uint numX=1, uint numY=1, uint numZ=1, ubyte flags=Discard.all}, ext: `C++`},
 			
 			/**
 			Dispatch compute indirect.
@@ -1805,14 +1799,14 @@ extern(C++, "bgfx") struct Encoder{
 				num = Number of dispatches.
 				flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 			*/
-			[q{void}, q{dispatch}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start=0, ushort num=1, ubyte flags=Discard.all}, `C++`],
+			{q{void}, q{dispatch}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start=0, ushort num=1, ubyte flags=Discard.all}, ext: `C++`},
 			
 			/**
 			Discard previously set state for draw or compute call.
 			Params:
 				flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 			*/
-			[q{void}, q{discard}, q{ubyte flags=Discard.all}, `C++`],
+			{q{void}, q{discard}, q{ubyte flags=Discard.all}, ext: `C++`},
 			
 			/**
 			Blit 2D texture region between two 2D textures.
@@ -1829,7 +1823,7 @@ extern(C++, "bgfx") struct Encoder{
 				width = Width of region.
 				height = Height of region.
 			*/
-			[q{void}, q{blit}, q{ViewID id, TextureHandle dst, ushort dstX, ushort dstY, TextureHandle src, ushort srcX=0, ushort srcY=0, ushort width=ushort.max, ushort height=ushort.max}, `C++`],
+			{q{void}, q{blit}, q{ViewID id, TextureHandle dst, ushort dstX, ushort dstY, TextureHandle src, ushort srcX=0, ushort srcY=0, ushort width=ushort.max, ushort height=ushort.max}, ext: `C++`},
 			
 			/**
 			Blit 2D texture region between two 2D textures.
@@ -1856,26 +1850,25 @@ extern(C++, "bgfx") struct Encoder{
 				depth = If texture is 3D this argument represents depth of region, otherwise it's
 			unused.
 			*/
-			[q{void}, q{blit}, q{ViewID id, TextureHandle dst, ubyte dstMIP, ushort dstX, ushort dstY, ushort dstZ, TextureHandle src, ubyte srcMIP=0, ushort srcX=0, ushort srcY=0, ushort srcZ=0, ushort width=ushort.max, ushort height=ushort.max, ushort depth=ushort.max}, `C++`],
-		], true);
+			{q{void}, q{blit}, q{ViewID id, TextureHandle dst, ubyte dstMIP, ushort dstX, ushort dstY, ushort dstZ, TextureHandle src, ubyte srcMIP=0, ushort srcX=0, ushort srcY=0, ushort srcZ=0, ushort width=ushort.max, ushort height=ushort.max, ushort depth=ushort.max}, ext: `C++`},
+		];
 		return ret;
-	}(), typeof(this).stringof));
+	}()));
 }
 
 mixin(joinFnBinds((){
-	string[][] ret;
-	ret ~= makeFnBinds([
+	FnBind[] ret = [
 		/**
 		* Pack vertex attribute into vertex stream format.
 		Params:
 			input = Value to be packed into vertex stream.
-			inputNormalized = `true` if input value is already normalized.
+			inputNormalised = `true` if input value is already normalized.
 			attr = Attribute to pack.
 			layout = Vertex stream layout.
 			data = Destination vertex stream where data will be packed.
 			index = Vertex index that will be modified.
 		*/
-		[q{void}, q{vertexPack}, q{const(float)* input, bool inputNormalized, bgfx.fakeenum.Attrib.Enum attr, ref const VertexLayout layout, void* data, uint index=0}, `C++, "bgfx"`],
+		{q{void}, q{vertexPack}, q{const(float)* input, bool inputNormalised, bgfx.fakeenum.Attrib.Enum attr, ref const VertexLayout layout, void* data, uint index=0}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Unpack vertex attribute from vertex stream format.
@@ -1886,7 +1879,7 @@ mixin(joinFnBinds((){
 			data = Source vertex stream from where data will be unpacked.
 			index = Vertex index that will be unpacked.
 		*/
-		[q{void}, q{vertexUnpack}, q{float* output, bgfx.fakeenum.Attrib.Enum attr, ref const VertexLayout layout, const(void)* data, uint index=0}, `C++, "bgfx"`],
+		{q{void}, q{vertexUnpack}, q{float* output, bgfx.fakeenum.Attrib.Enum attr, ref const VertexLayout layout, const(void)* data, uint index=0}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Converts vertex stream data from one vertex stream format to another.
@@ -1897,7 +1890,7 @@ mixin(joinFnBinds((){
 			srcData = Source vertex stream data.
 			num = Number of vertices to convert from source to destination.
 		*/
-		[q{void}, q{vertexConvert}, q{ref const VertexLayout dstLayout, void* dstData, ref const VertexLayout srcLayout, const(void)* srcData, uint num=1}, `C++, "bgfx"`],
+		{q{void}, q{vertexConvert}, q{ref const VertexLayout dstLayout, void* dstData, ref const VertexLayout srcLayout, const(void)* srcData, uint num=1}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Weld vertices.
@@ -1910,7 +1903,7 @@ mixin(joinFnBinds((){
 			index32 = Set to `true` if input indices are 32-bit.
 			epsilon = Error tolerance for vertex position comparison.
 		*/
-		[q{uint}, q{weldVertices}, q{void* output, ref const VertexLayout layout, const(void)* data, uint num, bool index32, float epsilon=0.001f}, `C++, "bgfx"`],
+		{q{uint}, q{weldVertices}, q{void* output, ref const VertexLayout layout, const(void)* data, uint num, bool index32, float epsilon=0.001f}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Convert index buffer for use with different primitive topologies.
@@ -1925,7 +1918,7 @@ mixin(joinFnBinds((){
 			numIndices = Number of input indices.
 			index32 = Set to `true` if input indices are 32-bit.
 		*/
-		[q{uint}, q{topologyConvert}, q{bgfx.fakeenum.TopologyConvert.Enum conversion, void* dst, uint dstSize, const(void)* indices, uint numIndices, bool index32}, `C++, "bgfx"`],
+		{q{uint}, q{topologyConvert}, q{bgfx.fakeenum.TopologyConvert.Enum conversion, void* dst, uint dstSize, const(void)* indices, uint numIndices, bool index32}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Sort indices.
@@ -1945,7 +1938,7 @@ mixin(joinFnBinds((){
 			numIndices = Number of input indices.
 			index32 = Set to `true` if input indices are 32-bit.
 		*/
-		[q{void}, q{topologySortTriList}, q{bgfx.fakeenum.TopologySort.Enum sort, void* dst, uint dstSize, const(float)* dir, const(float)* pos, const(void)* vertices, uint stride, const(void)* indices, uint numIndices, bool index32}, `C++, "bgfx"`],
+		{q{void}, q{topologySortTriList}, q{bgfx.fakeenum.TopologySort.Enum sort, void* dst, uint dstSize, const(float)* dir, const(float)* pos, const(void)* vertices, uint stride, const(void)* indices, uint numIndices, bool index32}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns supported backend API renderers.
@@ -1953,26 +1946,26 @@ mixin(joinFnBinds((){
 			max = Maximum number of elements in _enum array.
 			enum_ = Array where supported renderers will be written.
 		*/
-		[q{ubyte}, q{getSupportedRenderers}, q{ubyte max=0, bgfx.fakeenum.RendererType.Enum* enum_=null}, `C++, "bgfx"`],
+		{q{ubyte}, q{getSupportedRenderers}, q{ubyte max=0, bgfx.fakeenum.RendererType.Enum* enum_=null}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns name of renderer.
 		Params:
 			type = Renderer backend type. See: `bgfx::RendererType`
 		*/
-		[q{const(char)*}, q{getRendererName}, q{bgfx.fakeenum.RendererType.Enum type}, `C++, "bgfx"`],
+		{q{const(char)*}, q{getRendererName}, q{bgfx.fakeenum.RendererType.Enum type}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Initialize the bgfx library.
 		Params:
 			init = Initialization parameters. See: `bgfx::Init` for more info.
 		*/
-		[q{bool}, q{init}, q{ref const Init init}, `C++, "bgfx"`],
+		{q{bool}, q{init}, q{ref const Init init}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Shutdown bgfx library.
 		*/
-		[q{void}, q{shutdown}, q{}, `C++, "bgfx"`],
+		{q{void}, q{shutdown}, q{}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Reset graphic settings and back-buffer size.
@@ -1995,7 +1988,7 @@ mixin(joinFnBinds((){
 		  - `BGFX_RESET_SRGB_BACKBUFFER` - Enable sRGB back-buffer.
 			format = Texture format. See: `TextureFormat::Enum`.
 		*/
-		[q{void}, q{reset}, q{uint width, uint height, uint flags=Reset.none, bgfx.fakeenum.TextureFormat.Enum format=TextureFormat.count}, `C++, "bgfx"`],
+		{q{void}, q{reset}, q{uint width, uint height, uint flags=Reset.none, bgfx.fakeenum.TextureFormat.Enum format=TextureFormat.count}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Advance to next frame. When using multithreaded renderer, this call
@@ -2004,34 +1997,34 @@ mixin(joinFnBinds((){
 		Params:
 			capture = Capture frame with graphics debugger.
 		*/
-		[q{uint}, q{frame}, q{bool capture=false}, `C++, "bgfx"`],
+		{q{uint}, q{frame}, q{bool capture=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns current renderer backend API type.
 		* Remarks:
 		*   Library must be initialized.
 		*/
-		[q{RendererType}, q{getRendererType}, q{}, `C++, "bgfx"`],
+		{q{RendererType}, q{getRendererType}, q{}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns renderer capabilities.
 		* Remarks:
 		*   Library must be initialized.
 		*/
-		[q{const(Caps)*}, q{getCaps}, q{}, `C++, "bgfx"`],
+		{q{const(Caps)*}, q{getCaps}, q{}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns performance counters.
 		* Attention: Pointer returned is valid until `bgfx::frame` is called.
 		*/
-		[q{const(Stats)*}, q{getStats}, q{}, `C++, "bgfx"`],
+		{q{const(Stats)*}, q{getStats}, q{}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Allocate buffer to pass to bgfx calls. Data will be freed inside bgfx.
 		Params:
 			size = Size to allocate.
 		*/
-		[q{const(Memory)*}, q{alloc}, q{uint size}, `C++, "bgfx"`],
+		{q{const(Memory)*}, q{alloc}, q{uint size}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Allocate buffer and copy data into it. Data will be freed inside bgfx.
@@ -2039,7 +2032,7 @@ mixin(joinFnBinds((){
 			data = Pointer to data to be copied.
 			size = Size of data to be copied.
 		*/
-		[q{const(Memory)*}, q{copy}, q{const(void)* data, uint size}, `C++, "bgfx"`],
+		{q{const(Memory)*}, q{copy}, q{const(void)* data, uint size}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Make reference to data to pass to bgfx. Unlike `bgfx::alloc`, this call
@@ -2055,7 +2048,7 @@ mixin(joinFnBinds((){
 			releaseFn = Callback function to release memory after use.
 			userData = User data to be passed to callback function.
 		*/
-		[q{const(Memory)*}, q{makeRef}, q{const(void)* data, uint size, ReleaseFn releaseFn=null, void* userData=null}, `C++, "bgfx"`],
+		{q{const(Memory)*}, q{makeRef}, q{const(void)* data, uint size, ReleaseFn releaseFn=null, void* userData=null}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set debug flags.
@@ -2070,7 +2063,7 @@ mixin(joinFnBinds((){
 		  - `BGFX_DEBUG_WIREFRAME` - Wireframe rendering. All rendering
 		    primitives will be rendered as lines.
 		*/
-		[q{void}, q{setDebug}, q{uint debug_}, `C++, "bgfx"`],
+		{q{void}, q{setDebug}, q{uint debug_}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Clear internal debug text buffer.
@@ -2078,7 +2071,7 @@ mixin(joinFnBinds((){
 			attr = Background color.
 			small = Default 8x16 or 8x8 font.
 		*/
-		[q{void}, q{dbgTextClear}, q{ubyte attr=0, bool small=false}, `C++, "bgfx"`],
+		{q{void}, q{dbgTextClear}, q{ubyte attr=0, bool small=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Print formatted data to internal debug text character-buffer (VGA-compatible text mode).
@@ -2089,7 +2082,7 @@ mixin(joinFnBinds((){
 		4-bits represent foreground color from standard VGA text palette (ANSI escape codes).
 			format = `printf` style format.
 		*/
-		[q{void}, q{dbgTextPrintf}, q{ushort x, ushort y, ubyte attr, const(char)* format, ...}, `C++, "bgfx"`],
+		{q{void}, q{dbgTextPrintf}, q{ushort x, ushort y, ubyte attr, const(char)* format, ...}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Print formatted data from variable argument list to internal debug text character-buffer (VGA-compatible text mode).
@@ -2101,7 +2094,7 @@ mixin(joinFnBinds((){
 			format = `printf` style format.
 			argList = Variable arguments list for format string.
 		*/
-		[q{void}, q{dbgTextPrintfVargs}, q{ushort x, ushort y, ubyte attr, const(char)* format, va_list argList}, `C++, "bgfx"`],
+		{q{void}, q{dbgTextPrintfVargs}, q{ushort x, ushort y, ubyte attr, const(char)* format, va_list argList}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Draw image into internal debug text buffer.
@@ -2113,7 +2106,7 @@ mixin(joinFnBinds((){
 			data = Raw image data (character/attribute raw encoding).
 			pitch = Image pitch in bytes.
 		*/
-		[q{void}, q{dbgTextImage}, q{ushort x, ushort y, ushort width, ushort height, const(void)* data, ushort pitch}, `C++, "bgfx"`],
+		{q{void}, q{dbgTextImage}, q{ushort x, ushort y, ushort width, ushort height, const(void)* data, ushort pitch}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create static index buffer.
@@ -2132,7 +2125,7 @@ mixin(joinFnBinds((){
 		  - `BGFX_BUFFER_INDEX32` - Buffer is using 32-bit indices. This flag has effect only on
 		      index buffers.
 		*/
-		[q{IndexBufferHandle}, q{createIndexBuffer}, q{const(Memory)* mem, ushort flags=Buffer.none}, `C++, "bgfx"`],
+		{q{IndexBufferHandle}, q{createIndexBuffer}, q{const(Memory)* mem, ushort flags=Buffer.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set static index buffer debug name.
@@ -2142,28 +2135,28 @@ mixin(joinFnBinds((){
 			len = Static index buffer name length (if length is INT32_MAX, it's expected
 		that _name is zero terminated string.
 		*/
-		[q{void}, q{setName}, q{IndexBufferHandle handle, const(char)* name, int len=int.max}, `C++, "bgfx"`],
+		{q{void}, q{setName}, q{IndexBufferHandle handle, const(char)* name, int len=int.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy static index buffer.
 		Params:
 			handle = Static index buffer handle.
 		*/
-		[q{void}, q{destroy}, q{IndexBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{IndexBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create vertex layout.
 		Params:
 			layout = Vertex layout.
 		*/
-		[q{VertexLayoutHandle}, q{createVertexLayout}, q{ref const VertexLayout layout}, `C++, "bgfx"`],
+		{q{VertexLayoutHandle}, q{createVertexLayout}, q{ref const VertexLayout layout}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy vertex layout.
 		Params:
 			layoutHandle = Vertex layout handle.
 		*/
-		[q{void}, q{destroy}, q{VertexLayoutHandle layoutHandle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{VertexLayoutHandle layoutHandle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create static vertex buffer.
@@ -2181,7 +2174,7 @@ mixin(joinFnBinds((){
 		     will be trimmed to fit the existing buffer size. This flag has effect only on dynamic buffers.
 		 - `BGFX_BUFFER_INDEX32` - Buffer is using 32-bit indices. This flag has effect only on index buffers.
 		*/
-		[q{VertexBufferHandle}, q{createVertexBuffer}, q{const(Memory)* mem, ref const VertexLayout layout, ushort flags=Buffer.none}, `C++, "bgfx"`],
+		{q{VertexBufferHandle}, q{createVertexBuffer}, q{const(Memory)* mem, ref const VertexLayout layout, ushort flags=Buffer.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set static vertex buffer debug name.
@@ -2191,14 +2184,14 @@ mixin(joinFnBinds((){
 			len = Static vertex buffer name length (if length is INT32_MAX, it's expected
 		that _name is zero terminated string.
 		*/
-		[q{void}, q{setName}, q{VertexBufferHandle handle, const(char)* name, int len=int.max}, `C++, "bgfx"`],
+		{q{void}, q{setName}, q{VertexBufferHandle handle, const(char)* name, int len=int.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy static vertex buffer.
 		Params:
 			handle = Static vertex buffer handle.
 		*/
-		[q{void}, q{destroy}, q{VertexBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{VertexBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create empty dynamic index buffer.
@@ -2217,7 +2210,7 @@ mixin(joinFnBinds((){
 		  - `BGFX_BUFFER_INDEX32` - Buffer is using 32-bit indices. This flag has effect only on
 		      index buffers.
 		*/
-		[q{DynamicIndexBufferHandle}, q{createDynamicIndexBuffer}, q{uint num, ushort flags=Buffer.none}, `C++, "bgfx"`],
+		{q{DynamicIndexBufferHandle}, q{createDynamicIndexBuffer}, q{uint num, ushort flags=Buffer.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create a dynamic index buffer and initialize it.
@@ -2236,7 +2229,7 @@ mixin(joinFnBinds((){
 		  - `BGFX_BUFFER_INDEX32` - Buffer is using 32-bit indices. This flag has effect only on
 		      index buffers.
 		*/
-		[q{DynamicIndexBufferHandle}, q{createDynamicIndexBuffer}, q{const(Memory)* mem, ushort flags=Buffer.none}, `C++, "bgfx"`],
+		{q{DynamicIndexBufferHandle}, q{createDynamicIndexBuffer}, q{const(Memory)* mem, ushort flags=Buffer.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Update dynamic index buffer.
@@ -2245,14 +2238,14 @@ mixin(joinFnBinds((){
 			startIndex = Start index.
 			mem = Index buffer data.
 		*/
-		[q{void}, q{update}, q{DynamicIndexBufferHandle handle, uint startIndex, const(Memory)* mem}, `C++, "bgfx"`],
+		{q{void}, q{update}, q{DynamicIndexBufferHandle handle, uint startIndex, const(Memory)* mem}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy dynamic index buffer.
 		Params:
 			handle = Dynamic index buffer handle.
 		*/
-		[q{void}, q{destroy}, q{DynamicIndexBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{DynamicIndexBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create empty dynamic vertex buffer.
@@ -2272,7 +2265,7 @@ mixin(joinFnBinds((){
 		  - `BGFX_BUFFER_INDEX32` - Buffer is using 32-bit indices. This flag has effect only on
 		      index buffers.
 		*/
-		[q{DynamicVertexBufferHandle}, q{createDynamicVertexBuffer}, q{uint num, ref const VertexLayout layout, ushort flags=Buffer.none}, `C++, "bgfx"`],
+		{q{DynamicVertexBufferHandle}, q{createDynamicVertexBuffer}, q{uint num, ref const VertexLayout layout, ushort flags=Buffer.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create dynamic vertex buffer and initialize it.
@@ -2292,7 +2285,7 @@ mixin(joinFnBinds((){
 		  - `BGFX_BUFFER_INDEX32` - Buffer is using 32-bit indices. This flag has effect only on
 		      index buffers.
 		*/
-		[q{DynamicVertexBufferHandle}, q{createDynamicVertexBuffer}, q{const(Memory)* mem, ref const VertexLayout layout, ushort flags=Buffer.none}, `C++, "bgfx"`],
+		{q{DynamicVertexBufferHandle}, q{createDynamicVertexBuffer}, q{const(Memory)* mem, ref const VertexLayout layout, ushort flags=Buffer.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Update dynamic vertex buffer.
@@ -2301,14 +2294,14 @@ mixin(joinFnBinds((){
 			startVertex = Start vertex.
 			mem = Vertex buffer data.
 		*/
-		[q{void}, q{update}, q{DynamicVertexBufferHandle handle, uint startVertex, const(Memory)* mem}, `C++, "bgfx"`],
+		{q{void}, q{update}, q{DynamicVertexBufferHandle handle, uint startVertex, const(Memory)* mem}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy dynamic vertex buffer.
 		Params:
 			handle = Dynamic vertex buffer handle.
 		*/
-		[q{void}, q{destroy}, q{DynamicVertexBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{DynamicVertexBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns number of requested or maximum available indices.
@@ -2316,7 +2309,7 @@ mixin(joinFnBinds((){
 			num = Number of required indices.
 			index32 = Set to `true` if input indices will be 32-bit.
 		*/
-		[q{uint}, q{getAvailTransientIndexBuffer}, q{uint num, bool index32=false}, `C++, "bgfx"`],
+		{q{uint}, q{getAvailTransientIndexBuffer}, q{uint num, bool index32=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns number of requested or maximum available vertices.
@@ -2324,7 +2317,7 @@ mixin(joinFnBinds((){
 			num = Number of required vertices.
 			layout = Vertex layout.
 		*/
-		[q{uint}, q{getAvailTransientVertexBuffer}, q{uint num, ref const VertexLayout layout}, `C++, "bgfx"`],
+		{q{uint}, q{getAvailTransientVertexBuffer}, q{uint num, ref const VertexLayout layout}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns number of requested or maximum available instance buffer slots.
@@ -2332,7 +2325,7 @@ mixin(joinFnBinds((){
 			num = Number of required instances.
 			stride = Stride per instance.
 		*/
-		[q{uint}, q{getAvailInstanceDataBuffer}, q{uint num, ushort stride}, `C++, "bgfx"`],
+		{q{uint}, q{getAvailInstanceDataBuffer}, q{uint num, ushort stride}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Allocate transient index buffer.
@@ -2343,7 +2336,7 @@ mixin(joinFnBinds((){
 			num = Number of indices to allocate.
 			index32 = Set to `true` if input indices will be 32-bit.
 		*/
-		[q{void}, q{allocTransientIndexBuffer}, q{TransientIndexBuffer* tib, uint num, bool index32=false}, `C++, "bgfx"`],
+		{q{void}, q{allocTransientIndexBuffer}, q{TransientIndexBuffer* tib, uint num, bool index32=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Allocate transient vertex buffer.
@@ -2354,7 +2347,7 @@ mixin(joinFnBinds((){
 			num = Number of vertices to allocate.
 			layout = Vertex layout.
 		*/
-		[q{void}, q{allocTransientVertexBuffer}, q{TransientVertexBuffer* tvb, uint num, ref const VertexLayout layout}, `C++, "bgfx"`],
+		{q{void}, q{allocTransientVertexBuffer}, q{TransientVertexBuffer* tvb, uint num, ref const VertexLayout layout}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Check for required space and allocate transient vertex and index
@@ -2372,7 +2365,7 @@ mixin(joinFnBinds((){
 			numIndices = Number of indices to allocate.
 			index32 = Set to `true` if input indices will be 32-bit.
 		*/
-		[q{bool}, q{allocTransientBuffers}, q{TransientVertexBuffer* tvb, ref const VertexLayout layout, uint numVertices, TransientIndexBuffer* tib, uint numIndices, bool index32=false}, `C++, "bgfx"`],
+		{q{bool}, q{allocTransientBuffers}, q{TransientVertexBuffer* tvb, ref const VertexLayout layout, uint numVertices, TransientIndexBuffer* tib, uint numIndices, bool index32=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Allocate instance data buffer.
@@ -2383,28 +2376,28 @@ mixin(joinFnBinds((){
 			num = Number of instances.
 			stride = Instance stride. Must be multiple of 16.
 		*/
-		[q{void}, q{allocInstanceDataBuffer}, q{InstanceDataBuffer* idb, uint num, ushort stride}, `C++, "bgfx"`],
+		{q{void}, q{allocInstanceDataBuffer}, q{InstanceDataBuffer* idb, uint num, ushort stride}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create draw indirect buffer.
 		Params:
 			num = Number of indirect calls.
 		*/
-		[q{IndirectBufferHandle}, q{createIndirectBuffer}, q{uint num}, `C++, "bgfx"`],
+		{q{IndirectBufferHandle}, q{createIndirectBuffer}, q{uint num}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy draw indirect buffer.
 		Params:
 			handle = Indirect buffer handle.
 		*/
-		[q{void}, q{destroy}, q{IndirectBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{IndirectBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create shader from memory buffer.
 		Params:
 			mem = Shader binary.
 		*/
-		[q{ShaderHandle}, q{createShader}, q{const(Memory)* mem}, `C++, "bgfx"`],
+		{q{ShaderHandle}, q{createShader}, q{const(Memory)* mem}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns the number of uniforms and uniform handles used inside a shader.
@@ -2415,7 +2408,7 @@ mixin(joinFnBinds((){
 			uniforms = UniformHandle array where data will be stored.
 			max = Maximum capacity of array.
 		*/
-		[q{ushort}, q{getShaderUniforms}, q{ShaderHandle handle, UniformHandle* uniforms=null, ushort max=0}, `C++, "bgfx"`],
+		{q{ushort}, q{getShaderUniforms}, q{ShaderHandle handle, UniformHandle* uniforms=null, ushort max=0}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set shader debug name.
@@ -2425,7 +2418,7 @@ mixin(joinFnBinds((){
 			len = Shader name length (if length is INT32_MAX, it's expected
 		that _name is zero terminated string).
 		*/
-		[q{void}, q{setName}, q{ShaderHandle handle, const(char)* name, int len=int.max}, `C++, "bgfx"`],
+		{q{void}, q{setName}, q{ShaderHandle handle, const(char)* name, int len=int.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy shader.
@@ -2434,7 +2427,7 @@ mixin(joinFnBinds((){
 		Params:
 			handle = Shader handle.
 		*/
-		[q{void}, q{destroy}, q{ShaderHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{ShaderHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create program with vertex and fragment shaders.
@@ -2443,7 +2436,7 @@ mixin(joinFnBinds((){
 			fsh = Fragment shader.
 			destroyShaders = If true, shaders will be destroyed when program is destroyed.
 		*/
-		[q{ProgramHandle}, q{createProgram}, q{ShaderHandle vsh, ShaderHandle fsh, bool destroyShaders=false}, `C++, "bgfx"`],
+		{q{ProgramHandle}, q{createProgram}, q{ShaderHandle vsh, ShaderHandle fsh, bool destroyShaders=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create program with compute shader.
@@ -2451,14 +2444,14 @@ mixin(joinFnBinds((){
 			csh = Compute shader.
 			destroyShaders = If true, shaders will be destroyed when program is destroyed.
 		*/
-		[q{ProgramHandle}, q{createProgram}, q{ShaderHandle csh, bool destroyShaders=false}, `C++, "bgfx"`],
+		{q{ProgramHandle}, q{createProgram}, q{ShaderHandle csh, bool destroyShaders=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy program.
 		Params:
 			handle = Program handle.
 		*/
-		[q{void}, q{destroy}, q{ProgramHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{ProgramHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Validate texture parameters.
@@ -2469,7 +2462,7 @@ mixin(joinFnBinds((){
 			format = Texture format. See: `TextureFormat::Enum`.
 			flags = Texture flags. See `BGFX_TEXTURE_*`.
 		*/
-		[q{bool}, q{isTextureValid}, q{ushort depth, bool cubeMap, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format, ulong flags}, `C++, "bgfx"`],
+		{q{bool}, q{isTextureValid}, q{ushort depth, bool cubeMap, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 flags}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Validate frame buffer parameters.
@@ -2477,7 +2470,7 @@ mixin(joinFnBinds((){
 			num = Number of attachments.
 			attachment = Attachment texture info. See: `bgfx::Attachment`.
 		*/
-		[q{bool}, q{isFrameBufferValid}, q{ubyte num, const(Attachment)* attachment}, `C++, "bgfx"`],
+		{q{bool}, q{isFrameBufferValid}, q{ubyte num, const(Attachment)* attachment}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Calculate amount of memory required for texture.
@@ -2491,7 +2484,7 @@ mixin(joinFnBinds((){
 			numLayers = Number of layers in texture array.
 			format = Texture format. See: `TextureFormat::Enum`.
 		*/
-		[q{void}, q{calcTextureSize}, q{ref TextureInfo info, ushort width, ushort height, ushort depth, bool cubeMap, bool hasMIPs, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format}, `C++, "bgfx"`],
+		{q{void}, q{calcTextureSize}, q{ref TextureInfo info, ushort width, ushort height, ushort depth, bool cubeMap, bool hasMIPs, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create texture from memory buffer.
@@ -2506,7 +2499,7 @@ mixin(joinFnBinds((){
 			skip = Skip top level mips when parsing texture.
 			info = When non-`NULL` is specified it returns parsed texture information.
 		*/
-		[q{TextureHandle}, q{createTexture}, q{const(Memory)* mem, ulong flags, ubyte skip=0, TextureInfo* info=null}, `C++, "bgfx"`],
+		{q{TextureHandle}, q{createTexture}, q{const(Memory)* mem, c_uint64 flags, ubyte skip=0, TextureInfo* info=null}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create 2D texture.
@@ -2527,7 +2520,7 @@ mixin(joinFnBinds((){
 		`_mem` is NULL content of the texture is uninitialized. When `_numLayers` is more than
 		1, expected memory layout is texture and all mips together for each array element.
 		*/
-		[q{TextureHandle}, q{createTexture2D}, q{ushort width, ushort height, bool hasMIPs, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format, ulong flags, const(Memory)* mem=null}, `C++, "bgfx"`],
+		{q{TextureHandle}, q{createTexture2D}, q{ushort width, ushort height, bool hasMIPs, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 flags, const(Memory)* mem=null}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create texture with size based on back-buffer ratio. Texture will maintain ratio
@@ -2545,7 +2538,7 @@ mixin(joinFnBinds((){
 		- `BGFX_SAMPLER_[MIN/MAG/MIP]_[POINT/ANISOTROPIC]` - Point or anisotropic
 		  sampling.
 		*/
-		[q{TextureHandle}, q{createTexture2D}, q{bgfx.fakeenum.BackbufferRatio.Enum ratio, bool hasMIPs, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format, ulong flags=Texture.none|Sampler.none}, `C++, "bgfx"`],
+		{q{TextureHandle}, q{createTexture2D}, q{bgfx.fakeenum.BackbufferRatio.Enum ratio, bool hasMIPs, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 flags=Texture.none|Sampler.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create 3D texture.
@@ -2565,7 +2558,7 @@ mixin(joinFnBinds((){
 		`_mem` is NULL content of the texture is uninitialized. When `_numLayers` is more than
 		1, expected memory layout is texture and all mips together for each array element.
 		*/
-		[q{TextureHandle}, q{createTexture3D}, q{ushort width, ushort height, ushort depth, bool hasMIPs, bgfx.fakeenum.TextureFormat.Enum format, ulong flags=Texture.none|Sampler.none, const(Memory)* mem=null}, `C++, "bgfx"`],
+		{q{TextureHandle}, q{createTexture3D}, q{ushort width, ushort height, ushort depth, bool hasMIPs, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 flags=Texture.none|Sampler.none, const(Memory)* mem=null}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create Cube texture.
@@ -2585,7 +2578,7 @@ mixin(joinFnBinds((){
 		`_mem` is NULL content of the texture is uninitialized. When `_numLayers` is more than
 		1, expected memory layout is texture and all mips together for each array element.
 		*/
-		[q{TextureHandle}, q{createTextureCube}, q{ushort size, bool hasMIPs, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format, ulong flags=Texture.none|Sampler.none, const(Memory)* mem=null}, `C++, "bgfx"`],
+		{q{TextureHandle}, q{createTextureCube}, q{ushort size, bool hasMIPs, ushort numLayers, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 flags=Texture.none|Sampler.none, const(Memory)* mem=null}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Update 2D texture.
@@ -2602,7 +2595,7 @@ mixin(joinFnBinds((){
 			pitch = Pitch of input image (bytes). When _pitch is set to
 		UINT16_MAX, it will be calculated internally based on _width.
 		*/
-		[q{void}, q{updateTexture2D}, q{TextureHandle handle, ushort layer, ubyte mip, ushort x, ushort y, ushort width, ushort height, const(Memory)* mem, ushort pitch=ushort.max}, `C++, "bgfx"`],
+		{q{void}, q{updateTexture2D}, q{TextureHandle handle, ushort layer, ubyte mip, ushort x, ushort y, ushort width, ushort height, const(Memory)* mem, ushort pitch=ushort.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Update 3D texture.
@@ -2618,7 +2611,7 @@ mixin(joinFnBinds((){
 			depth = Depth of texture block.
 			mem = Texture update data.
 		*/
-		[q{void}, q{updateTexture3D}, q{TextureHandle handle, ubyte mip, ushort x, ushort y, ushort z, ushort width, ushort height, ushort depth, const(Memory)* mem}, `C++, "bgfx"`],
+		{q{void}, q{updateTexture3D}, q{TextureHandle handle, ubyte mip, ushort x, ushort y, ushort z, ushort width, ushort height, ushort depth, const(Memory)* mem}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Update Cube texture.
@@ -2653,7 +2646,7 @@ mixin(joinFnBinds((){
 			pitch = Pitch of input image (bytes). When _pitch is set to
 		UINT16_MAX, it will be calculated internally based on _width.
 		*/
-		[q{void}, q{updateTextureCube}, q{TextureHandle handle, ushort layer, ubyte side, ubyte mip, ushort x, ushort y, ushort width, ushort height, const(Memory)* mem, ushort pitch=ushort.max}, `C++, "bgfx"`],
+		{q{void}, q{updateTextureCube}, q{TextureHandle handle, ushort layer, ubyte side, ubyte mip, ushort x, ushort y, ushort width, ushort height, const(Memory)* mem, ushort pitch=ushort.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Read back texture content.
@@ -2664,7 +2657,7 @@ mixin(joinFnBinds((){
 			data = Destination buffer.
 			mip = Mip level.
 		*/
-		[q{uint}, q{readTexture}, q{TextureHandle handle, void* data, ubyte mip=0}, `C++, "bgfx"`],
+		{q{uint}, q{readTexture}, q{TextureHandle handle, void* data, ubyte mip=0}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set texture debug name.
@@ -2674,7 +2667,7 @@ mixin(joinFnBinds((){
 			len = Texture name length (if length is INT32_MAX, it's expected
 		that _name is zero terminated string.
 		*/
-		[q{void}, q{setName}, q{TextureHandle handle, const(char)* name, int len=int.max}, `C++, "bgfx"`],
+		{q{void}, q{setName}, q{TextureHandle handle, const(char)* name, int len=int.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Returns texture direct access pointer.
@@ -2683,14 +2676,14 @@ mixin(joinFnBinds((){
 		Params:
 			handle = Texture handle.
 		*/
-		[q{void*}, q{getDirectAccessPtr}, q{TextureHandle handle}, `C++, "bgfx"`],
+		{q{void*}, q{getDirectAccessPtr}, q{TextureHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy texture.
 		Params:
 			handle = Texture handle.
 		*/
-		[q{void}, q{destroy}, q{TextureHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{TextureHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create frame buffer (simple).
@@ -2705,7 +2698,7 @@ mixin(joinFnBinds((){
 		- `BGFX_SAMPLER_[MIN/MAG/MIP]_[POINT/ANISOTROPIC]` - Point or anisotropic
 		  sampling.
 		*/
-		[q{FrameBufferHandle}, q{createFrameBuffer}, q{ushort width, ushort height, bgfx.fakeenum.TextureFormat.Enum format, ulong textureFlags=SamplerU.clamp|SamplerV.clamp}, `C++, "bgfx"`],
+		{q{FrameBufferHandle}, q{createFrameBuffer}, q{ushort width, ushort height, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 textureFlags=SamplerU.clamp|SamplerV.clamp}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create frame buffer with size based on back-buffer ratio. Frame buffer will maintain ratio
@@ -2721,7 +2714,7 @@ mixin(joinFnBinds((){
 		- `BGFX_SAMPLER_[MIN/MAG/MIP]_[POINT/ANISOTROPIC]` - Point or anisotropic
 		  sampling.
 		*/
-		[q{FrameBufferHandle}, q{createFrameBuffer}, q{bgfx.fakeenum.BackbufferRatio.Enum ratio, bgfx.fakeenum.TextureFormat.Enum format, ulong textureFlags=SamplerU.clamp|SamplerV.clamp}, `C++, "bgfx"`],
+		{q{FrameBufferHandle}, q{createFrameBuffer}, q{bgfx.fakeenum.BackbufferRatio.Enum ratio, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 textureFlags=SamplerU.clamp|SamplerV.clamp}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create MRT frame buffer from texture handles (simple).
@@ -2731,7 +2724,7 @@ mixin(joinFnBinds((){
 			destroyTexture = If true, textures will be destroyed when
 		frame buffer is destroyed.
 		*/
-		[q{FrameBufferHandle}, q{createFrameBuffer}, q{ubyte num, const(TextureHandle)* handles, bool destroyTexture=false}, `C++, "bgfx"`],
+		{q{FrameBufferHandle}, q{createFrameBuffer}, q{ubyte num, const(TextureHandle)* handles, bool destroyTexture=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create MRT frame buffer from texture handles with specific layer and
@@ -2742,7 +2735,7 @@ mixin(joinFnBinds((){
 			destroyTexture = If true, textures will be destroyed when
 		frame buffer is destroyed.
 		*/
-		[q{FrameBufferHandle}, q{createFrameBuffer}, q{ubyte num, const(Attachment)* attachment, bool destroyTexture=false}, `C++, "bgfx"`],
+		{q{FrameBufferHandle}, q{createFrameBuffer}, q{ubyte num, const(Attachment)* attachment, bool destroyTexture=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create frame buffer for multiple window rendering.
@@ -2756,7 +2749,7 @@ mixin(joinFnBinds((){
 			format = Window back buffer color format.
 			depthFormat = Window back buffer depth format.
 		*/
-		[q{FrameBufferHandle}, q{createFrameBuffer}, q{void* nwh, ushort width, ushort height, bgfx.fakeenum.TextureFormat.Enum format=TextureFormat.count, bgfx.fakeenum.TextureFormat.Enum depthFormat=TextureFormat.count}, `C++, "bgfx"`],
+		{q{FrameBufferHandle}, q{createFrameBuffer}, q{void* nwh, ushort width, ushort height, bgfx.fakeenum.TextureFormat.Enum format=TextureFormat.count, bgfx.fakeenum.TextureFormat.Enum depthFormat=TextureFormat.count}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set frame buffer debug name.
@@ -2766,21 +2759,21 @@ mixin(joinFnBinds((){
 			len = Frame buffer name length (if length is INT32_MAX, it's expected
 		that _name is zero terminated string.
 		*/
-		[q{void}, q{setName}, q{FrameBufferHandle handle, const(char)* name, int len=int.max}, `C++, "bgfx"`],
+		{q{void}, q{setName}, q{FrameBufferHandle handle, const(char)* name, int len=int.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Obtain texture handle of frame buffer attachment.
 		Params:
 			handle = Frame buffer handle.
 		*/
-		[q{TextureHandle}, q{getTexture}, q{FrameBufferHandle handle, ubyte attachment=0}, `C++, "bgfx"`],
+		{q{TextureHandle}, q{getTexture}, q{FrameBufferHandle handle, ubyte attachment=0}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy frame buffer.
 		Params:
 			handle = Frame buffer handle.
 		*/
-		[q{void}, q{destroy}, q{FrameBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{FrameBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create shader uniform parameter.
@@ -2811,7 +2804,7 @@ mixin(joinFnBinds((){
 			type = Type of uniform (See: `bgfx::UniformType`).
 			num = Number of elements in array.
 		*/
-		[q{UniformHandle}, q{createUniform}, q{const(char)* name, bgfx.fakeenum.UniformType.Enum type, ushort num=1}, `C++, "bgfx"`],
+		{q{UniformHandle}, q{createUniform}, q{const(char)* name, bgfx.fakeenum.UniformType.Enum type, ushort num=1}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Retrieve uniform info.
@@ -2819,19 +2812,19 @@ mixin(joinFnBinds((){
 			handle = Handle to uniform object.
 			info = Uniform info.
 		*/
-		[q{void}, q{getUniformInfo}, q{UniformHandle handle, ref UniformInfo info}, `C++, "bgfx"`],
+		{q{void}, q{getUniformInfo}, q{UniformHandle handle, ref UniformInfo info}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy shader uniform parameter.
 		Params:
 			handle = Handle to uniform object.
 		*/
-		[q{void}, q{destroy}, q{UniformHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{UniformHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Create occlusion query.
 		*/
-		[q{OcclusionQueryHandle}, q{createOcclusionQuery}, q{}, `C++, "bgfx"`],
+		{q{OcclusionQueryHandle}, q{createOcclusionQuery}, q{}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Retrieve occlusion query result from previous frame.
@@ -2840,14 +2833,14 @@ mixin(joinFnBinds((){
 			result = Number of pixels that passed test. This argument
 		can be `NULL` if result of occlusion query is not needed.
 		*/
-		[q{OcclusionQueryResult}, q{getResult}, q{OcclusionQueryHandle handle, int* result=null}, `C++, "bgfx"`],
+		{q{OcclusionQueryResult}, q{getResult}, q{OcclusionQueryHandle handle, int* result=null}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Destroy occlusion query.
 		Params:
 			handle = Handle to occlusion query object.
 		*/
-		[q{void}, q{destroy}, q{OcclusionQueryHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{destroy}, q{OcclusionQueryHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set palette color value.
@@ -2855,7 +2848,7 @@ mixin(joinFnBinds((){
 			index = Index into palette.
 			rgba = RGBA floating point values.
 		*/
-		[q{void}, q{setPaletteColor}, q{ubyte index, const(float)* rgba}, `C++, "bgfx"`],
+		{q{void}, q{setPaletteColor}, q{ubyte index, const(float)* rgba}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set palette color value.
@@ -2863,7 +2856,7 @@ mixin(joinFnBinds((){
 			index = Index into palette.
 			rgba = Packed 32-bit RGBA value.
 		*/
-		[q{void}, q{setPaletteColor}, q{ubyte index, uint rgba}, `C++, "bgfx"`],
+		{q{void}, q{setPaletteColor}, q{ubyte index, uint rgba}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view name.
@@ -2878,7 +2871,7 @@ mixin(joinFnBinds((){
 			id = View id.
 			name = View name.
 		*/
-		[q{void}, q{setViewName}, q{ViewID id, const(char)* name}, `C++, "bgfx"`],
+		{q{void}, q{setViewName}, q{ViewID id, const(char)* name}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view rectangle. Draw primitive outside view will be clipped.
@@ -2889,7 +2882,7 @@ mixin(joinFnBinds((){
 			width = Width of view port region.
 			height = Height of view port region.
 		*/
-		[q{void}, q{setViewRect}, q{ViewID id, ushort x, ushort y, ushort width, ushort height}, `C++, "bgfx"`],
+		{q{void}, q{setViewRect}, q{ViewID id, ushort x, ushort y, ushort width, ushort height}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view rectangle. Draw primitive outside view will be clipped.
@@ -2900,7 +2893,7 @@ mixin(joinFnBinds((){
 			ratio = Width and height will be set in respect to back-buffer size.
 		See: `BackbufferRatio::Enum`.
 		*/
-		[q{void}, q{setViewRect}, q{ViewID id, ushort x, ushort y, bgfx.fakeenum.BackbufferRatio.Enum ratio}, `C++, "bgfx"`],
+		{q{void}, q{setViewRect}, q{ViewID id, ushort x, ushort y, bgfx.fakeenum.BackbufferRatio.Enum ratio}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view scissor. Draw primitive outside view will be clipped. When
@@ -2912,7 +2905,7 @@ mixin(joinFnBinds((){
 			width = Width of view scissor region.
 			height = Height of view scissor region.
 		*/
-		[q{void}, q{setViewScissor}, q{ViewID id, ushort x=0, ushort y=0, ushort width=0, ushort height=0}, `C++, "bgfx"`],
+		{q{void}, q{setViewScissor}, q{ViewID id, ushort x=0, ushort y=0, ushort width=0, ushort height=0}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view clear flags.
@@ -2924,7 +2917,7 @@ mixin(joinFnBinds((){
 			depth = Depth clear value.
 			stencil = Stencil clear value.
 		*/
-		[q{void}, q{setViewClear}, q{ViewID id, ushort flags, uint rgba=0x000000ff, float depth=1.0f, ubyte stencil=0}, `C++, "bgfx"`],
+		{q{void}, q{setViewClear}, q{ViewID id, ushort flags, uint rgba=0x000000ff, float depth=1.0f, ubyte stencil=0}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view clear flags with different clear color for each
@@ -2945,7 +2938,7 @@ mixin(joinFnBinds((){
 			c6 = Palette index for frame buffer attachment 6.
 			c7 = Palette index for frame buffer attachment 7.
 		*/
-		[q{void}, q{setViewClear}, q{ViewID id, ushort flags, float depth, ubyte stencil, ubyte c0=ubyte.max, ubyte c1=ubyte.max, ubyte c2=ubyte.max, ubyte c3=ubyte.max, ubyte c4=ubyte.max, ubyte c5=ubyte.max, ubyte c6=ubyte.max, ubyte c7=ubyte.max}, `C++, "bgfx"`],
+		{q{void}, q{setViewClear}, q{ViewID id, ushort flags, float depth, ubyte stencil, ubyte c0=ubyte.max, ubyte c1=ubyte.max, ubyte c2=ubyte.max, ubyte c3=ubyte.max, ubyte c4=ubyte.max, ubyte c5=ubyte.max, ubyte c6=ubyte.max, ubyte c7=ubyte.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view sorting mode.
@@ -2955,7 +2948,7 @@ mixin(joinFnBinds((){
 			id = View id.
 			mode = View sort mode. See `ViewMode::Enum`.
 		*/
-		[q{void}, q{setViewMode}, q{ViewID id, bgfx.fakeenum.ViewMode.Enum mode=ViewMode.default_}, `C++, "bgfx"`],
+		{q{void}, q{setViewMode}, q{ViewID id, bgfx.fakeenum.ViewMode.Enum mode=ViewMode.default_}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view frame buffer.
@@ -2967,7 +2960,7 @@ mixin(joinFnBinds((){
 		frame buffer handle will draw primitives from this view into
 		default back buffer.
 		*/
-		[q{void}, q{setViewFrameBuffer}, q{ViewID id, FrameBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{setViewFrameBuffer}, q{ViewID id, FrameBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set view's view matrix and projection matrix,
@@ -2977,7 +2970,7 @@ mixin(joinFnBinds((){
 			view = View matrix.
 			proj = Projection matrix.
 		*/
-		[q{void}, q{setViewTransform}, q{ViewID id, const(void)* view, const(void)* proj}, `C++, "bgfx"`],
+		{q{void}, q{setViewTransform}, q{ViewID id, const(void)* view, const(void)* proj}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Post submit view reordering.
@@ -2987,26 +2980,26 @@ mixin(joinFnBinds((){
 			order = View remap id table. Passing `NULL` will reset view ids
 		to default state.
 		*/
-		[q{void}, q{setViewOrder}, q{ViewID id=0, ushort num=ushort.max, const(ViewID)* order=null}, `C++, "bgfx"`],
+		{q{void}, q{setViewOrder}, q{ViewID id=0, ushort num=ushort.max, const(ViewID)* order=null}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Reset all view settings to default.
 		*/
-		[q{void}, q{resetView}, q{ViewID id}, `C++, "bgfx"`],
+		{q{void}, q{resetView}, q{ViewID id}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Begin submitting draw calls from thread.
 		Params:
 			forThread = Explicitly request an encoder for a worker thread.
 		*/
-		[q{Encoder*}, q{begin}, q{bool forThread=false}, `C++, "bgfx"`],
+		{q{Encoder*}, q{begin}, q{bool forThread=false}, ext: `C++, "bgfx"`},
 		
 		/**
 		* End submitting draw calls from thread.
 		Params:
 			encoder = Encoder.
 		*/
-		[q{void}, q{end}, q{Encoder* encoder}, `C++, "bgfx"`],
+		{q{void}, q{end}, q{Encoder* encoder}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Request screen shot of window back buffer.
@@ -3018,7 +3011,7 @@ mixin(joinFnBinds((){
 		made for main window back buffer.
 			filePath = Will be passed to `bgfx::CallbackI::screenShot` callback.
 		*/
-		[q{void}, q{requestScreenShot}, q{FrameBufferHandle handle, const(char)* filePath}, `C++, "bgfx"`],
+		{q{void}, q{requestScreenShot}, q{FrameBufferHandle handle, const(char)* filePath}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Render frame.
@@ -3032,7 +3025,7 @@ mixin(joinFnBinds((){
 		Params:
 			msecs = Timeout in milliseconds.
 		*/
-		[q{RenderFrame}, q{renderFrame}, q{int msecs=-1}, `C++, "bgfx"`],
+		{q{RenderFrame}, q{renderFrame}, q{int msecs=-1}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set platform data.
@@ -3040,7 +3033,7 @@ mixin(joinFnBinds((){
 		Params:
 			data = Platform data.
 		*/
-		[q{void}, q{setPlatformData}, q{ref const PlatformData data}, `C++, "bgfx"`],
+		{q{void}, q{setPlatformData}, q{ref const PlatformData data}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Get internal data for interop.
@@ -3048,7 +3041,7 @@ mixin(joinFnBinds((){
 		*   use this call.
 		* Warning: Must be called only on render thread.
 		*/
-		[q{const(InternalData)*}, q{getInternalData}, q{}, `C++, "bgfx"`],
+		{q{const(InternalData)*}, q{getInternalData}, q{}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Override internal texture with externally created texture. Previously
@@ -3060,7 +3053,7 @@ mixin(joinFnBinds((){
 			handle = Texture handle.
 			ptr = Native API pointer to texture.
 		*/
-		[q{size_t}, q{overrideInternal}, q{TextureHandle handle, size_t ptr}, `C++, "bgfx"`],
+		{q{size_t}, q{overrideInternal}, q{TextureHandle handle, size_t ptr}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Override internal texture by creating new texture. Previously created
@@ -3083,7 +3076,7 @@ mixin(joinFnBinds((){
 		- `BGFX_SAMPLER_[MIN/MAG/MIP]_[POINT/ANISOTROPIC]` - Point or anisotropic
 		  sampling.
 		*/
-		[q{size_t}, q{overrideInternal}, q{TextureHandle handle, ushort width, ushort height, ubyte numMIPs, bgfx.fakeenum.TextureFormat.Enum format, ulong flags}, `C++, "bgfx"`],
+		{q{size_t}, q{overrideInternal}, q{TextureHandle handle, ushort width, ushort height, ubyte numMIPs, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 flags}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Sets a debug marker. This allows you to group graphics calls together for easy browsing in
@@ -3091,7 +3084,7 @@ mixin(joinFnBinds((){
 		Params:
 			marker = Marker string.
 		*/
-		[q{void}, q{setMarker}, q{const(char)* marker}, `C++, "bgfx"`],
+		{q{void}, q{setMarker}, q{const(char)* marker}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set render states for draw primitive.
@@ -3118,7 +3111,7 @@ mixin(joinFnBinds((){
 			rgba = Sets blend factor used by `BGFX_STATE_BLEND_FACTOR` and
 		  `BGFX_STATE_BLEND_INV_FACTOR` blend modes.
 		*/
-		[q{void}, q{setState}, q{ulong state, uint rgba=0}, `C++, "bgfx"`],
+		{q{void}, q{setState}, q{c_uint64 state, uint rgba=0}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set condition for rendering.
@@ -3126,16 +3119,16 @@ mixin(joinFnBinds((){
 			handle = Occlusion query handle.
 			visible = Render if occlusion query is visible.
 		*/
-		[q{void}, q{setCondition}, q{OcclusionQueryHandle handle, bool visible}, `C++, "bgfx"`],
+		{q{void}, q{setCondition}, q{OcclusionQueryHandle handle, bool visible}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set stencil test state.
 		Params:
-			fstencil = Front stencil state.
-			bstencil = Back stencil state. If back is set to `BGFX_STENCIL_NONE`
+			fStencil = Front stencil state.
+			bStencil = Back stencil state. If back is set to `BGFX_STENCIL_NONE`
 		_fstencil is applied to both front and back facing primitives.
 		*/
-		[q{void}, q{setStencil}, q{uint fstencil, uint bstencil=Stencil.none}, `C++, "bgfx"`],
+		{q{void}, q{setStencil}, q{uint fStencil, uint bStencil=Stencil.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set scissor for draw primitive.
@@ -3147,7 +3140,7 @@ mixin(joinFnBinds((){
 			width = Width of view scissor region.
 			height = Height of view scissor region.
 		*/
-		[q{ushort}, q{setScissor}, q{ushort x, ushort y, ushort width, ushort height}, `C++, "bgfx"`],
+		{q{ushort}, q{setScissor}, q{ushort x, ushort y, ushort width, ushort height}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set scissor from cache for draw primitive.
@@ -3156,7 +3149,7 @@ mixin(joinFnBinds((){
 		Params:
 			cache = Index in scissor cache.
 		*/
-		[q{void}, q{setScissor}, q{ushort cache=ushort.max}, `C++, "bgfx"`],
+		{q{void}, q{setScissor}, q{ushort cache=ushort.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set model matrix for draw primitive. If it is not called,
@@ -3165,7 +3158,7 @@ mixin(joinFnBinds((){
 			mtx = Pointer to first matrix in array.
 			num = Number of matrices in array.
 		*/
-		[q{uint}, q{setTransform}, q{const(void)* mtx, ushort num}, `C++, "bgfx"`],
+		{q{uint}, q{setTransform}, q{const(void)* mtx, ushort num}, ext: `C++, "bgfx"`},
 		
 		/**
 		*  Set model matrix from matrix cache for draw primitive.
@@ -3173,7 +3166,7 @@ mixin(joinFnBinds((){
 			cache = Index in matrix cache.
 			num = Number of matrices from cache.
 		*/
-		[q{void}, q{setTransform}, q{uint cache, ushort num=1}, `C++, "bgfx"`],
+		{q{void}, q{setTransform}, q{uint cache, ushort num=1}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Reserve matrices in internal matrix cache.
@@ -3182,7 +3175,7 @@ mixin(joinFnBinds((){
 			transform = Pointer to `Transform` structure.
 			num = Number of matrices.
 		*/
-		[q{uint}, q{allocTransform}, q{Transform* transform, ushort num}, `C++, "bgfx"`],
+		{q{uint}, q{allocTransform}, q{Transform* transform, ushort num}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set shader uniform parameter for draw primitive.
@@ -3192,14 +3185,14 @@ mixin(joinFnBinds((){
 			num = Number of elements. Passing `UINT16_MAX` will
 		use the _num passed on uniform creation.
 		*/
-		[q{void}, q{setUniform}, q{UniformHandle handle, const(void)* value, ushort num=1}, `C++, "bgfx"`],
+		{q{void}, q{setUniform}, q{UniformHandle handle, const(void)* value, ushort num=1}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set index buffer for draw primitive.
 		Params:
 			handle = Index buffer.
 		*/
-		[q{void}, q{setIndexBuffer}, q{IndexBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{setIndexBuffer}, q{IndexBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set index buffer for draw primitive.
@@ -3208,14 +3201,14 @@ mixin(joinFnBinds((){
 			firstIndex = First index to render.
 			numIndices = Number of indices to render.
 		*/
-		[q{void}, q{setIndexBuffer}, q{IndexBufferHandle handle, uint firstIndex, uint numIndices}, `C++, "bgfx"`],
+		{q{void}, q{setIndexBuffer}, q{IndexBufferHandle handle, uint firstIndex, uint numIndices}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set index buffer for draw primitive.
 		Params:
 			handle = Dynamic index buffer.
 		*/
-		[q{void}, q{setIndexBuffer}, q{DynamicIndexBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{setIndexBuffer}, q{DynamicIndexBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set index buffer for draw primitive.
@@ -3224,14 +3217,14 @@ mixin(joinFnBinds((){
 			firstIndex = First index to render.
 			numIndices = Number of indices to render.
 		*/
-		[q{void}, q{setIndexBuffer}, q{DynamicIndexBufferHandle handle, uint firstIndex, uint numIndices}, `C++, "bgfx"`],
+		{q{void}, q{setIndexBuffer}, q{DynamicIndexBufferHandle handle, uint firstIndex, uint numIndices}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set index buffer for draw primitive.
 		Params:
 			tib = Transient index buffer.
 		*/
-		[q{void}, q{setIndexBuffer}, q{const(TransientIndexBuffer)* tib}, `C++, "bgfx"`],
+		{q{void}, q{setIndexBuffer}, q{const(TransientIndexBuffer)* tib}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set index buffer for draw primitive.
@@ -3240,7 +3233,7 @@ mixin(joinFnBinds((){
 			firstIndex = First index to render.
 			numIndices = Number of indices to render.
 		*/
-		[q{void}, q{setIndexBuffer}, q{const(TransientIndexBuffer)* tib, uint firstIndex, uint numIndices}, `C++, "bgfx"`],
+		{q{void}, q{setIndexBuffer}, q{const(TransientIndexBuffer)* tib, uint firstIndex, uint numIndices}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set vertex buffer for draw primitive.
@@ -3248,7 +3241,7 @@ mixin(joinFnBinds((){
 			stream = Vertex stream.
 			handle = Vertex buffer.
 		*/
-		[q{void}, q{setVertexBuffer}, q{ubyte stream, VertexBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{setVertexBuffer}, q{ubyte stream, VertexBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set vertex buffer for draw primitive.
@@ -3261,7 +3254,7 @@ mixin(joinFnBinds((){
 		handle is used, vertex layout used for creation
 		of vertex buffer will be used.
 		*/
-		[q{void}, q{setVertexBuffer}, q{ubyte stream, VertexBufferHandle handle, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, `C++, "bgfx"`],
+		{q{void}, q{setVertexBuffer}, q{ubyte stream, VertexBufferHandle handle, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set vertex buffer for draw primitive.
@@ -3269,7 +3262,7 @@ mixin(joinFnBinds((){
 			stream = Vertex stream.
 			handle = Dynamic vertex buffer.
 		*/
-		[q{void}, q{setVertexBuffer}, q{ubyte stream, DynamicVertexBufferHandle handle}, `C++, "bgfx"`],
+		{q{void}, q{setVertexBuffer}, q{ubyte stream, DynamicVertexBufferHandle handle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set vertex buffer for draw primitive.
@@ -3282,7 +3275,7 @@ mixin(joinFnBinds((){
 		handle is used, vertex layout used for creation
 		of vertex buffer will be used.
 		*/
-		[q{void}, q{setVertexBuffer}, q{ubyte stream, DynamicVertexBufferHandle handle, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, `C++, "bgfx"`],
+		{q{void}, q{setVertexBuffer}, q{ubyte stream, DynamicVertexBufferHandle handle, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set vertex buffer for draw primitive.
@@ -3290,7 +3283,7 @@ mixin(joinFnBinds((){
 			stream = Vertex stream.
 			tvb = Transient vertex buffer.
 		*/
-		[q{void}, q{setVertexBuffer}, q{ubyte stream, const(TransientVertexBuffer)* tvb}, `C++, "bgfx"`],
+		{q{void}, q{setVertexBuffer}, q{ubyte stream, const(TransientVertexBuffer)* tvb}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set vertex buffer for draw primitive.
@@ -3303,7 +3296,7 @@ mixin(joinFnBinds((){
 		handle is used, vertex layout used for creation
 		of vertex buffer will be used.
 		*/
-		[q{void}, q{setVertexBuffer}, q{ubyte stream, const(TransientVertexBuffer)* tvb, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, `C++, "bgfx"`],
+		{q{void}, q{setVertexBuffer}, q{ubyte stream, const(TransientVertexBuffer)* tvb, uint startVertex, uint numVertices, VertexLayoutHandle layoutHandle=invalidHandle!VertexLayoutHandle}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set number of vertices for auto generated vertices use in conjunction
@@ -3312,14 +3305,14 @@ mixin(joinFnBinds((){
 		Params:
 			numVertices = Number of vertices.
 		*/
-		[q{void}, q{setVertexCount}, q{uint numVertices}, `C++, "bgfx"`],
+		{q{void}, q{setVertexCount}, q{uint numVertices}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set instance data buffer for draw primitive.
 		Params:
 			idb = Transient instance data buffer.
 		*/
-		[q{void}, q{setInstanceDataBuffer}, q{const(InstanceDataBuffer)* idb}, `C++, "bgfx"`],
+		{q{void}, q{setInstanceDataBuffer}, q{const(InstanceDataBuffer)* idb}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set instance data buffer for draw primitive.
@@ -3328,7 +3321,7 @@ mixin(joinFnBinds((){
 			start = First instance data.
 			num = Number of data instances.
 		*/
-		[q{void}, q{setInstanceDataBuffer}, q{const(InstanceDataBuffer)* idb, uint start, uint num}, `C++, "bgfx"`],
+		{q{void}, q{setInstanceDataBuffer}, q{const(InstanceDataBuffer)* idb, uint start, uint num}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set instance data buffer for draw primitive.
@@ -3337,7 +3330,7 @@ mixin(joinFnBinds((){
 			startVertex = First instance data.
 			num = Number of data instances.
 		*/
-		[q{void}, q{setInstanceDataBuffer}, q{VertexBufferHandle handle, uint startVertex, uint num}, `C++, "bgfx"`],
+		{q{void}, q{setInstanceDataBuffer}, q{VertexBufferHandle handle, uint startVertex, uint num}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set instance data buffer for draw primitive.
@@ -3346,14 +3339,14 @@ mixin(joinFnBinds((){
 			startVertex = First instance data.
 			num = Number of data instances.
 		*/
-		[q{void}, q{setInstanceDataBuffer}, q{DynamicVertexBufferHandle handle, uint startVertex, uint num}, `C++, "bgfx"`],
+		{q{void}, q{setInstanceDataBuffer}, q{DynamicVertexBufferHandle handle, uint startVertex, uint num}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set number of instances for auto generated instances use in conjunction
 		* with gl_InstanceID.
 		* Attention: Availability depends on: `BGFX_CAPS_VERTEX_ID`.
 		*/
-		[q{void}, q{setInstanceCount}, q{uint numInstances}, `C++, "bgfx"`],
+		{q{void}, q{setInstanceCount}, q{uint numInstances}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set texture stage for draw primitive.
@@ -3368,7 +3361,7 @@ mixin(joinFnBinds((){
 		  - `BGFX_SAMPLER_[MIN/MAG/MIP]_[POINT/ANISOTROPIC]` - Point or anisotropic
 		    sampling.
 		*/
-		[q{void}, q{setTexture}, q{ubyte stage, UniformHandle sampler, TextureHandle handle, uint flags=uint.max}, `C++, "bgfx"`],
+		{q{void}, q{setTexture}, q{ubyte stage, UniformHandle sampler, TextureHandle handle, uint flags=uint.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Submit an empty primitive for rendering. Uniforms and draw state
@@ -3378,7 +3371,7 @@ mixin(joinFnBinds((){
 		Params:
 			id = View id.
 		*/
-		[q{void}, q{touch}, q{ViewID id}, `C++, "bgfx"`],
+		{q{void}, q{touch}, q{ViewID id}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Submit primitive for rendering.
@@ -3388,7 +3381,7 @@ mixin(joinFnBinds((){
 			depth = Depth for sorting.
 			flags = Which states to discard for next draw. See `BGFX_DISCARD_*`.
 		*/
-		[q{void}, q{submit}, q{ViewID id, ProgramHandle program, uint depth=0, ubyte flags=Discard.all}, `C++, "bgfx"`],
+		{q{void}, q{submit}, q{ViewID id, ProgramHandle program, uint depth=0, ubyte flags=Discard.all}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Submit primitive with occlusion query for rendering.
@@ -3399,7 +3392,7 @@ mixin(joinFnBinds((){
 			depth = Depth for sorting.
 			flags = Which states to discard for next draw. See `BGFX_DISCARD_*`.
 		*/
-		[q{void}, q{submit}, q{ViewID id, ProgramHandle program, OcclusionQueryHandle occlusionQuery, uint depth=0, ubyte flags=Discard.all}, `C++, "bgfx"`],
+		{q{void}, q{submit}, q{ViewID id, ProgramHandle program, OcclusionQueryHandle occlusionQuery, uint depth=0, ubyte flags=Discard.all}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Submit primitive for rendering with index and instance data info from
@@ -3414,7 +3407,7 @@ mixin(joinFnBinds((){
 			depth = Depth for sorting.
 			flags = Which states to discard for next draw. See `BGFX_DISCARD_*`.
 		*/
-		[q{void}, q{submit}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start=0, ushort num=1, uint depth=0, ubyte flags=Discard.all}, `C++, "bgfx"`],
+		{q{void}, q{submit}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start=0, ushort num=1, uint depth=0, ubyte flags=Discard.all}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Submit primitive for rendering with index and instance data info and
@@ -3432,7 +3425,7 @@ mixin(joinFnBinds((){
 			depth = Depth for sorting.
 			flags = Which states to discard for next draw. See `BGFX_DISCARD_*`.
 		*/
-		[q{void}, q{submit}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start, IndexBufferHandle numHandle, uint numIndex=0, ushort numMax=ushort.max, uint depth=0, ubyte flags=Discard.all}, `C++, "bgfx"`],
+		{q{void}, q{submit}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start, IndexBufferHandle numHandle, uint numIndex=0, ushort numMax=ushort.max, uint depth=0, ubyte flags=Discard.all}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set compute index buffer.
@@ -3441,7 +3434,7 @@ mixin(joinFnBinds((){
 			handle = Index buffer handle.
 			access = Buffer access. See `Access::Enum`.
 		*/
-		[q{void}, q{setBuffer}, q{ubyte stage, IndexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++, "bgfx"`],
+		{q{void}, q{setBuffer}, q{ubyte stage, IndexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set compute vertex buffer.
@@ -3450,7 +3443,7 @@ mixin(joinFnBinds((){
 			handle = Vertex buffer handle.
 			access = Buffer access. See `Access::Enum`.
 		*/
-		[q{void}, q{setBuffer}, q{ubyte stage, VertexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++, "bgfx"`],
+		{q{void}, q{setBuffer}, q{ubyte stage, VertexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set compute dynamic index buffer.
@@ -3459,7 +3452,7 @@ mixin(joinFnBinds((){
 			handle = Dynamic index buffer handle.
 			access = Buffer access. See `Access::Enum`.
 		*/
-		[q{void}, q{setBuffer}, q{ubyte stage, DynamicIndexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++, "bgfx"`],
+		{q{void}, q{setBuffer}, q{ubyte stage, DynamicIndexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set compute dynamic vertex buffer.
@@ -3468,7 +3461,7 @@ mixin(joinFnBinds((){
 			handle = Dynamic vertex buffer handle.
 			access = Buffer access. See `Access::Enum`.
 		*/
-		[q{void}, q{setBuffer}, q{ubyte stage, DynamicVertexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++, "bgfx"`],
+		{q{void}, q{setBuffer}, q{ubyte stage, DynamicVertexBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set compute indirect buffer.
@@ -3477,7 +3470,7 @@ mixin(joinFnBinds((){
 			handle = Indirect buffer handle.
 			access = Buffer access. See `Access::Enum`.
 		*/
-		[q{void}, q{setBuffer}, q{ubyte stage, IndirectBufferHandle handle, bgfx.fakeenum.Access.Enum access}, `C++, "bgfx"`],
+		{q{void}, q{setBuffer}, q{ubyte stage, IndirectBufferHandle handle, bgfx.fakeenum.Access.Enum access}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Set compute image from texture.
@@ -3488,7 +3481,7 @@ mixin(joinFnBinds((){
 			access = Image access. See `Access::Enum`.
 			format = Texture format. See: `TextureFormat::Enum`.
 		*/
-		[q{void}, q{setImage}, q{ubyte stage, TextureHandle handle, ubyte mip, bgfx.fakeenum.Access.Enum access, bgfx.fakeenum.TextureFormat.Enum format=TextureFormat.count}, `C++, "bgfx"`],
+		{q{void}, q{setImage}, q{ubyte stage, TextureHandle handle, ubyte mip, bgfx.fakeenum.Access.Enum access, bgfx.fakeenum.TextureFormat.Enum format=TextureFormat.count}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Dispatch compute.
@@ -3500,7 +3493,7 @@ mixin(joinFnBinds((){
 			numZ = Number of groups Z.
 			flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 		*/
-		[q{void}, q{dispatch}, q{ViewID id, ProgramHandle program, uint numX=1, uint numY=1, uint numZ=1, ubyte flags=Discard.all}, `C++, "bgfx"`],
+		{q{void}, q{dispatch}, q{ViewID id, ProgramHandle program, uint numX=1, uint numY=1, uint numZ=1, ubyte flags=Discard.all}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Dispatch compute indirect.
@@ -3512,14 +3505,14 @@ mixin(joinFnBinds((){
 			num = Number of dispatches.
 			flags = Discard or preserve states. See `BGFX_DISCARD_*`.
 		*/
-		[q{void}, q{dispatch}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start=0, ushort num=1, ubyte flags=Discard.all}, `C++, "bgfx"`],
+		{q{void}, q{dispatch}, q{ViewID id, ProgramHandle program, IndirectBufferHandle indirectHandle, ushort start=0, ushort num=1, ubyte flags=Discard.all}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Discard previously set state for draw or compute call.
 		Params:
 			flags = Draw/compute states to discard.
 		*/
-		[q{void}, q{discard}, q{ubyte flags=Discard.all}, `C++, "bgfx"`],
+		{q{void}, q{discard}, q{ubyte flags=Discard.all}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Blit 2D texture region between two 2D textures.
@@ -3536,7 +3529,7 @@ mixin(joinFnBinds((){
 			width = Width of region.
 			height = Height of region.
 		*/
-		[q{void}, q{blit}, q{ViewID id, TextureHandle dst, ushort dstX, ushort dstY, TextureHandle src, ushort srcX=0, ushort srcY=0, ushort width=ushort.max, ushort height=ushort.max}, `C++, "bgfx"`],
+		{q{void}, q{blit}, q{ViewID id, TextureHandle dst, ushort dstX, ushort dstY, TextureHandle src, ushort srcX=0, ushort srcY=0, ushort width=ushort.max, ushort height=ushort.max}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Blit 2D texture region between two 2D textures.
@@ -3563,11 +3556,11 @@ mixin(joinFnBinds((){
 			depth = If texture is 3D this argument represents depth of region, otherwise it's
 		unused.
 		*/
-		[q{void}, q{blit}, q{ViewID id, TextureHandle dst, ubyte dstMIP, ushort dstX, ushort dstY, ushort dstZ, TextureHandle src, ubyte srcMIP=0, ushort srcX=0, ushort srcY=0, ushort srcZ=0, ushort width=ushort.max, ushort height=ushort.max, ushort depth=ushort.max}, `C++, "bgfx"`],
+		{q{void}, q{blit}, q{ViewID id, TextureHandle dst, ubyte dstMIP, ushort dstX, ushort dstY, ushort dstZ, TextureHandle src, ubyte srcMIP=0, ushort srcX=0, ushort srcY=0, ushort srcZ=0, ushort width=ushort.max, ushort height=ushort.max, ushort depth=ushort.max}, ext: `C++, "bgfx"`},
 		
-	]);
+	];
 	return ret;
-}(), __MODULE__, "Resolution, Init, Attachment, VertexLayout, Encoder, "));
+}()));
 
 static if(!staticBinding):
 import bindbc.loader;


### PR DESCRIPTION
I have no idea why it still shows the 9 commits you already merged, but the last 2 are the new ones. Apparently I have no idea how Git works... :')

Changes:
1. I fixed a platform-specific mangling error caused by
  a. C++ Itanium mangling distinguishing between `long` and `long long`; and
  b. the definition of (`u`)`int64_t` arbitrarily being either `long` or `long long`.
2. D function binding generation now uses the improved BindBC-Common API (0.1.0 -> 0.1.1), which is nearly identical while also a lot more extensible for me, and approachable for others.