### PR TITLE
Use correct GLSL shader version if onyl gl_VertexID is used

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -6546,6 +6546,7 @@ namespace bgfx { namespace gl
 						|| usesVertexID
 						|| usesUint
 						|| usesTexelFetch
+					    || usesGpuShader4
 						|| usesGpuShader5
 						|| usesInterpQ
 						? 130


### PR DESCRIPTION
Fixes GLSL shader compile errors due to wrong `#version 120` instead of `#version 130`.

Before setting the version the following checks are performed:

```c++
const bool usesVertexID = true
						&& !s_extension[Extension::EXT_gpu_shader4].m_supported
						&& !bx::findIdentifierMatch(code, "gl_VertexID").isEmpty()
						;
...
const bool usesGpuShader4 = true
						&& s_extension[Extension::EXT_gpu_shader4].m_supported
						&& !bx::findIdentifierMatch(code, s_EXT_gpu_shader4).isEmpty()
						;
```

So if `s_extension[Extension::EXT_gpu_shader4].m_supported` evaluates to `true` and we use a shader that only uses `gl_VertexID` we will get `usesVertexID=false` and `usesGpuShader4=true`. 

This leads to the version not recognizing that version `130` is necessary (https://registry.khronos.org/OpenGL-Refpages/gl4/html/gl_VertexID.xhtml).

Vertex Shader that fails to compile:
```glsl
$input a_position, i_data0, i_data1
$output v_texcoord0

#include <bgfx/bgfx_shader.sh>

uniform vec4 u_textureSize;
void main()
{
    // Unpack Data
    vec2 pos = i_data0.xy;
    vec2 spriteSizePx = i_data0.zw;
    vec2 textureOffsetPx = i_data1.xy;

    // Calculate Position
    vec2 posScaleFactor = spriteSizePx / 32.0;

    gl_Position = mul(u_modelViewProj, vec4((a_position*posScaleFactor) + pos, 0.0, 1.0) );

    // Calculate Texture Coords
    vec2 upper = textureOffsetPx + spriteSizePx;
    vec2 lowerUV = textureOffsetPx / u_textureSize.xy;
    vec2 upperUV = upper / u_textureSize.xy;

    if (gl_VertexID == 0) {
        v_texcoord0 = lowerUV;
    } else if (gl_VertexID == 1) {
        v_texcoord0 = vec2(upperUV.x, lowerUV.y);
    } else if (gl_VertexID == 2) {
        v_texcoord0 = vec2(lowerUV.x, upperUV.y);
    } else if (gl_VertexID == 3) {
        v_texcoord0 = upperUV;
    }
}
```