### PR TITLE
feat: bring back ios-simulator support

### DIFF
--- a/examples/common/entry/entry_ios.mm
+++ b/examples/common/entry/entry_ios.mm
@@ -11,7 +11,7 @@
 #import <UIKit/UIKit.h>
 #import <QuartzCore/CAEAGLLayer.h>
 
-#if __IPHONE_8_0 && !TARGET_IPHONE_SIMULATOR  // check if sdk/target supports metal
+#if __IPHONE_13_0 // From iOS 13 Simulators support metal
 #   import <Metal/Metal.h>
 #   import <QuartzCore/CAMetalLayer.h>
 #   define HAS_METAL_SDK

--- a/examples/runtime/ios-info.plist
+++ b/examples/runtime/ios-info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.company.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/makefile
+++ b/makefile
@@ -56,6 +56,8 @@ projgen: ## Generate project files for all configurations.
 	$(GENIE)              --with-examples                            --gcc=wasm2js         gmake
 	$(GENIE)              --with-combined-examples                   --gcc=ios-arm         gmake
 	$(GENIE)              --with-combined-examples                   --gcc=ios-arm64       gmake
+	$(GENIE)              --with-combined-examples                   --gcc=ios-simulator   gmake
+	$(GENIE)              --with-combined-examples                   --gcc=tvos-simulator  gmake
 	$(GENIE)              --with-combined-examples                   --gcc=rpi             gmake
 
 idl: ## Generate code from IDL.
@@ -214,6 +216,14 @@ ios-arm64-debug: .build/projects/gmake-ios-arm64 ## Build - iOS ARM64 Debug
 ios-arm64-release: .build/projects/gmake-ios-arm64 ## Build - iOS ARM64 Release
 	$(MAKE) -R -C .build/projects/gmake-ios-arm64 config=release
 ios-arm64: ios-arm64-debug ios-arm64-release ## Build - iOS ARM64 Debug and Release
+
+.build/projects/gmake-ios-simulator:
+	$(GENIE) --gcc=ios-simulator gmake
+ios-simulator-debug: .build/projects/gmake-ios-simulator ## Build - iOS Simulator Debug
+	$(MAKE) -R -C .build/projects/gmake-ios-simulator config=debug
+ios-simulator-release: .build/projects/gmake-ios-simulator ## Build - iOS Simulator Release
+	$(MAKE) -R -C .build/projects/gmake-ios-simulator config=release
+ios-simulator: ios-simulator-debug ios-simulator-release ## Build - iOS Simulator Debug and Release
 
 .build/projects/gmake-rpi:
 	$(GENIE) --gcc=rpi gmake

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -414,6 +414,11 @@ function exampleProjectDefaults()
 			"-framework UIKit",
 			"-weak_framework Metal",
 		}
+		xcodecopyresources {
+			{ "shaders/metal", {
+				os.matchfiles(path.join(BGFX_DIR, "examples/runtime/shaders/metal/**.bin"))
+			}}
+		}
 
 	configuration { "xcode*", "ios" }
 		kind "WindowedApp"

--- a/scripts/geometryv.lua
+++ b/scripts/geometryv.lua
@@ -170,7 +170,7 @@ project ("geometryv")
 			"-framework UIKit",
 		}
 
-	configuration { "xcode4", "ios" }
+	configuration { "xcode*", "ios" }
 		kind "WindowedApp"
 
 	configuration { "qnx*" }


### PR DESCRIPTION
This PR reintroduces ios/tvos simulator support to bgfx. It will allow developers to develop and extend the framework easily.

Corresponding PR to `bx`: https://github.com/bkaradzic/bx/pull/322

It should fix this issue: #3239

## Test plan

Generate test projects using GENie (I've used the latest version from main):

iOS:

```sh
 ~/GENie/bin/darwin/genie --with-combined-examples --xcode=ios --gcc=ios-simulator xcode15
```

tvOS:

```sh
 ~/GENie/bin/darwin/genie --with-combined-examples --xcode=tvos --gcc=tvos-simulator xcode15
```

## Screenshots

![CleanShot 2024-04-12 at 14 35 08@2x](https://github.com/bkaradzic/bgfx/assets/52801365/b0c20bbc-5927-4eee-8d85-aad0bfe3af4d)

![CleanShot 2024-04-12 at 14 39 13@2x](https://github.com/bkaradzic/bgfx/assets/52801365/f7f4df15-33d9-4ecc-936b-1bc4d0ac817e)


Note: I've tested everything on M1 Macbook Pro (Apple Silicon)
