### PR TITLE
D3D12: fix D3D12_VERTEX_BUFFER_VIEW stride when both vertex layout handles are valid

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -4253,7 +4253,7 @@ namespace bgfx { namespace d3d12
 				VertexBufferD3D12& vb = s_renderD3D12->m_vertexBuffers[handle];
 				vb.setState(_commandList, D3D12_RESOURCE_STATE_GENERIC_READ);
 
-				const uint16_t layoutIdx = !isValid(vb.m_layoutHandle) ? stream.m_layoutHandle.idx : vb.m_layoutHandle.idx;
+				const uint16_t layoutIdx = isValid(stream.m_layoutHandle) ? stream.m_layoutHandle.idx : vb.m_layoutHandle.idx;
 				const VertexLayout& layout = s_renderD3D12->m_vertexLayouts[layoutIdx];
 				const uint32_t stride = layout.m_stride;
 


### PR DESCRIPTION
Fix for this issue: https://github.com/falia18/bgfx/tree/pr-example/fix-d3d12-layout-issue  
To repro launch 01-cubes with --d3d12, it gives this:  
![image](https://github.com/bkaradzic/bgfx/assets/9404523/48e330dc-ccc8-4cc9-8c17-e48c1d6f7aa2)  


The fix makes the layout selection consistant (when both layouts are valid) between these lines:
https://github.com/bkaradzic/bgfx/blob/a9f61040c751f9600eccf1b17be96e759303a519/src/renderer_d3d12.cpp#L4256
https://github.com/bkaradzic/bgfx/blob/a9f61040c751f9600eccf1b17be96e759303a519/src/renderer_d3d12.cpp#L6893-L6895

(It's my first PR sorry if I messed up something)