### PR TITLE
Fix vertex attributes having incorrect state when restarting BGFX

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2265,6 +2265,10 @@ namespace bgfx { namespace gl
 
 			ErrorState::Enum errorState = ErrorState::Default;
 
+			s_currentlyEnabledVertexAttribArrays = 0;
+			s_vertexAttribArraysPendingDisable   = 0;
+			s_vertexAttribArraysPendingEnable    = 0;
+
 			if (_init.debug
 			||  _init.profile)
 			{


### PR DESCRIPTION
I've been having some issues when restarting BGFX using `bgfx::shutdown()` and `bgfx::init()`. It seems that some vertex attributes are disabled when they shouldn't be. I think this is because the following static variables are not reset:

- s_currentlyEnabledVertexAttribArrays
- s_vertexAttribArraysPendingDisable
- s_vertexAttribArraysPendingEnable

This change just resets these back to zero when initializing.