### PR TITLE
Fix D3D12 debug crash due to validation layers SDK bug

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2728,7 +2728,7 @@ namespace bgfx
 
 				if (BX_ENABLED(BX_PLATFORM_WINDOWS) )
 				{
-					if (windowsVersionIs(Condition::GreaterEqual, 0x0603) )
+					if (windowsVersionIs(Condition::GreaterEqual, 0x0602) )
 					{
 						score += RendererType::Direct3D11 == renderer ? 20 : 0;
 						score += RendererType::Direct3D12 == renderer ? 10 : 0;

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2670,6 +2670,7 @@ namespace bgfx
 				{
 					return false;
 				}
+				ovi.dwBuildNumber =  UINT32_MAX == _build ? UINT32_MAX : ovi.dwBuildNumber;
 			}
 		}
 		// _WIN32_WINNT_WIN10   0x0A00
@@ -2682,23 +2683,9 @@ namespace bgfx
 		switch (_op)
 		{
 			case Condition::LessEqual:
-				if (_build != UINT32_MAX)
-				{
-					return (ovi.dwMajorVersion < cMajorVersion || (ovi.dwMajorVersion == cMajorVersion && ovi.dwMinorVersion <= cMinorVersion)) && ovi.dwBuildNumber <= _build;
-				}
-				else
-				{
-					return ovi.dwMajorVersion < cMajorVersion || (ovi.dwMajorVersion == cMajorVersion && ovi.dwMinorVersion <= cMinorVersion);
-				}
+				return (ovi.dwMajorVersion < cMajorVersion || (ovi.dwMajorVersion == cMajorVersion && ovi.dwMinorVersion <= cMinorVersion)) && ovi.dwBuildNumber <= _build;
 			case Condition::GreaterEqual:
-				if (_build != UINT32_MAX)
-				{
-					return (ovi.dwMajorVersion > cMajorVersion || (ovi.dwMajorVersion == cMajorVersion && ovi.dwMinorVersion >= cMinorVersion)) && ovi.dwBuildNumber >= _build;
-				}
-				else
-				{
-					return ovi.dwMajorVersion > cMajorVersion || (ovi.dwMajorVersion == cMajorVersion && ovi.dwMinorVersion >= cMinorVersion);
-				}
+				return (ovi.dwMajorVersion > cMajorVersion || (ovi.dwMajorVersion == cMajorVersion && ovi.dwMinorVersion >= cMinorVersion)) && ovi.dwBuildNumber >= _build;
 			default:
 				return false;
 		}

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2656,27 +2656,70 @@ namespace bgfx
 	bool windowsVersionIs(Condition::Enum _op, uint32_t _version)
 	{
 #if BX_PLATFORM_WINDOWS
-		static const uint8_t s_condition[] =
-		{
-			VER_LESS_EQUAL,
-			VER_GREATER_EQUAL,
-		};
-
-		OSVERSIONINFOEXA ovi;
-		bx::memSet(&ovi, 0, sizeof(ovi) );
+		RTL_OSVERSIONINFOW ovi;
+		bx::memSet(&ovi, 0 , sizeof(ovi));
 		ovi.dwOSVersionInfoSize = sizeof(ovi);
-		// _WIN32_WINNT_WINBLUE 0x0603
-		// _WIN32_WINNT_WIN8    0x0602
-		// _WIN32_WINNT_WIN7    0x0601
-		// _WIN32_WINNT_VISTA   0x0600
-		ovi.dwMajorVersion = HIBYTE(_version);
-		ovi.dwMinorVersion = LOBYTE(_version);
-		DWORDLONG cond = 0;
-		VER_SET_CONDITION(cond, VER_MAJORVERSION, s_condition[_op]);
-		VER_SET_CONDITION(cond, VER_MINORVERSION, s_condition[_op]);
-		return !!VerifyVersionInfoA(&ovi, VER_MAJORVERSION | VER_MINORVERSION, cond);
+		const HMODULE hMod = GetModuleHandleW(L"ntdll.dll");
+		if (NULL != hMod)
+		{
+			FARPROC (WINAPI* rtlGetVersionPtr) (PRTL_OSVERSIONINFOW) = reinterpret_cast<FARPROC (WINAPI*)(PRTL_OSVERSIONINFOW)>(GetProcAddress(hMod, "RtlGetVersion"));
+			if (NULL != rtlGetVersionPtr)
+			{
+				rtlGetVersionPtr(&ovi);
+				if (ovi.dwMajorVersion == 0)
+				{
+					return false;
+				}
+			}
+		}
+		const DWORD cMajorVersion = HIBYTE(_version);
+		const DWORD cMinorVersion = LOBYTE(_version);
+		switch (_op)
+		{
+			case Condition::LessEqual:
+				return ovi.dwMajorVersion <= cMajorVersion && ovi.dwMinorVersion <= cMinorVersion;
+			case Condition::GreaterEqual:
+				return ovi.dwMajorVersion >= cMajorVersion && ovi.dwMinorVersion >= cMinorVersion;
+			default:
+				return false;
+		}
 #else
 		BX_UNUSED(_op, _version);
+		return false;
+#endif // BX_PLATFORM_WINDOWS
+	}
+
+	bool windowsBuildIs(Condition::Enum _op, uint32_t _build)
+	{
+#if BX_PLATFORM_WINDOWS
+		RTL_OSVERSIONINFOW ovi;
+		bx::memSet(&ovi, 0 , sizeof(ovi));
+		ovi.dwOSVersionInfoSize = sizeof(ovi);
+		const HMODULE hMod = GetModuleHandleW(L"ntdll.dll");
+		if (NULL != hMod)
+		{
+			FARPROC (WINAPI* rtlGetVersionPtr) (PRTL_OSVERSIONINFOW) = reinterpret_cast<FARPROC (WINAPI*)(PRTL_OSVERSIONINFOW)>(GetProcAddress(hMod, "RtlGetVersion"));
+			if (NULL != rtlGetVersionPtr)
+			{
+				rtlGetVersionPtr(&ovi);
+				if (ovi.dwBuildNumber == 0)
+				{
+					return false;
+				}
+			}
+		}
+
+		switch (_op)
+		{
+			case Condition::LessEqual:
+				return ovi.dwBuildNumber <= _build;
+			case Condition::GreaterEqual:
+				return ovi.dwBuildNumber >= _build;
+			default:
+				return false;
+		}
+#else
+		BX_UNUSED(_op, _build);
 		return false;
 #endif // BX_PLATFORM_WINDOWS
 	}
@@ -2701,7 +2744,7 @@ namespace bgfx
 
 				if (BX_ENABLED(BX_PLATFORM_WINDOWS) )
 				{
-					if (windowsVersionIs(Condition::GreaterEqual, 0x0602) )
+					if (windowsVersionIs(Condition::GreaterEqual, 0x0603) )
 					{
 						score += RendererType::Direct3D11 == renderer ? 20 : 0;
 						score += RendererType::Direct3D12 == renderer ? 10 : 0;

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2672,7 +2672,7 @@ namespace bgfx
 				}
 			}
 		}
-		// _WIN32_IE_WIN10      0x0A00
+		// _WIN32_WINNT_WIN10   0x0A00
 		// _WIN32_WINNT_WINBLUE 0x0603
 		// _WIN32_WINNT_WIN8    0x0602
 		// _WIN32_WINNT_WIN7    0x0601

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -427,9 +427,7 @@ namespace bgfx
 		};
 	};
 
-	bool windowsVersionIs(Condition::Enum _op, uint32_t _version);
-
-	bool windowsBuildIs(Condition::Enum _op, uint32_t _build);
+	bool windowsVersionIs(Condition::Enum _op, uint32_t _version, uint32_t _build = UINT32_MAX);
 
 	constexpr bool isShaderType(uint32_t _magic, char _type)
 	{

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -429,6 +429,8 @@ namespace bgfx
 
 	bool windowsVersionIs(Condition::Enum _op, uint32_t _version);
 
+	bool windowsBuildIs(Condition::Enum _op, uint32_t _build);
+
 	constexpr bool isShaderType(uint32_t _magic, char _type)
 	{
 		return uint32_t(_type) == (_magic & BX_MAKEFOURCC(0xff, 0, 0, 0) );

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -844,29 +844,18 @@ namespace bgfx { namespace d3d12
 
 								if (SUCCEEDED(hr))
 								{
-									//This is the least ugly way to get the windows build that still works past win10 without deprecation warnings or needing app manifests
-									RTL_OSVERSIONINFOW osver;
-									bx::memSet(&osver, 0 , sizeof(RTL_OSVERSIONINFOW));
-									const HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
-								    if (hMod) {
-										FARPROC (WINAPI* rtlGetVersionPtr) (PRTL_OSVERSIONINFOW) = reinterpret_cast<FARPROC (WINAPI*)(PRTL_OSVERSIONINFOW)>(::GetProcAddress(hMod, "RtlGetVersion"));
-								        if (rtlGetVersionPtr != nullptr) {
-								            rtlGetVersionPtr(&osver);
-											if (osver.dwBuildNumber > 0) {
-												osver.dwOSVersionInfoSize = sizeof(RTL_OSVERSIONINFOW);
-											}
-								        }
-								    }
-
 									// https://discordapp.com/channels/590611987420020747/593519198995742733/703642988345032804
 									// D3D12 Bug Number: 26131261
 									// There is a bug in the D3D12 validation that causes example-21 to fail when using UAV
 									// Setting SetEnableSynchronizedCommandQueueValidation below to false avoids the bug
 									// It was fixed in (probably) the first windows 11 sdk, 22000
 									// However, the fix causes any dx12 context with validation to break if this is set to false, so we can't do that anymore
-									if (osver.dwOSVersionInfoSize > 0 && osver.dwBuildNumber >= 22000) {
+									if (windowsBuildIs(Condition::GreaterEqual, 22000))
+									{
 										debug1->SetEnableGPUBasedValidation(true);
-									} else {
+									}
+									else
+									{
 										debug1->SetEnableSynchronizedCommandQueueValidation(false);
 									}
 								}

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -849,7 +849,7 @@ namespace bgfx { namespace d3d12
 									bx::memSet(&osver, 0 , sizeof(RTL_OSVERSIONINFOW));
 									const HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
 								    if (hMod) {
-										LONG (WINAPI* rtlGetVersionPtr) (PRTL_OSVERSIONINFOW) = reinterpret_cast<LONG (WINAPI*)(PRTL_OSVERSIONINFOW)>(::GetProcAddress(hMod, "RtlGetVersion"));
+										FARPROC (WINAPI* rtlGetVersionPtr) (PRTL_OSVERSIONINFOW) = reinterpret_cast<FARPROC (WINAPI*)(PRTL_OSVERSIONINFOW)>(::GetProcAddress(hMod, "RtlGetVersion"));
 								        if (rtlGetVersionPtr != nullptr) {
 								            rtlGetVersionPtr(&osver);
 											if (osver.dwBuildNumber > 0) {

--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -850,7 +850,7 @@ namespace bgfx { namespace d3d12
 									// Setting SetEnableSynchronizedCommandQueueValidation below to false avoids the bug
 									// It was fixed in (probably) the first windows 11 sdk, 22000
 									// However, the fix causes any dx12 context with validation to break if this is set to false, so we can't do that anymore
-									if (windowsBuildIs(Condition::GreaterEqual, 22000))
+									if (windowsVersionIs(Condition::GreaterEqual, 0x0A00, 22000))
 									{
 										debug1->SetEnableGPUBasedValidation(true);
 									}


### PR DESCRIPTION
This fixes https://github.com/bkaradzic/bgfx/issues/3176 and the other intermittent questions about this problem.
This way of runtime checking the windows build is the least ugly/hacky that I could find (and yet, it's still awful).
I only tested on win11 build 22621. If we think tests on other versions or builds are necessary I can try to make some VMs.