### PR TITLE
Fixed calcNumMips for non-power-of-2 texture dimensions

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -635,7 +635,7 @@ namespace bgfx
 		if (_hasMips)
 		{
 			const uint32_t max = bx::max(_width, _height, _depth);
-			const uint32_t num = 1 + bx::ceilLog2(max);
+			const uint32_t num = 1 + bx::floorLog2(max);
 
 			return uint8_t(num);
 		}


### PR DESCRIPTION
`calcNumMips` function was calculating often wrong number of mipmaps for textures whose dimensions are not power of 2 such as 96x96; Apparently this is not an issue in Vulkan and probably others(IMHO is bad), but Metal seems to complain about it:
```
-[MTLTextureDescriptorInternal validateWithDevice:]:1357: failed assertion `Texture Descriptor Validation
MTLTextureDescriptor requests 8 mipmap levels, but the dimensions (96, 96, 1) can only support a maxiumum of 7 levels
'
```
I introduced `floorLog2` function in `bx` so now this function can use it instead of `ceilLog2`, which works properly for all texture dimensions.

PS: This PR might fail checks because it might not be using the updated `bx`: https://github.com/bkaradzic/bx/pull/314