### PR TITLE
egl: Release per-thread resources before unloading

### DIFF
--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -71,6 +71,7 @@ namespace bgfx { namespace gl
 	EGL_IMPORT_FUNC(PFNEGLGETPROCADDRESSPROC,       eglGetProcAddress);       \
 	EGL_IMPORT_FUNC(PFNEGLINITIALIZEPROC,           eglInitialize);           \
 	EGL_IMPORT_FUNC(PFNEGLMAKECURRENTPROC,          eglMakeCurrent);          \
+	EGL_IMPORT_FUNC(PFNEGLRELEASETHREADPROC,        eglReleaseThread);        \
 	EGL_IMPORT_FUNC(PFNEGLSWAPBUFFERSPROC,          eglSwapBuffers);          \
 	EGL_IMPORT_FUNC(PFNEGLSWAPINTERVALPROC,         eglSwapInterval);         \
 	EGL_IMPORT_FUNC(PFNEGLTERMINATEPROC,            eglTerminate);            \
@@ -433,6 +434,7 @@ EGL_IMPORT
 			m_context = NULL;
 		}
 
+		EGL_CHECK(eglReleaseThread() );
 		eglClose(m_eglLibrary);
 
 #	if BX_PLATFORM_RPI


### PR DESCRIPTION
Release EGL's per-thread resources before unloading the EGL library to avoid a potential crash when the render thread is terminated.