### PR TITLE
Fix incorrect psslShaderPreamble in compute shader

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -1547,7 +1547,7 @@ namespace bgfx
 				}
 				else
 				{
-					if (profile->lang != ShadingLang::PSSL)
+					if (profile->lang == ShadingLang::PSSL)
 					{
 						preprocessor.writef(getPsslPreamble() );
 					}


### PR DESCRIPTION
fix compute shader emitting pssl preamble when target shader type is _not_ PSSL