### PR TITLE
Changes to API reference

### DIFF
--- a/docs/bgfx.rst
+++ b/docs/bgfx.rst
@@ -318,7 +318,7 @@ State Flags
 .. doxygendefine:: BGFX_STATE_BLEND_FACTOR
 .. doxygendefine:: BGFX_STATE_BLEND_INV_FACTOR
 
-**Blend Equaation**
+**Blend Equation**
 
 .. doxygendefine:: BGFX_STATE_BLEND_EQUATION_ADD
 .. doxygendefine:: BGFX_STATE_BLEND_EQUATION_SUB
@@ -549,6 +549,20 @@ Textures
 
 .. doxygenstruct:: bgfx::TextureFormat
     :members:
+
+**Texture Flags**
+
+.. doxygendefine:: BGFX_TEXTURE_MSAA_SAMPLE
+.. doxygendefine:: BGFX_TEXTURE_RT
+.. doxygendefine:: BGFX_TEXTURE_COMPUTE_WRITE
+.. doxygendefine:: BGFX_TEXTURE_SRGB
+.. doxygendefine:: BGFX_TEXTURE_BLIT_DST
+.. doxygendefine:: BGFX_TEXTURE_READ_BACK
+.. doxygendefine:: BGFX_TEXTURE_RT_MSAA_X2
+.. doxygendefine:: BGFX_TEXTURE_RT_MSAA_X4
+.. doxygendefine:: BGFX_TEXTURE_RT_MSAA_X8
+.. doxygendefine:: BGFX_TEXTURE_RT_MSAA_X16
+.. doxygendefine:: BGFX_TEXTURE_RT_WRITE_ONLY
 
 .. doxygenfunction:: bgfx::isTextureValid
 

--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -3070,7 +3070,8 @@ namespace bgfx
 	/// @param[in] _width Texture width.
 	/// @param[in] _height Texture height.
 	/// @param[in] _format Texture format. See: `TextureFormat::Enum`.
-	/// @param[in] _textureFlags Default texture sampling mode is linear, and wrap mode
+	/// @param[in] _textureFlags Texture creation (see `BGFX_TEXTURE_*`.), and sampler (see `BGFX_SAMPLER_*`)
+	///   flags. Default texture sampling mode is linear, and wrap mode
 	///   is repeat.
 	///   - `BGFX_SAMPLER_[U/V/W]_[MIRROR/CLAMP]` - Mirror or clamp to edge wrap
 	///     mode.
@@ -3094,7 +3095,8 @@ namespace bgfx
 	/// @param[in] _ratio Frame buffer size in respect to back-buffer size. See:
 	///   `BackbufferRatio::Enum`.
 	/// @param[in] _format Texture format. See: `TextureFormat::Enum`.
-	/// @param[in] _textureFlags Default texture sampling mode is linear, and wrap mode
+	/// @param[in] _textureFlags Texture creation (see `BGFX_TEXTURE_*`.), and sampler (see `BGFX_SAMPLER_*`)
+	///   flags. Default texture sampling mode is linear, and wrap mode
 	///   is repeat.
 	///   - `BGFX_SAMPLER_[U/V/W]_[MIRROR/CLAMP]` - Mirror or clamp to edge wrap
 	///     mode.


### PR DESCRIPTION
included BGFX_TEXTURE_* description and explicit reference to them when describing createFrameBuffer functions