### PR TITLE
Fixed: BGFX_TEXTURE_MSAA_SAMPLE and msaa sampling bugs

### DIFF
--- a/3rdparty/glsl-optimizer/src/glsl/ir_print_glsl_visitor.cpp
+++ b/3rdparty/glsl-optimizer/src/glsl/ir_print_glsl_visitor.cpp
@@ -954,7 +954,7 @@ void ir_print_glsl_visitor::visit(ir_texture *ir)
 	ir->coordinate->accept(this);
 	
 	// lod
-	if (ir->op == ir_txl || ir->op == ir_txf || ir->op == ir_txf_ms)
+	if (ir->op == ir_txl || ir->op == ir_txf)
 	{
 		buffer.asprintf_append (", ");
 		ir->lod_info.lod->accept(this);

--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4535,13 +4535,13 @@ namespace bgfx
 				++depth;
 
 				BGFX_ERROR_CHECK(
-					// if BGFX_TEXTURE_RT_MSAA_X2 or greater than BGFX_TEXTURE_RT_WRITE_ONLY is required
-					// if BGFX_TEXTURE_RT with no MSSA then WRITE_ONLY is not required.
+					// if BGFX_TEXTURE_RT_MSAA_X2 or greater than either BGFX_TEXTURE_RT_WRITE_ONLY or BGFX_TEXTURE_MSAA_SAMPLE is required 
+					// if BGFX_TEXTURE_RT with no MSSA then this is not required.
 					(1 == ((tr.m_flags & BGFX_TEXTURE_RT_MSAA_MASK) >> BGFX_TEXTURE_RT_MSAA_SHIFT))
-					|| (0 != (tr.m_flags & BGFX_TEXTURE_RT_WRITE_ONLY))
+					|| (0 != (tr.m_flags & (BGFX_TEXTURE_RT_WRITE_ONLY | BGFX_TEXTURE_MSAA_SAMPLE)))
 					, _err
 					, BGFX_ERROR_FRAME_BUFFER_VALIDATION
-					, "Frame buffer depth MSAA texture cannot be resolved. It must be created with `BGFX_TEXTURE_RT_WRITE_ONLY` flag."
+					, "Frame buffer depth MSAA texture cannot be resolved. It must be created with either `BGFX_TEXTURE_RT_WRITE_ONLY` or `BGFX_TEXTURE_MSAA_SAMPLE` flag."
 					, "Attachment %d, texture flags 0x%016" PRIx64 "."
 					, ii
 					, tr.m_flags

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -7101,7 +7101,7 @@ namespace bgfx { namespace gl
 					{
 						const TextureGL& texture = s_renderGL->m_textures[at.handle.idx];
 
-						if (0 != texture.m_id)
+						if (0 != texture.m_rbo && 0 != texture.m_id)
 						{
 
 							GLenum attachment = GL_INVALID_ENUM;

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -1479,7 +1479,7 @@ namespace bgfx { namespace gl
 				, _internalFormat
 				, _width
 				, _height
-				, false
+				, true
 				);
 		}
 		else


### PR DESCRIPTION
BGFX_TEXTURE_MSAA_SAMPLE wasn't usable with multiple attachments.
Depth attachments couldn't be used with BGFX_TEXTURE_MSAA_SAMPLE.
Using texelFetch with Sampler2DMS would result in shader errors.