### PR TITLE
Fix: Fix Uniform buffer doing too many iterations when updating renderer uniforms

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1313,10 +1313,8 @@ namespace bgfx
 
 		m_draw.clear(_flags);
 		m_bind.clear(_flags);
-		if (_flags & BGFX_DISCARD_STATE)
-		{
-			m_uniformBegin = m_uniformEnd;
-		}
+
+		m_uniformBegin = m_uniformEnd;
 	}
 
 	void EncoderImpl::dispatch(ViewId _id, ProgramHandle _handle, uint32_t _numX, uint32_t _numY, uint32_t _numZ, uint8_t _flags)


### PR DESCRIPTION
When rendering 1275 drawcalls with heavy uniform use without discarding textures and uniforms, I was having terrible performance, worse than when discarding.

While investigating, I realized that when BGFX calls `rendererUpdateUniforms`, it always had `_begin` set to 0.

I looked at how `EncoderImpl::dispatch` always sets the `m_uniformBegin` to `m_uniformEnd` after each item is added, so I did the same for `EncoderImpl::submit`, and the issue is fixed! I actually have much better performance than when using discards, which is to be expected!

As requested, I tested the examples and they seem to work fine, so I believe there should be no side effects!