### PR TITLE
use BX_MAKEFOURCC in shaderc_hlsl.cpp

### DIFF
--- a/tools/shaderc/shaderc_hlsl.cpp
+++ b/tools/shaderc/shaderc_hlsl.cpp
@@ -287,7 +287,7 @@ namespace bgfx { namespace hlsl
 		const uint32_t D3DSIO_END = 0x0000FFFF;
 		const uint32_t D3DSI_OPCODE_MASK = 0x0000FFFF;
 		const uint32_t D3DSI_COMMENTSIZE_MASK = 0x7FFF0000;
-		const uint32_t CTAB_CONSTANT = MAKEFOURCC('C', 'T', 'A', 'B');
+		const uint32_t CTAB_CONSTANT = BX_MAKEFOURCC('C', 'T', 'A', 'B');
 
 		// parse the shader blob for the constant table
 		const size_t codeSize = _code->GetBufferSize();


### PR DESCRIPTION
Fixes "error: 'MAKEFOURCC' was not declared in this scope", when compiling with mingw64. 
The macro (in the bx library) is slightly different from the one found in the system header <mmsyscom.h> (which isn't included in the source), but with values under a byte, the result is the same. 