### PR TITLE
Restore support for older macOS/iOS version. Determine features at init, and use at runtime.

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -216,6 +216,8 @@ namespace bgfx { namespace mtl
 		bool                      m_autoGetMipmap;
 	};
 
+	#pragma clang diagnostic push
+	#pragma clang diagnostic ignored "-Wunguarded-availability-new"
 	static TextureFormatInfo s_textureFormat[] =
 	{
 #define $0 MTLTextureSwizzleZero
@@ -344,6 +346,7 @@ namespace bgfx { namespace mtl
 #undef $B
 #undef $A
 	};
+	#pragma clang diagnostic pop
 	BX_STATIC_ASSERT(TextureFormat::Count == BX_COUNTOF(s_textureFormat) );
 
 	int32_t s_msaa[] =
@@ -485,7 +488,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 
 #define CHECK_FEATURE_AVAILABLE(feature, ...) if (@available(__VA_ARGS__)) { feature = true; } else { feature = false; }
 
-			CHECK_FEATURE_AVAILABLE(m_usesNewMetalAPI, macOS 13.0, iOS 16.0, tvOS 16.0, macCatalyst 16.0, VISION_OS_MINIMUM *);
+			CHECK_FEATURE_AVAILABLE(m_usesMTLBindings, macOS 13.0, iOS 16.0, tvOS 16.0, macCatalyst 16.0, VISION_OS_MINIMUM *);
 			CHECK_FEATURE_AVAILABLE(m_hasCPUCacheModesAndStorageModes, iOS 9.0, macOS 10.11, macCatalyst 13.1, tvOS 9.0, VISION_OS_MINIMUM *);
 			CHECK_FEATURE_AVAILABLE(m_hasSynchronizeResource, macOS 10.11, macCatalyst 13.0, *);
 			CHECK_FEATURE_AVAILABLE(m_hasVSync, macOS 10.13, macCatalyst 13.1, *);
@@ -1972,6 +1975,9 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 			m_renderCommandEncoder.setStencilReferenceValue(ref);
 		}
 
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+		#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
 		void processArguments(
 			  PipelineStateMtl* ps
 			, NSArray<id<MTLBinding>>* _vertexArgs
@@ -1992,7 +1998,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 				{
 					BX_TRACE("arg: %s type:%d", utf8String(arg.name), arg.type);
 
-					if ((!m_usesNewMetalAPI && [arg isActive]) || (m_usesNewMetalAPI && arg.used))
+					if ((!m_usesMTLBindings && [(MTLArgument*)arg isActive]) || (m_usesMTLBindings && arg.used))
 					{
 						if (arg.type == MTLBindingTypeBuffer)
 						{
@@ -2140,6 +2146,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 				}
 			}
 		}
+		#pragma clang diagnostic pop
 
 		PipelineStateMtl* getPipelineState(
 			  uint64_t _state
@@ -2397,11 +2404,15 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 
 					if (NULL != reflection)
 					{
-						if (m_usesNewMetalAPI) {
+						#pragma clang diagnostic push
+						#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+						#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+						if (m_usesMTLBindings) {
 							processArguments(pso, reflection.vertexBindings, reflection.fragmentBindings);
 						} else {
 							processArguments(pso, reflection.vertexArguments, reflection.fragmentArguments);
 						}
+						#pragma clang diagnostic pop
 					}
 				}
 
@@ -2449,11 +2460,15 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 					, &reflection
 					);
 
-				if (m_usesNewMetalAPI) {
+				#pragma clang diagnostic push
+				#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+				#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+				if (m_usesMTLBindings) {
 					processArguments(pso, reflection.bindings, NULL);
 				} else {
 					processArguments(pso, reflection.arguments, NULL);
 				}
+				#pragma clang diagnostic pop
 
 				for (uint32_t ii = 0; ii < 3; ++ii)
 				{
@@ -2554,7 +2569,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 		bool m_hasStoreActionStoreAndMultisampleResolve;
 		bool m_hasCPUCacheModesAndStorageModes;
 		bool m_hasSynchronizeResource;
-		bool m_usesNewMetalAPI;
+		bool m_usesMTLBindings;
 		bool m_hasVSync;
 		bool m_hasMaximumDrawableCount;
 

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -9,6 +9,7 @@
 
 #include "renderer_mtl.h"
 #include "renderer.h"
+#include <bx/macros.h>
 
 #if BX_PLATFORM_OSX
 #	include <Cocoa/Cocoa.h>
@@ -216,8 +217,8 @@ namespace bgfx { namespace mtl
 		bool                      m_autoGetMipmap;
 	};
 
-	#pragma clang diagnostic push
-	#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+	BX_PRAGMA_DIAGNOSTIC_PUSH();
+	BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG("-Wunguarded-availability-new");
 	static TextureFormatInfo s_textureFormat[] =
 	{
 #define $0 MTLTextureSwizzleZero
@@ -346,7 +347,7 @@ namespace bgfx { namespace mtl
 #undef $B
 #undef $A
 	};
-	#pragma clang diagnostic pop
+	BX_PRAGMA_DIAGNOSTIC_POP();
 	BX_STATIC_ASSERT(TextureFormat::Count == BX_COUNTOF(s_textureFormat) );
 
 	int32_t s_msaa[] =
@@ -1975,9 +1976,9 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 			m_renderCommandEncoder.setStencilReferenceValue(ref);
 		}
 
-		#pragma clang diagnostic push
-		#pragma clang diagnostic ignored "-Wunguarded-availability-new"
-		#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+		BX_PRAGMA_DIAGNOSTIC_PUSH();
+		BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG("-Wunguarded-availability-new");
+		BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG("-Wincompatible-pointer-types");
 		void processArguments(
 			  PipelineStateMtl* ps
 			, NSArray<id<MTLBinding>>* _vertexArgs
@@ -2146,7 +2147,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 				}
 			}
 		}
-		#pragma clang diagnostic pop
+		BX_PRAGMA_DIAGNOSTIC_POP();
 
 		PipelineStateMtl* getPipelineState(
 			  uint64_t _state
@@ -2404,15 +2405,15 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 
 					if (NULL != reflection)
 					{
-						#pragma clang diagnostic push
-						#pragma clang diagnostic ignored "-Wunguarded-availability-new"
-						#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+						BX_PRAGMA_DIAGNOSTIC_PUSH();
+						BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG("-Wunguarded-availability-new");
+						BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG("-Wincompatible-pointer-types");
 						if (m_usesMTLBindings) {
 							processArguments(pso, reflection.vertexBindings, reflection.fragmentBindings);
 						} else {
 							processArguments(pso, reflection.vertexArguments, reflection.fragmentArguments);
 						}
-						#pragma clang diagnostic pop
+						BX_PRAGMA_DIAGNOSTIC_POP();
 					}
 				}
 
@@ -2460,15 +2461,15 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 					, &reflection
 					);
 
-				#pragma clang diagnostic push
-				#pragma clang diagnostic ignored "-Wunguarded-availability-new"
-				#pragma clang diagnostic ignored "-Wincompatible-pointer-types"
+				BX_PRAGMA_DIAGNOSTIC_PUSH();
+				BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG("-Wunguarded-availability-new");
+				BX_PRAGMA_DIAGNOSTIC_IGNORED_CLANG("-Wincompatible-pointer-types");
 				if (m_usesMTLBindings) {
 					processArguments(pso, reflection.bindings, NULL);
 				} else {
 					processArguments(pso, reflection.arguments, NULL);
 				}
-				#pragma clang diagnostic pop
+				BX_PRAGMA_DIAGNOSTIC_POP();
 
 				for (uint32_t ii = 0; ii < 3; ++ii)
 				{

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -450,7 +450,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 #endif
 
 #if BX_XCODE_15
-#	define VISION_OS_MINIMUM visionOS 1.0
+#	define VISION_OS_MINIMUM visionOS 1.0,
 #else
 #	define VISION_OS_MINIMUM
 #	warning "XCode 15 is required for visionOS"


### PR DESCRIPTION
A lot of the warnings could be silenced by doing what Apple suggests: using the `@available` check at the code. However, I agree that readability increases if you name the feature you are testing for, instead of just random-looking version number checks.

Examples still work.