### PR TITLE
feat: add module map

### DIFF
--- a/include/bgfx/module.modulemap
+++ b/include/bgfx/module.modulemap
@@ -1,0 +1,8 @@
+module bgfx {
+    header "platform.h"
+    header "embedded_shader.h"
+    header "c99/bgfx.h"
+    header "defines.h"
+
+    export *
+}


### PR DESCRIPTION
This PR adds a module map that allows the use of BGFX together with Swift C++ interop (https://www.swift.org/documentation/cxx-interop/#creating-a-clang-module). 

Example: 
![CleanShot 2024-04-04 at 11 55 41@2x](https://github.com/bkaradzic/bgfx/assets/52801365/aded7189-8d65-4f2f-8879-a4323582601b)
