### PR TITLE
Fix a crash in renderer_d3d12.cpp

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -858,9 +858,9 @@ namespace bgfx { namespace d3d12
 									{
 										debug1->SetEnableSynchronizedCommandQueueValidation(false);
 									}
-								}
 
-								DX_RELEASE(debug1, 1);
+									DX_RELEASE(debug1, 1);
+								}
 							}
 #endif // BX_PLATFORM_WINDOWS
 						}


### PR DESCRIPTION
If querying the debug1 interface fails, don't attempt to release it.