### PR TITLE
Fix shader_dxbc.h compiling on linux with vulkan

### DIFF
--- a/src/shader_dxbc.h
+++ b/src/shader_dxbc.h
@@ -10,6 +10,11 @@
 
 #define DXBC_CHUNK_HEADER BX_MAKEFOURCC('D', 'X', 'B', 'C')
 
+// on linux when trying to build with vulkan on and opengl off, this file is included after Xlib.h
+// which includes X.h, which in turn #define None 0
+// undefining so DxbcOperandModifier::None properly compiles
+#undef None
+
 namespace bgfx
 {
 	struct DxbcOpcode

--- a/src/shader_dxbc.h
+++ b/src/shader_dxbc.h
@@ -10,10 +10,12 @@
 
 #define DXBC_CHUNK_HEADER BX_MAKEFOURCC('D', 'X', 'B', 'C')
 
+#ifdef None
 // on linux when trying to build with vulkan on and opengl off, this file is included after Xlib.h
 // which includes X.h, which in turn #define None 0
 // undefining so DxbcOperandModifier::None properly compiles
 #undef None
+#endif /* #ifdef None */
 
 namespace bgfx
 {


### PR DESCRIPTION
On linux when trying to build with vulkan on and opengl off, shader_dxbc.h is included after Xlib.h which includes X.h which in turn `#define None 0`. Undefining so we can properly compile the file.