### PR TITLE
Replace ALooper_pollAll with ALooper_pollOnce

### DIFF
--- a/examples/common/entry/entry_android.cpp
+++ b/examples/common/entry/entry_android.cpp
@@ -189,9 +189,10 @@ namespace entry
 
 			while (0 == m_app->destroyRequested)
 			{
-				int32_t num;
 				android_poll_source* source;
-				/*int32_t id =*/ ALooper_pollAll(-1, NULL, &num, (void**)&source);
+				int32_t result = ALooper_pollOnce(-1, NULL, NULL, reinterpret_cast<void**>(&source));
+
+				BX_ASSERT(ALOOPER_POLL_ERROR != result, "ALooper_pollOnce returned an error.");
 
 				if (NULL != source)
 				{


### PR DESCRIPTION
Fixes #3333 

Since the android entry is very close to android samples, the changes were heavily inspired by https://github.com/android/ndk-samples/pull/1008
Tested with https://github.com/gsfare/bgfx-android-examples on a pixel 7 pro with NDK r26.
Successfully compiles with r27.