### PR TITLE
Fix random, erroneous D binding type generation; add missing IDL defaults

### DIFF
--- a/bindings/d/package.d
+++ b/bindings/d/package.d
@@ -3078,7 +3078,7 @@ mixin(joinFnBinds((){
 		- `BGFX_SAMPLER_[MIN/MAG/MIP]_[POINT/ANISOTROPIC]` - Point or anisotropic
 		  sampling.
 		*/
-		{q{size_t}, q{overrideInternal}, q{TextureHandle handle, ushort width, ushort height, ubyte numMIPs, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 flags}, ext: `C++, "bgfx"`},
+		{q{size_t}, q{overrideInternal}, q{TextureHandle handle, ushort width, ushort height, ubyte numMIPs, bgfx.fakeenum.TextureFormat.Enum format, c_uint64 flags=Texture.none | Sampler.none}, ext: `C++, "bgfx"`},
 		
 		/**
 		* Sets a debug marker. This allows you to group graphics calls together for easy browsing in
@@ -3160,7 +3160,7 @@ mixin(joinFnBinds((){
 			mtx = Pointer to first matrix in array.
 			num = Number of matrices in array.
 		*/
-		{q{uint}, q{setTransform}, q{const(void)* mtx, ushort num}, ext: `C++, "bgfx"`},
+		{q{uint}, q{setTransform}, q{const(void)* mtx, ushort num=1}, ext: `C++, "bgfx"`},
 		
 		/**
 		*  Set model matrix from matrix cache for draw primitive.

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -2795,6 +2795,7 @@ func.setTransform
 	                   --- to be used for other draw primitive call.
 	.mtx "const void*" --- Pointer to first matrix in array.
 	.num "uint16_t"    --- Number of matrices in array.
+	 { default = 1 }
 
 ---  Set model matrix from matrix cache for draw primitive.
 func.setTransform { cname = "set_transform_cached" }

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -2715,6 +2715,7 @@ func.overrideInternal { cname = "override_internal_texture" }
 	                               ---   mode.
 	                               --- - `BGFX_SAMPLER_[MIN/MAG/MIP]_[POINT/ANISOTROPIC]` - Point or anisotropic
 	                               ---   sampling.
+	{ default = "BGFX_TEXTURE_NONE | BGFX_SAMPLER_NONE" }
 
 -- Legacy API:
 

--- a/scripts/bindings-d.lua
+++ b/scripts/bindings-d.lua
@@ -228,20 +228,20 @@ local function convArray(array)
 end
 
 local typeSubs = {
-	uint32_t  = "uint",     int32_t = "int",
-	uint16_t  = "ushort",   int16_t = "short",
-	uint64_t  = "c_uint64", int64_t = "c_int64",
-	uint8_t   = "ubyte",    int8_t  = "byte",
-	uintptr_t = "size_t"
+	{"uint32_t",  "uint"},     {"int32_t", "int"},
+	{"uint16_t",  "ushort"},   {"int16_t", "short"},
+	{"uint64_t",  "c_uint64"}, {"int64_t", "c_int64"},
+	{"uint8_t",   "ubyte"},    {"int8_t",  "byte"},
+	{"uintptr_t", "size_t"}
 }
 local function convSomeType(arg, isFnArg)
 	local type = arg.fulltype
 	if type == "bx::AllocatorI*" or type == "CallbackI*" then
 		type = "void*"
 	else
-		for from, to in pairs(typeSubs) do
-			if type:find(from) then
-				type = type:gsub(from, to)
+		for _, item in ipairs(typeSubs) do
+			if type:find(item[1]) then
+				type = type:gsub(item[1], item[2])
 				break
 			end
 		end


### PR DESCRIPTION
- Fixed `c_uint64` being generated as `uc_int64` at random, due to non-deterministic hash-map iteration ordering in Lua.
- Added 2 missing default arguments to `bgfx.idl`.
- Re-generated bindings with new `bgfx.idl`.