### PR TITLE
Avoid extra 3 flip/presents during initialization

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2046,12 +2046,14 @@ namespace bgfx
 
 		m_submit->m_transientVb = createTransientVertexBuffer(_init.limits.transientVbSize);
 		m_submit->m_transientIb = createTransientIndexBuffer(_init.limits.transientIbSize);
+		m_submit->m_startupFlipLatch = -1;
 		frame();
 
 		if (BX_ENABLED(BGFX_CONFIG_MULTITHREADED) )
 		{
 			m_submit->m_transientVb = createTransientVertexBuffer(_init.limits.transientVbSize);
 			m_submit->m_transientIb = createTransientIndexBuffer(_init.limits.transientIbSize);
+			m_submit->m_startupFlipLatch = -1;
 			frame();
 		}
 
@@ -2402,7 +2404,7 @@ namespace bgfx
 	void Context::flip()
 	{
 		if (m_rendererInitialized
-		&& !m_flipped)
+		&& !m_flipped && ++m_render->m_startupFlipLatch > 0)
 		{
 			m_renderCtx->flip();
 			m_flipped = true;

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -2361,6 +2361,9 @@ namespace bgfx
 
 		CommandBuffer m_cmdPre;
 		CommandBuffer m_cmdPost;
+		// This is a large negative number so that during startup, the incremental by the render thread will not make it positive
+		// When the main thread signals the render thread to start present next frame, the main thread sets this to -1. 
+		int64_t m_startupFlipLatch = -10000;
 
 		template<typename Ty, uint32_t Max>
 		struct FreeHandle


### PR DESCRIPTION
It seems that the flip and is called three times during initialization, even though we have not yet done any rendering yet. We are trying to optimize our startup time and due to frame rates with vsync, these 3 frames with presents are quite a lot for us.

This sounds like a simple change, it does not feel very elegant though. I wonder what you think?