### PR TITLE
feat: add visionOS support

### DIFF
--- a/examples/common/entry/dialog.cpp
+++ b/examples/common/entry/dialog.cpp
@@ -68,7 +68,7 @@ void openUrl(const bx::StringView& _url)
 #if BX_PLATFORM_WINDOWS
 	void* result = ShellExecuteA(NULL, NULL, tmp, NULL, NULL, false);
 	BX_UNUSED(result);
-#elif !BX_PLATFORM_IOS
+#elif !BX_PLATFORM_IOS && !BX_PLATFORM_VISIONOS
 	int32_t result = system(tmp);
 	BX_UNUSED(result);
 #endif // BX_PLATFORM_*

--- a/examples/common/entry/entry_sdl.cpp
+++ b/examples/common/entry/entry_sdl.cpp
@@ -68,7 +68,7 @@ namespace entry
 			else
 #		endif // ENTRY_CONFIG_USE_WAYLAND
 				return (void*)wmi.info.x11.window;
-#	elif BX_PLATFORM_OSX || BX_PLATFORM_IOS
+#	elif BX_PLATFORM_OSX || BX_PLATFORM_IOS || BX_PLATFORM_VISIONOS
 		return wmi.info.cocoa.window;
 #	elif BX_PLATFORM_WINDOWS
 		return wmi.info.win.window;

--- a/include/bgfx/embedded_shader.h
+++ b/include/bgfx/embedded_shader.h
@@ -34,6 +34,7 @@
 	|| BX_PLATFORM_LINUX                \
 	|| BX_PLATFORM_OSX                  \
 	|| BX_PLATFORM_RPI                  \
+	|| BX_PLATFORM_VISIONOS             \
 	|| BX_PLATFORM_WINDOWS              \
 	)
 #define BGFX_PLATFORM_SUPPORTS_GLSL (0  \
@@ -44,6 +45,7 @@
 #define BGFX_PLATFORM_SUPPORTS_METAL (0 \
 	|| BX_PLATFORM_IOS                  \
 	|| BX_PLATFORM_OSX                  \
+	|| BX_PLATFORM_VISIONOS             \
 	)
 #define BGFX_PLATFORM_SUPPORTS_NVN (0   \
 	|| BX_PLATFORM_NX                   \

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -12,7 +12,7 @@
 
 #include "topology.h"
 
-#if BX_PLATFORM_OSX || BX_PLATFORM_IOS
+#if BX_PLATFORM_OSX || BX_PLATFORM_IOS || BX_PLATFORM_VISIONOS
 #	include <objc/message.h>
 #elif BX_PLATFORM_WINDOWS
 #	ifndef WIN32_LEAN_AND_MEAN
@@ -2413,7 +2413,7 @@ namespace bgfx
 		}
 	}
 
-#if BX_PLATFORM_OSX || BX_PLATFORM_IOS
+#if BX_PLATFORM_OSX || BX_PLATFORM_IOS || BX_PLATFORM_VISIONOS
 	struct NSAutoreleasePoolScope
 	{
 		NSAutoreleasePoolScope()
@@ -2437,7 +2437,7 @@ namespace bgfx
 	{
 		BGFX_PROFILER_SCOPE("bgfx::renderFrame", 0xff2040ff);
 
-#if BX_PLATFORM_OSX || BX_PLATFORM_IOS
+#if BX_PLATFORM_OSX || BX_PLATFORM_IOS || BX_PLATFORM_VISIONOS
 		NSAutoreleasePoolScope pool;
 #endif // BX_PLATFORM_OSX
 
@@ -2635,11 +2635,11 @@ namespace bgfx
 		{ d3d11::rendererCreate,  d3d11::rendererDestroy,  BGFX_RENDERER_DIRECT3D11_NAME, !!BGFX_CONFIG_RENDERER_DIRECT3D11 }, // Direct3D11
 		{ d3d12::rendererCreate,  d3d12::rendererDestroy,  BGFX_RENDERER_DIRECT3D12_NAME, !!BGFX_CONFIG_RENDERER_DIRECT3D12 }, // Direct3D12
 		{ gnm::rendererCreate,    gnm::rendererDestroy,    BGFX_RENDERER_GNM_NAME,        !!BGFX_CONFIG_RENDERER_GNM        }, // GNM
-#if BX_PLATFORM_OSX || BX_PLATFORM_IOS
+#if BX_PLATFORM_OSX || BX_PLATFORM_IOS || BX_PLATFORM_VISIONOS
 		{ mtl::rendererCreate,    mtl::rendererDestroy,    BGFX_RENDERER_METAL_NAME,      !!BGFX_CONFIG_RENDERER_METAL      }, // Metal
 #else
 		{ noop::rendererCreate,   noop::rendererDestroy,   BGFX_RENDERER_NOOP_NAME,       false                             }, // Noop
-#endif // BX_PLATFORM_OSX || BX_PLATFORM_IOS
+#endif // BX_PLATFORM_OSX || BX_PLATFORM_IOS || BX_PLATFORM_VISIONOS
 		{ nvn::rendererCreate,    nvn::rendererDestroy,    BGFX_RENDERER_NVN_NAME,        !!BGFX_CONFIG_RENDERER_NVN        }, // NVN
 		{ gl::rendererCreate,     gl::rendererDestroy,     BGFX_RENDERER_OPENGL_NAME,     !!BGFX_CONFIG_RENDERER_OPENGLES   }, // OpenGLES
 		{ gl::rendererCreate,     gl::rendererDestroy,     BGFX_RENDERER_OPENGL_NAME,     !!BGFX_CONFIG_RENDERER_OPENGL     }, // OpenGL
@@ -2737,7 +2737,7 @@ namespace bgfx
 					score += RendererType::Metal    == renderer ? 20 : 0;
 					score += RendererType::Vulkan   == renderer ? 10 : 0;
 				}
-				else if (BX_ENABLED(BX_PLATFORM_IOS) )
+				else if (BX_ENABLED(BX_PLATFORM_IOS) || BX_ENABLED(BX_PLATFORM_VISIONOS))
 				{
 					score += RendererType::Metal    == renderer ? 20 : 0;
 				}

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,7 @@
 #		define BGFX_CONFIG_RENDERER_METAL (0 \
 					|| BX_PLATFORM_IOS       \
 					|| BX_PLATFORM_OSX       \
+					|| BX_PLATFORM_VISIONOS \
 					? 1 : 0)
 #	endif // BGFX_CONFIG_RENDERER_METAL
 

--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -1160,6 +1160,7 @@ namespace bgfx
 		preprocessor.setDefaultDefine("BX_PLATFORM_ANDROID");
 		preprocessor.setDefaultDefine("BX_PLATFORM_EMSCRIPTEN");
 		preprocessor.setDefaultDefine("BX_PLATFORM_IOS");
+		preprocessor.setDefaultDefine("BX_PLATFORM_VISIONOS");
 		preprocessor.setDefaultDefine("BX_PLATFORM_LINUX");
 		preprocessor.setDefaultDefine("BX_PLATFORM_OSX");
 		preprocessor.setDefaultDefine("BX_PLATFORM_PS4");
@@ -1225,11 +1226,18 @@ namespace bgfx
 				preprocessor.setDefine(glslDefine);
 			}
 		}
-		else if (0 == bx::strCmpI(platform, "ios") || (0 == bx::strCmpI(platform, "osx")) )
+		else if (
+			0 == bx::strCmpI(platform, "ios") ||
+			0 == bx::strCmpI(platform, "osx") ||
+			0 == bx::strCmpI(platform, "visionos")
+		)
 		{
 			if (0 == bx::strCmpI(platform, "osx"))
 			{
 				preprocessor.setDefine("BX_PLATFORM_OSX=1");
+			}
+			else if (0 == bx::strCmpI(platform, "visionos")) {
+				preprocessor.setDefine("BX_PLATFORM_VISIONOS=1");
 			}
 			else
 			{


### PR DESCRIPTION
Hello,

This PR adds visionOS support to bgfx. It's the continuation of [this PR](https://github.com/bkaradzic/bx/pull/323) which added support to `bx` library. I've worked on this together with @mani3xis.


Apple Vision uses bgfx in single threaded mode (`BGFX_CONFIG_MULTITHREADED = 0`), but the example framework isn't really working nice with single threaded mode, so there might be some crashes in the examples but it works great when integrated separately.


![Simulator Screenshot - Apple Vision Pro - 2024-05-09 at 11 27 58](https://github.com/bkaradzic/bgfx/assets/52801365/5afe828a-8bac-42c3-967f-a918f5ba1877)
