### PR TITLE
Examples: change order of calls in loadTexture()

### DIFF
--- a/examples/common/bgfx_utils.cpp
+++ b/examples/common/bgfx_utils.cpp
@@ -185,6 +185,20 @@ bgfx::TextureHandle loadTexture(bx::FileReaderI* _reader, const bx::FilePath& _f
 					);
 			unload(data);
 
+			if (NULL != _info)
+			{
+				bgfx::calcTextureSize(
+					*_info
+					, uint16_t(imageContainer->m_width)
+					, uint16_t(imageContainer->m_height)
+					, uint16_t(imageContainer->m_depth)
+					, imageContainer->m_cubeMap
+					, 1 < imageContainer->m_numMips
+					, imageContainer->m_numLayers
+					, bgfx::TextureFormat::Enum(imageContainer->m_format)
+				);
+			}
+
 			if (imageContainer->m_cubeMap)
 			{
 				handle = bgfx::createTextureCube(
@@ -225,20 +239,6 @@ bgfx::TextureHandle loadTexture(bx::FileReaderI* _reader, const bx::FilePath& _f
 			{
 				const bx::StringView name(_filePath);
 				bgfx::setName(handle, name.getPtr(), name.getLength() );
-			}
-
-			if (NULL != _info)
-			{
-				bgfx::calcTextureSize(
-					  *_info
-					, uint16_t(imageContainer->m_width)
-					, uint16_t(imageContainer->m_height)
-					, uint16_t(imageContainer->m_depth)
-					, imageContainer->m_cubeMap
-					, 1 < imageContainer->m_numMips
-					, imageContainer->m_numLayers
-					, bgfx::TextureFormat::Enum(imageContainer->m_format)
-					);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes possible concurrency issue - makes code usable in a multithreaded environment. imageReleasCb releases imageContainer after bgfx::createTexture...() is called. If bgfx::frame() is called from another thread, the release can happen before imageContainer is used in bgfx::calcTextureSize(), leading to a crash. Although loadTexture() is not used in multithreaded environment in the examples, calling bgfx::calcTextureSize() before bgfx::createTexture...() is a better reference for users.