### PR TITLE
Fix: Only adjust view rect if it uses custom FrameBuffer with textures using BackbufferRatio

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1413,7 +1413,6 @@ namespace bgfx
 			viewRemap[m_viewRemap[ii] ] = ViewId(ii);
 
 			View& view = m_view[ii];
-			Rect rect(0, 0, uint16_t(m_resolution.width), uint16_t(m_resolution.height) );
 
 			if (isValid(view.m_fbh) )
 			{
@@ -1425,20 +1424,17 @@ namespace bgfx
 
 				if (BackbufferRatio::Count != bbRatio)
 				{
+                    Rect rect(0, 0, uint16_t(m_resolution.width), uint16_t(m_resolution.height) );
+
 					getTextureSizeFromRatio(bbRatio, rect.m_width, rect.m_height);
-				}
-				else
-				{
-					rect.m_width  = fbr.m_width;
-					rect.m_height = fbr.m_height;
-				}
-			}
 
-			view.m_rect.intersect(rect);
+                    view.m_rect.intersect(rect);
 
-			if (!view.m_scissor.isZero() )
-			{
-				view.m_scissor.intersect(rect);
+                    if (!view.m_scissor.isZero() )
+                    {
+                        view.m_scissor.intersect(rect);
+                    }
+				}
 			}
 		}
 


### PR DESCRIPTION
In case a framebuffer would be created with textures with custom dimensions instead of using BackbufferRatio the existing code can write incorrect predefined uniforms to the shaders. In a case that the window has 1280x720 resolution (m_resolution = {1280, 720}) and the custom framebuffer being set to textures with 3840x2160 resolution the existing code will adjust the m_view from any value set in the user code to {*, *, 1280, 720} thus putting several invalid predefined uniforms in the shaders.

This fix should only do that for framebuffers that are related to the m_resolution using the BackbufferRatio feature, other ones are ignored and the m_view value is not touched.