### PR TITLE
fix: properly set viewports and render targets for Apple Vision Pro

### DIFF
--- a/src/renderer_mtl.h
+++ b/src/renderer_mtl.h
@@ -435,6 +435,11 @@ namespace bgfx { namespace mtl
 			[m_obj setBlendColorRed:_red green:_green blue:_blue alpha:_alpha];
 		}
 
+		void setVertexAmplificationCount(NSUInteger count, MTLVertexAmplificationViewMapping* viewMappings)
+		{
+			[m_obj setVertexAmplificationCount:count viewMappings:viewMappings];
+		}
+
 		void setCullMode(MTLCullMode _cullMode)
 		{
 			[m_obj setCullMode:_cullMode];
@@ -478,6 +483,11 @@ namespace bgfx { namespace mtl
 		void setViewport(MTLViewport _viewport)
 		{
 			[m_obj setViewport:_viewport];
+		}
+
+		void setViewports(MTLViewport _viewport[], NSInteger count)
+		{
+			[m_obj setViewports:_viewport count:count];
 		}
 
 		void setVisibilityResultMode(MTLVisibilityResultMode _mode, NSUInteger _offset)
@@ -1061,6 +1071,7 @@ namespace bgfx { namespace mtl
 
 #if BX_PLATFORM_VISIONOS
         cp_layer_renderer_t m_layerRenderer;
+        cp_layer_renderer_configuration_t m_layerRendererConfiguration;
         cp_frame_t m_frame;
         cp_drawable_t m_drawable;
 #else


### PR DESCRIPTION
This PR partially fixes issues with bgfx rendering on Apple Vision Pro devices. It aims to fix issues described in this Tweet: https://x.com/o_kwasniewski/status/1811313113527992391

Here is the outline of what this PR is doing: 

- Correctly calculate and set the viewports for each eye
- Retrieve configuration `layer_renderer`
- Set Vertex Amplification to make both eyes see the content. (MRT - multiple render targets)
- Fixes issues with frame rendering function calls (now it's following Apple docs)
- Properly sets fields on renderPassDescriptor
- Warns users that `BFGX does not support .dedicated` layout at this point