### PR TITLE
Make the semaphore pool larger, such that there are enough for any number of swapchain images AND frames in flight.

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -7092,7 +7092,10 @@ VK_DESTROY
 		sci.pNext = NULL;
 		sci.flags = 0;
 
-		for (uint32_t ii = 0; ii < m_numSwapchainImages; ++ii)
+		// We will make a fully filled pool of semaphores and cycle through those.
+		// This is to make sure we have enough, even in the case where there are
+		// more frames in flight than images on the swapchain.
+		for (uint32_t ii = 0; ii < kMaxBackBuffers; ++ii)
 		{
 			if (VK_SUCCESS != vkCreateSemaphore(device, &sci, allocatorCb, &m_presentDoneSemaphore[ii])
 			||  VK_SUCCESS != vkCreateSemaphore(device, &sci, allocatorCb, &m_renderDoneSemaphore[ii]) )
@@ -7118,7 +7121,10 @@ VK_DESTROY
 			release(m_backBufferColorImageView[ii]);
 
 			m_backBufferFence[ii] = VK_NULL_HANDLE;
+		}
 
+		for (uint32_t ii = 0; ii < kMaxBackBuffers; ++ii)
+		{
 			release(m_presentDoneSemaphore[ii]);
 			release(m_renderDoneSemaphore[ii]);
 		}
@@ -7419,7 +7425,7 @@ VK_DESTROY
 
 			m_lastImageAcquiredSemaphore = m_presentDoneSemaphore[m_currentSemaphore];
 			m_lastImageRenderedSemaphore = m_renderDoneSemaphore[m_currentSemaphore];
-			m_currentSemaphore = (m_currentSemaphore + 1) % m_numSwapchainImages;
+			m_currentSemaphore = (m_currentSemaphore + 1) % kMaxBackBuffers;
 
 			VkResult result;
 			{


### PR DESCRIPTION
Constructed this together with @pezcode.

This very simple change fixes the issue on my device.

Summary:

 - my device made a swapchain of 2 images.
 - bgfx has by default a max frame latency of 3; so 3 frames in flight.
 - there is therefore missing one semaphore to have enough for the 3 frames in flight.

This fixes #3302 and replaces #3303.