### PR TITLE
fix: visionOS 1.2 build errors

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3502,6 +3502,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 				release(m_metalLayer);
 			}
 			
+#if !BX_PLATFORM_VISIONOS
 			if (NULL != NSClassFromString(@"MTKView") )
 			{
 				MTKView *view = (MTKView *)_nwh;
@@ -3512,6 +3513,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 					m_metalLayer = (CAMetalLayer *)view.layer;
 				}
 			}
+#endif
 			
 			if (NULL != NSClassFromString(@"CAMetalLayer") )
 			{


### PR DESCRIPTION
This PR fixes visionOS 1.2 build errors. 

I've checked the previous PR on visionOS 2.0 (which supports MTKView) but 1.2 doesn't, causing a build error. 

Everything still works after this change, it's just not trying to reference MTKView anymore. 

Screenshot from Babylon Native flat rendering integration.

![CleanShot 2024-08-28 at 17 44 23@2x](https://github.com/user-attachments/assets/7aafe4a0-8476-4612-a90a-1052cbd543d4)
