### PR TITLE
Fix various typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ different platforms, writing examples (see [Help Needed](https://github.com/bkar
 for ideas), improving documentation, profiling and optimizing, helping
 newcomers, telling others about bgfx, etc.
 
-If you have just quick oneliner question it's prefereable to ask it at chat
+If you have just quick oneliner question it's preferable to ask it at chat
 https://discord.gg/9eMbv7J instead opening new issue.
 
 ## Submitting bugs

--- a/examples/31-rsm/reflectiveshadowmap.cpp
+++ b/examples/31-rsm/reflectiveshadowmap.cpp
@@ -511,7 +511,7 @@ public:
 					bgfx::setTexture(0, s_normal, bgfx::getTexture(m_gbuffer, GBUFFER_RT_NORMAL) );  // Normal for lighting calculations
 					bgfx::setTexture(1, s_depth,  bgfx::getTexture(m_gbuffer, GBUFFER_RT_DEPTH) );   // Depth to reconstruct world position
 
-					// Thse are used in the vert shader
+					// These are used in the vert shader
 					bgfx::setTexture(2, s_shadowMap, bgfx::getTexture(m_shadowBuffer, SHADOW_RT_DEPTH) );  // Used to place sphere
 					bgfx::setTexture(3, s_rsm,       bgfx::getTexture(m_shadowBuffer, SHADOW_RT_RSM) );    // Used to scale/color sphere
 

--- a/examples/40-svt/vt.cpp
+++ b/examples/40-svt/vt.cpp
@@ -1263,7 +1263,7 @@ bool TileGenerator::generate(const bx::FilePath& _filePath)
 		}
 	}
 
-	bx::debugPrintf("Finising\n");
+	bx::debugPrintf("Finishing\n");
 	// Write header
 	m_tileDataFile->writeInfo();
 	// Close tile file

--- a/examples/42-bunnylod/progmesh.c
+++ b/examples/42-bunnylod/progmesh.c
@@ -50,7 +50,7 @@
 
 struct triangle {
 	int vertex[3];		// the 3 points (id) that make this tri
-	float normal[3];	// unit vector othogonal to this face
+	float normal[3];	// unit vector orthogonal to this face
 };
 
 struct array {

--- a/examples/48-drawindirect/drawindirect.cpp
+++ b/examples/48-drawindirect/drawindirect.cpp
@@ -376,7 +376,7 @@ public:
 				// This is done here for demonstration purposes
 
 				// The model matrix for each instance is also set on compute
-				// you could modify this to, eg, do frustrum culling on the GPU
+				// you could modify this to, eg, do frustum culling on the GPU
 				float ud[4] = { float(m_nDrawElements), float(m_sideSize), float(time), 0 };
 				uint32_t numToDraw = (m_sideSize*m_sideSize);
 

--- a/examples/49-hextile/fs_hextile.sc
+++ b/examples/49-hextile/fs_hextile.sc
@@ -157,7 +157,7 @@ void hex2colTex(out vec4 color, out vec3 weights, vec2 uv,
 	vec2 uv3 = mul(uv - cen3, rot3) + cen3 + hash(vertex3);
 
 	// Fetch input
-	// We could simply use texture2D function, however, the sreen space derivatives could be broken 
+	// We could simply use texture2D function, however, the screen space derivatives could be broken 
 	// since we are using random offsets, we use texture2DGrad to make sure that we pass correct derivatives explicitly.
 	vec4 c1 = texture2DGrad(s_trx_d, uv1,
 		mul(dSTdx, rot1), mul(dSTdy, rot1));

--- a/examples/common/entry/entry_x11.cpp
+++ b/examples/common/entry/entry_x11.cpp
@@ -336,7 +336,7 @@ namespace entry
 			m_display = XOpenDisplay(NULL);
 			if (NULL == m_display)
 			{
-				// Use `DISPLAY` enviroment variable to pick display. If `DISPLAY` is not set try ":0"
+				// Use `DISPLAY` environment variable to pick display. If `DISPLAY` is not set try ":0"
 				m_display = XOpenDisplay(":0");
 				if (NULL == m_display)
 				{

--- a/include/bgfx/bgfx.h
+++ b/include/bgfx/bgfx.h
@@ -350,7 +350,7 @@ namespace bgfx
 		enum Enum
 		{
 			TriListFlipWinding,  //!< Flip winding order of triangle list.
-			TriStripFlipWinding, //!< Flip winding order of trinagle strip.
+			TriStripFlipWinding, //!< Flip winding order of triangle strip.
 			TriListToLineList,   //!< Convert triangle list to line list.
 			TriStripToTriList,   //!< Convert triangle strip to triangle list.
 			LineStripToLineList, //!< Convert line strip to line list.

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3792,7 +3792,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 			if (m_drawable != NULL)
 			{
 				m_drawableTexture = m_drawable.texture;
-				retain(m_drawable); // keep alive to be useable at 'flip'
+				retain(m_drawable); // keep alive to be usable at 'flip'
 				retain(m_drawableTexture);
 			}
 			else
@@ -5141,7 +5141,7 @@ BX_STATIC_ASSERT(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNa
 										BGFX_FATAL(
 											  false
 											, Fatal::DebugCheck
-											, "Failed to set image with access: %s, format:%s is not supoort"
+											, "Failed to set image with access: %s, format:%s is not supported"
 											, s_accessNames[bind.m_access]
 											, bimg::getName(bimg::TextureFormat::Enum(bind.m_format) )
 											);


### PR DESCRIPTION
Found via `codespell -q 3 -S "./3rdparty,*.ttf,*.bin,./examples/common/imgui,./examples/common/font" -L attribut,ba,clude,conly,constan,espace,hashin,indext,inout,lod,nclude,retur,ser,sroll,struc,te,truct,unknwn,usin,utput,varyin`