### PR TITLE
Fix adapter object leak when there are more than 4 graphics cards

### DIFF
--- a/src/dxgi.cpp
+++ b/src/dxgi.cpp
@@ -278,7 +278,7 @@ namespace bgfx
 		{
 			AdapterI* adapter;
 			for (uint32_t ii = 0
-				; DXGI_ERROR_NOT_FOUND != m_factory->EnumAdapters(ii, reinterpret_cast<IDXGIAdapter**>(&adapter) ) && ii < BX_COUNTOF(_caps.gpu)
+				; ii < BX_COUNTOF(_caps.gpu) && DXGI_ERROR_NOT_FOUND != m_factory->EnumAdapters(ii, reinterpret_cast<IDXGIAdapter**>(&adapter) )
 				; ++ii
 				)
 			{


### PR DESCRIPTION
when my computer have more than 4 gpus, it's break on close when call `DX_RELEASE(m_factory, 0)` at function `Dxgi::shutdown()`
because there is an `AdapterI` object leak if gpu count more than `BX_COUNTOF(_caps.gpu)`, it's should compare first then call `EnumAdapters`

fix #3305 