### PR TITLE
Fixes Emscripten wasm64 compile error in `glcontext_html5.cpp`.

### DIFF
--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -71,7 +71,7 @@ namespace bgfx { namespace gl
 
 		const char* canvas = (const char*) g_platformData.nwh;
 
-		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = (EMSCRIPTEN_WEBGL_CONTEXT_HANDLE) g_platformData.context;
+		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = bx::narrowCast<EMSCRIPTEN_WEBGL_CONTEXT_HANDLE>((uintptr_t) g_platformData.context);
 		if (context > 0)
 		{
 			if (emscripten_webgl_get_context_attributes(context, &s_attrs) >= 0)


### PR DESCRIPTION
Fixes compile error:

```
glcontext_html5.cpp:74:45: error: cast from pointer to smaller type
'EMSCRIPTEN_WEBGL_CONTEXT_HANDLE' (aka 'int') loses information
74 |                 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context =
reinterpret_cast<EMSCRIPTEN_WEBGL_CONTEXT_HANDLE>(g_platformData.context);
|
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```