### PR TITLE
add error log detecting uint8_t overflow in hlsl shader compilation

### DIFF
--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -481,6 +481,17 @@ namespace bgfx { namespace hlsl
 							if (UniformType::Count != uniformType
 							&&  0 != (varDesc.uFlags & D3D_SVF_USED) )
 							{
+								if (constDesc.Elements > UINT8_MAX)
+								{
+									bx::write(_messageWriter
+										, &messageErr
+										, "Error: Uniform %s has %u elements. 255 is the limit for shaderc uniform serialization.\n"
+										, varDesc.Name
+										, constDesc.Elements
+										);
+									return false;
+								}
+
 								Uniform un;
 								un.name = varDesc.Name;
 								un.type = uniformType;


### PR DESCRIPTION
Error looks like following:
![image](https://github.com/bkaradzic/bgfx/assets/40307536/da7d2bf7-bc50-40ed-a077-c403eeff4c7f)

I ran into this because I tried to make a shader with a uniform array of over 255 elements. Finding the problem was kind of tricky.. had to back track to where the shader was being deserialized. This error would have helped.