### PR TITLE
Minimal changes for Vulkan support on NX.

### DIFF
--- a/include/bgfx/embedded_shader.h
+++ b/include/bgfx/embedded_shader.h
@@ -56,6 +56,7 @@
 	|| BX_PLATFORM_LINUX                \
 	|| BX_PLATFORM_WINDOWS              \
 	|| BX_PLATFORM_OSX                  \
+	|| BX_PLATFORM_NX                   \
 	)
 
 ///

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -6709,7 +6709,11 @@ VK_DESTROY
 			m_sci.imageSharingMode      = VK_SHARING_MODE_EXCLUSIVE;
 			m_sci.queueFamilyIndexCount = 0;
 			m_sci.pQueueFamilyIndices   = NULL;
+			#ifdef BX_PLATFORM_NX
+			m_sci.preTransform          = VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR;
+			#else
 			m_sci.preTransform          = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+			#endif
 			m_sci.oldSwapchain          = VK_NULL_HANDLE;
 
 			for (uint32_t ii = 0; ii < BX_COUNTOF(m_backBufferColorImageView); ++ii)


### PR DESCRIPTION
I have a fully working version of bgfx running on the Nintendo Switch, rendering via Vulkan. Unfortunately due to the licensing of the Switch SDK I have to be careful of what code I can publish. This is the first step, sharing a little bit of code that is not closely tied to Nintendo.

This works together with https://github.com/bkaradzic/bx/pull/332.