### PR TITLE
Fix compiling entry_noop

### DIFF
--- a/examples/common/entry/entry_noop.cpp
+++ b/examples/common/entry/entry_noop.cpp
@@ -80,7 +80,6 @@ namespace entry
 
 	bgfx::NativeWindowHandleType::Enum getNativeWindowHandleType()
 	{
-		BX_UNUSED(_handle);
 		return bgfx::NativeWindowHandleType::Default;
 	}
 


### PR DESCRIPTION
_handle no longer exists in getNativeWindowHandleType so this would not compile