### PR TITLE
Vulkan: improve staging data performance by using scratch buffers per frame.

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -2537,6 +2537,7 @@ namespace bgfx
 
 	void Context::flushTextureUpdateBatch(CommandBuffer& _cmdbuf)
 	{
+		BGFX_PROFILER_SCOPE("flushTextureUpdateBatch", 0xff2040ff);
 		if (m_textureUpdateBatch.sort() )
 		{
 			const uint32_t pos = _cmdbuf.m_pos;

--- a/src/config.h
+++ b/src/config.h
@@ -323,6 +323,22 @@ BX_STATIC_ASSERT(bx::isPowerOf2(BGFX_CONFIG_MAX_VIEWS), "BGFX_CONFIG_MAX_VIEWS m
 #	define BGFX_CONFIG_TRANSIENT_INDEX_BUFFER_SIZE (2<<20)
 #endif // BGFX_CONFIG_TRANSIENT_INDEX_BUFFER_SIZE
 
+#ifndef BGFX_CONFIG_PER_FRAME_SCRATCH_STAGING_BUFFER_SIZE
+/// Amount of scratch buffer size (per in-flight frame) that will be reserved
+/// for staging data for copying to the device (such as vertex buffer data,
+/// texture data, etc). This buffer will be used instead of allocating memory
+/// on device separately for every data copy.
+/// Note: Currently only used by the Vulkan backend.
+#   define BGFX_CONFIG_PER_FRAME_SCRATCH_STAGING_BUFFER_SIZE (32<<20)
+#endif
+
+#ifndef BGFX_CONFIG_MAX_STAGING_SIZE_FOR_SCRACH_BUFFER
+/// The threshold of data size above which the staging scratch buffer will
+/// not be used, but instead a separate device memory allocation will take
+/// place to stage the data for copying to device.
+#   define BGFX_CONFIG_MAX_STAGING_SIZE_FOR_SCRACH_BUFFER (16 << 20)
+#endif
+
 #ifndef BGFX_CONFIG_MAX_INSTANCE_DATA_COUNT
 #	define BGFX_CONFIG_MAX_INSTANCE_DATA_COUNT 5
 #endif // BGFX_CONFIG_MAX_INSTANCE_DATA_COUNT

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -389,6 +389,15 @@ VK_DESTROY_FUNC(DescriptorSet);
 		HashMap m_hashMap;
 	};
 
+	struct StagingBufferVK {
+		VkBuffer m_buffer;
+		VkDeviceMemory m_deviceMem;
+		uint8_t *m_data;
+		uint32_t m_size;
+		uint32_t m_offset;
+		bool m_isFromScratch;
+	};
+
 	class ScratchBufferVK
 	{
 	public:
@@ -400,7 +409,9 @@ VK_DESTROY_FUNC(DescriptorSet);
 		{
 		}
 
-		void create(uint32_t _size, uint32_t _count);
+		void create(uint32_t _size, uint32_t _count, VkBufferUsageFlags _usage, uint32_t align);
+		void createUniform(uint32_t _size, uint32_t _count);
+		void createStaging(uint32_t _size);
 		void destroy();
 		void reset();
 		uint32_t write(const void* _data, uint32_t _size);
@@ -411,6 +422,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 		uint8_t* m_data;
 		uint32_t m_size;
 		uint32_t m_pos;
+		uint32_t m_align;
 	};
 
 	struct BufferVK


### PR DESCRIPTION
Opening this PR to have a discussion on the work I did to improve performance of streaming data in the Vulkan backend. Will put as draft for now.

A few before/after profiling screenshots for regular SilverNode usage (simply navigating UI and rerendering UI every frame with vg-renderer):

 - UpdateDynamicVertexBuffer:
   ![UpdateDynamicVertexBuffer](https://github.com/bkaradzic/bgfx/assets/845012/dea745d5-8470-4b26-83d4-eab28f490e22)
 - bgfx::frame():
   ![frame](https://github.com/bkaradzic/bgfx/assets/845012/7ffee8ff-975d-4eff-a198-4d7451b38118)
 - Exec commands pre
   ![submit](https://github.com/bkaradzic/bgfx/assets/845012/6f25181c-d2d7-4d11-8cc3-487ceb5f5e18)
 - ContextVK::submit
   ![image](https://github.com/bkaradzic/bgfx/assets/845012/e29951e3-0182-4739-ab8b-ed0f5c8f4e5d)
 - CommandQueueVK::finish():
   ![image](https://github.com/bkaradzic/bgfx/assets/845012/87bece95-7628-4096-b401-b32988f76911)

These zones were profiled thanks to additional profiled scopes (also in this PR).
Now most of the runtime of the vulkan backend is actually timed if the profiler is enabled:
![image](https://github.com/bkaradzic/bgfx/assets/845012/a5765126-c68b-4a7f-8a28-ceeddd597d89)
