### PR TITLE
Add a file formatting script for pre-commit

### DIFF
--- a/.github/workflows/file_format.py
+++ b/.github/workflows/file_format.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+
+if len(sys.argv) < 2:
+    print("Invalid usage of file_format.py, it should be called with a path to one or multiple files.")
+    sys.exit(1)
+
+BOM = b"\xef\xbb\xbf"
+
+changed = []
+invalid = []
+
+for file in sys.argv[1:]:
+    try:
+        with open(file, "rt", encoding="utf-8") as f:
+            original = f.read()
+    except UnicodeDecodeError:
+        invalid.append(file)
+        continue
+
+    if original == "":
+        continue
+
+    EOL = "\n"
+    WANTS_BOM = False
+
+    revamp = EOL.join([line.rstrip("\n\r\t ") for line in original.splitlines(True)]).rstrip(EOL) + EOL
+
+    new_raw = revamp.encode(encoding="utf-8")
+    if not WANTS_BOM and new_raw.startswith(BOM):
+        new_raw = new_raw[len(BOM) :]
+    elif WANTS_BOM and not new_raw.startswith(BOM):
+        new_raw = BOM + new_raw
+
+    with open(file, "rb") as f:
+        old_raw = f.read()
+
+    if old_raw != new_raw:
+        changed.append(file)
+        with open(file, "wb") as f:
+            f.write(new_raw)
+
+if changed:
+    for file in changed:
+        print(f"FIXED: {file}")
+
+if invalid:
+    for file in invalid:
+        print(f"REQUIRES MANUAL CHANGES: {file}")
+    sys.exit(1)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+default_language_version:
+  python: python3
+
+exclude: |
+  (?x)^(
+    3rdparty/.*|
+    bindings/.*|
+    include/bgfx/c99/bgfx\.h|
+    .*\.bin\.h|
+    .*\.ttf\.h$
+  )
+
+repos:
+  - repo: local
+    hooks:
+      - id: file-format
+        name: file-format
+        language: python
+        entry: python .github/workflows/file_format.py
+        types_or: [text]


### PR DESCRIPTION
This PR adds a script for file formatting, set up to be used with [pre-commit](https://pre-commit.com/), and formats the files in this repo using the script.

- The formatting script is cross-platform, works on Windows, MacOS, and Linux.
- The formatting script can run without installing any OS-level dependencies, except for Python. Once Python is installed you can install `pre-commit` via `pip install pre-commit`. Then `pre-commit run --all-files` in the repo to run.
- The formatting script can run automatically on changed files when making a commit using Git's pre-commit hooks feature, if you opt-in via `pre-commit install` in the repo.
- Due to the `static_checks.yml` file, the formatting script runs automatically on PRs via GitHub Actions CI checks.

The script ensures text files do not have trailing spaces, do not have BOM, do not have carriage returns, and are terminated with one `\n` character to ensure text files are POSIX-compliant.

I excluded `3rdparty/`, `*.bin.h`, and `*.ttf.h` files from formatting because `3rdparty/` is third-party code and the headers are serialized text files which intentionally contain trailing spaces in the comments.