### PR TITLE
Improve NX Vulkan support.

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -7022,6 +7022,16 @@ VK_DESTROY
 				result = vkCreateMacOSSurfaceMVK(instance, &sci, allocatorCb, &m_surface);
 			}
 		}
+#elif BX_PLATFORM_NX
+		if (NULL != vkCreateViSurfaceNN)
+		{
+			VkViSurfaceCreateInfoNN sci;
+			sci.sType  = VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN;
+			sci.pNext  = NULL;
+			sci.flags  = 0;
+			sci.window = m_nwh;
+			result = vkCreateViSurfaceNN(instance, &sci, allocatorCb, &m_surface);
+		}
 #else
 #	error "Figure out KHR surface..."
 #endif // BX_PLATFORM_

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -31,6 +31,10 @@
 #	define VK_USE_PLATFORM_MACOS_MVK
 #	define KHR_SURFACE_EXTENSION_NAME  VK_MVK_MACOS_SURFACE_EXTENSION_NAME
 #	define VK_IMPORT_INSTANCE_PLATFORM VK_IMPORT_INSTANCE_MACOS
+#elif BX_PLATFORM_NX
+# define VK_USE_PLATFORM_VI_NN
+#	define KHR_SURFACE_EXTENSION_NAME  VK_NN_VI_SURFACE_EXTENSION_NAME
+#	define VK_IMPORT_INSTANCE_PLATFORM VK_IMPORT_INSTANCE_NX
 #else
 #	define KHR_SURFACE_EXTENSION_NAME ""
 #	define VK_IMPORT_INSTANCE_PLATFORM
@@ -101,6 +105,10 @@
 #define VK_IMPORT_INSTANCE_MACOS                                     \
 			/* VK_MVK_macos_surface */                               \
 			VK_IMPORT_INSTANCE_FUNC(true,  vkCreateMacOSSurfaceMVK); \
+
+#define VK_IMPORT_INSTANCE_NX \
+			/* VK_NN_vi_surface */                              \
+			VK_IMPORT_INSTANCE_FUNC(true, vkCreateViSurfaceNN); \
 
 #define VK_IMPORT_INSTANCE                                                             \
 			VK_IMPORT_INSTANCE_FUNC(false, vkDestroyInstance);                         \


### PR DESCRIPTION
This change was developed using publicly available information found in Vulkan headers and official documentation. No proprietary NX resources were used.

This is a smaller alternative to #3356 based on comments in that PR.