### PR TITLE
Dynamically load libwayland-egl.so.1 when dealing with Wayland.

### DIFF
--- a/examples/common/entry/entry_sdl.cpp
+++ b/examples/common/entry/entry_sdl.cpp
@@ -8,9 +8,6 @@
 #if ENTRY_CONFIG_USE_SDL
 
 #if BX_PLATFORM_LINUX
-#	if ENTRY_CONFIG_USE_WAYLAND
-#		include <wayland-egl.h>
-#	endif
 #elif BX_PLATFORM_WINDOWS
 #	define SDL_MAIN_HANDLED
 #endif
@@ -68,16 +65,6 @@ namespace entry
 	{
 		if(!_window)
 			return;
-#	if BX_PLATFORM_LINUX
-#		if ENTRY_CONFIG_USE_WAYLAND
-		wl_egl_window *win_impl = (wl_egl_window*)SDL_GetWindowData(_window, "wl_egl_window");
-		if(win_impl)
-		{
-			SDL_SetWindowData(_window, "wl_egl_window", nullptr);
-			wl_egl_window_destroy(win_impl);
-		}
-#		endif
-#	endif
 		SDL_DestroyWindow(_window);
 	}
 

--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -22,7 +22,7 @@ newoption {
 
 newoption {
 	trigger = "with-wayland",
-	description = "Use Wayland backend.",
+	description = "Enable Wayland support.",
 }
 
 newoption {
@@ -235,13 +235,6 @@ function exampleProjectDefaults()
 		defines { "ENTRY_CONFIG_USE_SDL=1" }
 		links   { "SDL2" }
 
-		configuration { "linux or freebsd" }
-			if _OPTIONS["with-wayland"]  then
-				links {
-					"wayland-egl",
-				}
-			end
-
 		configuration { "osx*" }
 			libdirs { "$(SDL2_DIR)/lib" }
 
@@ -253,19 +246,13 @@ function exampleProjectDefaults()
 		links   { "glfw3" }
 
 		configuration { "linux or freebsd" }
-			if _OPTIONS["with-wayland"] then
-				links {
-					"wayland-egl",
-				}
-			else
-				links {
-					"Xrandr",
-					"Xinerama",
-					"Xi",
-					"Xxf86vm",
-					"Xcursor",
-				}
-			end
+			links {
+				"Xrandr",
+				"Xinerama",
+				"Xi",
+				"Xxf86vm",
+				"Xcursor",
+			}
 
 		configuration { "osx*" }
 			linkoptions {

--- a/src/glcontext_egl.h
+++ b/src/glcontext_egl.h
@@ -37,6 +37,7 @@ namespace bgfx { namespace gl
 			, m_display(NULL)
 			, m_surface(NULL)
 #if BX_PLATFORM_LINUX && defined(WL_EGL_PLATFORM)
+			, m_waylandEglLibrary(NULL)
 			, m_egl_window(NULL)
 #endif
 			, m_msaaContext(false)
@@ -67,6 +68,7 @@ namespace bgfx { namespace gl
 		EGLDisplay m_display;
 		EGLSurface m_surface;
 #if BX_PLATFORM_LINUX && defined(WL_EGL_PLATFORM)
+		void *m_waylandEglLibrary;
 		struct wl_egl_window *m_egl_window;
 #endif
 		// true when MSAA is handled by the context instead of using MSAA FBO


### PR DESCRIPTION
Follow-up on #3358. Tested with SilverNode and the examples under both Vulkan (irrelevant) and EGL (relevant).

Confirmed that libwayland-egl.so is no longer linked:

```cpp
❯ ldd .build/linux64_gcc/bin/example-06-bumpRelease
	linux-vdso.so.1 (0x00007f9005562000)
	libSDL2-2.0.so.0 => /lib64/libSDL2-2.0.so.0 (0x00007f9005373000)
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x00007f9005000000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f900528f000)
	libmvec.so.1 => /lib64/libmvec.so.1 (0x00007f9004f06000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f9004d15000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f9005564000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007f9004ce7000)
```
