### PR TITLE
example-08-update: Scan through the LODs of the textures with shader.

### DIFF
--- a/examples/08-update/fs_update.sc
+++ b/examples/08-update/fs_update.sc
@@ -8,8 +8,10 @@ $input v_texcoord0
 #include "../common/common.sh"
 
 SAMPLERCUBE(s_texCube, 0);
+uniform vec4 u_time;
 
 void main()
 {
-	gl_FragColor = textureCube(s_texCube, v_texcoord0);
+	float lod = (1.0 - cos(u_time.x)) * 4.0; // 0 to 8
+	gl_FragColor = textureCubeLod(s_texCube, v_texcoord0, lod);
 }

--- a/examples/08-update/fs_update_cmp.sc
+++ b/examples/08-update/fs_update_cmp.sc
@@ -9,7 +9,10 @@ $input v_texcoord0
 
 SAMPLER2D(s_texColor, 0);
 
+uniform vec4 u_time;
+
 void main()
 {
-	gl_FragColor = texture2D(s_texColor, v_texcoord0.xy*0.5+0.5);
+	float lod = (1.0 - cos(u_time.x)) * 4.0; // 0 to 8
+	gl_FragColor = texture2DLod(s_texColor, v_texcoord0.xy*0.5+0.5, lod);
 }

--- a/examples/08-update/update.cpp
+++ b/examples/08-update/update.cpp
@@ -761,7 +761,7 @@ public:
 				if (bgfx::isValid(m_textureCube[ii]))
 				{
 					float mtx[16];
-					bx::mtxSRT(mtx, 0.65f, 0.65f, 0.65f, time, time*0.37f, 0.0f, -2.5f +ii*1.8f, 0.0f, 0.0f);
+					bx::mtxSRT(mtx, 0.65f, 0.65f, 0.65f, time, time*0.37f, 0.0f, -2.5f +ii*1.8f, 0.3f, 0.0f);
 
 					// Set model matrix for rendering.
 					bgfx::setTransform(mtx);
@@ -788,7 +788,7 @@ public:
 
 			const float aspectRatio = float(m_height)/float(m_width);
 			const float margin = 0.7f;
-			const float sizeX = 0.5f * numColumns * 2.3f + margin;
+			const float sizeX = 0.5f * (numColumns + 2) * 2.3f + margin;
 			const float sizeY = sizeX * aspectRatio;
 
 			const bgfx::Caps* caps = bgfx::getCaps();
@@ -798,7 +798,7 @@ public:
 			bx::mtxMul(worldToScreen, proj, projToScreen);
 
 			float mtx[16];
-			bx::mtxTranslate(mtx, -sizeX + margin + 1.0f, 1.9f, 0.0f);
+			bx::mtxTranslate(mtx, -sizeX + margin + 1.0f, 0.0f, 0.0f);
 
 			// Set model matrix for rendering.
 			bgfx::setTransform(mtx);
@@ -851,7 +851,7 @@ public:
 
 			for (uint32_t ii = 0; ii < BX_COUNTOF(m_textures); ++ii)
 			{
-				bx::mtxTranslate(mtx, xpos + (ii%numColumns) * 2.3f, sizeY - margin - 2.8f + (ii/numColumns) * 2.3f, 0.0f);
+				bx::mtxTranslate(mtx, xpos + (1+ii%numColumns) * 2.3f, sizeY - margin - 2.8f + (ii/numColumns) * 2.3f, 0.0f);
 
 				// Set model matrix for rendering.
 				bgfx::setTransform(mtx);


### PR DESCRIPTION
I have not committed the binary shaders because when I rebuild them, literally all shaders gets modified, which is not on-topic for this PR, so I'll leave that to @bkaradzic.

I also updated the positions a little bit to reduce overlap:

![image](https://github.com/bkaradzic/bgfx/assets/845012/4985577b-c042-4721-bcc0-e1977b8d2034)

So this PR uses time to loop through the different LODs.

![image](https://github.com/bkaradzic/bgfx/assets/845012/09517cec-6ad9-468b-b592-084aa68f89bf)

This immediately reveals some issues:

Vulkan:

https://github.com/bkaradzic/bgfx/assets/845012/0403ab8c-7a92-411e-9286-9fb00144361a

OpenGL:


https://github.com/bkaradzic/bgfx/assets/845012/161c04a8-5a8a-4d1d-a903-3048feaa9930

ETC1 is flickering badly in deeper LODs.