### PR TITLE
Make use of bx::bit_cast

### DIFF
--- a/examples/09-hdr/hdr.cpp
+++ b/examples/09-hdr/hdr.cpp
@@ -362,9 +362,10 @@ public:
 
 			if (bgfx::isValid(m_rb) )
 			{
-				union { uint32_t color; uint8_t bgra[4]; } cast = { m_lumBgra8 };
-				float exponent = cast.bgra[3]/255.0f * 255.0f - 128.0f;
-				float lumAvg   = cast.bgra[2]/255.0f * bx::exp2(exponent);
+				struct Packed { uint8_t bgra[4]; } arr = bx::bit_cast<Packed>(m_lumBgra8);
+				float exponent = arr.bgra[3] / 255.0f * 255.0f - 128.0f;
+				float lumAvg = arr.bgra[2] / 255.0f * bx::exp2(exponent);
+
 				ImGui::SliderFloat("Lum Avg", &lumAvg, 0.0f, 1.0f);
 			}
 

--- a/examples/33-pom/pom.cpp
+++ b/examples/33-pom/pom.cpp
@@ -37,29 +37,15 @@ struct PosTangentBitangentTexcoordVertex
 
 bgfx::VertexLayout PosTangentBitangentTexcoordVertex::ms_layout;
 
-uint32_t packUint32(uint8_t _x, uint8_t _y, uint8_t _z, uint8_t _w)
-{
-	union
-	{
-		uint32_t ui32;
-		uint8_t arr[4];
-	} un;
-
-	un.arr[0] = _x;
-	un.arr[1] = _y;
-	un.arr[2] = _z;
-	un.arr[3] = _w;
-
-	return un.ui32;
-}
-
 uint32_t packF4u(float _x, float _y = 0.0f, float _z = 0.0f, float _w = 0.0f)
 {
-	const uint8_t xx = uint8_t(_x*127.0f + 128.0f);
-	const uint8_t yy = uint8_t(_y*127.0f + 128.0f);
-	const uint8_t zz = uint8_t(_z*127.0f + 128.0f);
-	const uint8_t ww = uint8_t(_w*127.0f + 128.0f);
-	return packUint32(xx, yy, zz, ww);
+	struct Packed { uint8_t value[4]; } arr = { 0 };
+	arr.value[0] = uint8_t(_x * 127.0f + 128.0f);
+	arr.value[1] = uint8_t(_y * 127.0f + 128.0f);
+	arr.value[2] = uint8_t(_z * 127.0f + 128.0f);
+	arr.value[3] = uint8_t(_w * 127.0f + 128.0f);
+
+	return bx::bit_cast<uint32_t>(arr);
 }
 
 static PosTangentBitangentTexcoordVertex s_cubeVertices[24] =

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -605,13 +605,6 @@ namespace bgfx
 		release( (const Memory*)_mem);
 	}
 
-	inline uint32_t castfu(float _value)
-	{
-		union {	float fl; uint32_t ui; } un;
-		un.fl = _value;
-		return un.ui;
-	}
-
 	inline uint64_t packStencil(uint32_t _fstencil, uint32_t _bstencil)
 	{
 		return (uint64_t(_bstencil)<<32)|uint64_t(_fstencil);

--- a/src/shader_dxbc.cpp
+++ b/src/shader_dxbc.cpp
@@ -1723,11 +1723,10 @@ namespace bgfx
 			case DxbcOperandType::Imm64:
 				for (uint32_t jj = 0; jj < operand.num; ++jj)
 				{
-					union { uint32_t i; float f; } cast = { operand.un.imm32[jj] };
 					size += bx::snprintf(&_out[size], bx::uint32_imax(0, _size-size)
 								, "%s%f"
 								, 0 == jj ? "(" : ", "
-								, cast.f
+								, bx::bit_cast<float>(operand.un.imm32[jj])
 								);
 				}
 


### PR DESCRIPTION
Use `bx::bit_cast()` where appropriate for type punning, and applying packed struct for arrays when necessary.

`bx::bit_cast()` is introduced in bkaradzic/bx#313 to address the similar issue of type punning in `bx` (bkaradzic/bx#312).

~This PR also uses `reinterpret_cast` for direct `void*` translations for integer handles.~
~Within `renderer_vk.cpp`, we remove the union when casting from void* to xcb_window_t, it isn't necessary.~

