### PR TITLE
[ALTERNATIVE] Fix UniformBuffer UB regarding UniformType::Enum with extra bits.

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1517,14 +1517,14 @@ namespace bgfx
 
 	void UniformBuffer::writeUniform(UniformType::Enum _type, uint16_t _loc, const void* _value, uint16_t _num)
 	{
-		const uint32_t opcode = encodeOpcode(_type, _loc, _num, true);
+		const uint32_t opcode = encodeOpcode(_type, 0, _loc, _num, true);
 		write(opcode);
 		write(_value, g_uniformTypeSize[_type]*_num);
 	}
 
-	void UniformBuffer::writeUniformHandle(UniformType::Enum _type, uint16_t _loc, UniformHandle _handle, uint16_t _num)
+	void UniformBuffer::writeUniformHandle(UniformType::Enum _type, uint8_t _typeBits, uint16_t _loc, UniformHandle _handle, uint16_t _num)
 	{
-		const uint32_t opcode = encodeOpcode(_type, _loc, _num, false);
+		const uint32_t opcode = encodeOpcode(_type, _typeBits, _loc, _num, false);
 		write(opcode);
 		write(&_handle, sizeof(UniformHandle) );
 	}
@@ -1532,7 +1532,7 @@ namespace bgfx
 	void UniformBuffer::writeMarker(const bx::StringView& _name)
 	{
 		const uint16_t num = bx::narrowCast<uint16_t>(_name.getLength()+1);
-		const uint32_t opcode = encodeOpcode(bgfx::UniformType::Count, 0, num, true);
+		const uint32_t opcode = encodeOpcode(bgfx::UniformType::Count, 0, 0, num, true);
 		write(opcode);
 		write(_name.getPtr(), num-1);
 		const char zero = '\0';
@@ -2521,10 +2521,11 @@ namespace bgfx
 			}
 
 			UniformType::Enum type;
+			uint8_t typeBits;
 			uint16_t loc;
 			uint16_t num;
 			uint16_t copy;
-			UniformBuffer::decodeOpcode(opcode, type, loc, num, copy);
+			UniformBuffer::decodeOpcode(opcode, type, typeBits, loc, num, copy);
 
 			const uint32_t size = g_uniformTypeSize[type]*num;
 			const char* data = _uniformBuffer->read(size);

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -1508,23 +1508,25 @@ namespace bgfx
 			}
 		}
 
-		static uint32_t encodeOpcode(UniformType::Enum _type, uint16_t _loc, uint16_t _num, uint16_t _copy)
+		static uint32_t encodeOpcode(UniformType::Enum _type, uint8_t _typeBits, uint16_t _loc, uint16_t _num, uint16_t _copy)
 		{
-			const uint32_t type = _type << kConstantOpcodeTypeShift;
-			const uint32_t loc  = _loc  << kConstantOpcodeLocShift;
-			const uint32_t num  = _num  << kConstantOpcodeNumShift;
-			const uint32_t copy = _copy << kConstantOpcodeCopyShift;
+			const uint32_t type = (_type | _typeBits) << kConstantOpcodeTypeShift;
+			const uint32_t loc  =  _loc               << kConstantOpcodeLocShift;
+			const uint32_t num  =  _num               << kConstantOpcodeNumShift;
+			const uint32_t copy =  _copy              << kConstantOpcodeCopyShift;
 			return type|loc|num|copy;
 		}
 
-		static void decodeOpcode(uint32_t _opcode, UniformType::Enum& _type, uint16_t& _loc, uint16_t& _num, uint16_t& _copy)
+		static void decodeOpcode(uint32_t _opcode, UniformType::Enum& _type, uint8_t& _typeBits, uint16_t& _loc, uint16_t& _num, uint16_t& _copy)
 		{
-			const uint32_t type = (_opcode&kConstantOpcodeTypeMask) >> kConstantOpcodeTypeShift;
+			const uint32_t type = ((_opcode&kConstantOpcodeTypeMask) >> kConstantOpcodeTypeShift) & (~kUniformMask);
+			const uint32_t bits = ((_opcode&kConstantOpcodeTypeMask) >> kConstantOpcodeTypeShift) & ( kUniformMask);
 			const uint32_t loc  = (_opcode&kConstantOpcodeLocMask ) >> kConstantOpcodeLocShift;
 			const uint32_t num  = (_opcode&kConstantOpcodeNumMask ) >> kConstantOpcodeNumShift;
 			const uint32_t copy = (_opcode&kConstantOpcodeCopyMask); // >> kConstantOpcodeCopyShift;
 
-			_type = (UniformType::Enum)(type);
+			_type = (UniformType::Enum)type;
+			_typeBits = (uint8_t)bits;
 			_copy = (uint16_t)copy;
 			_num  = (uint16_t)num;
 			_loc  = (uint16_t)loc;
@@ -1583,7 +1585,7 @@ namespace bgfx
 		}
 
 		void writeUniform(UniformType::Enum _type, uint16_t _loc, const void* _value, uint16_t _num = 1);
-		void writeUniformHandle(UniformType::Enum _type, uint16_t _loc, UniformHandle _handle, uint16_t _num = 1);
+		void writeUniformHandle(UniformType::Enum _type, uint8_t _typeBits, uint16_t _loc, UniformHandle _handle, uint16_t _num = 1);
 		void writeMarker(const bx::StringView& _name);
 
 	private:

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -4426,7 +4426,7 @@ namespace bgfx { namespace gl
 				uint16_t num;
 				uint16_t copy;
 				UniformBuffer::decodeOpcode(opcode, type, typeBits, ignore, num, copy);
-				BX_ASSERT(typeBits == 0);
+				BX_ASSERT(typeBits == 0, "OpenGL never uses typeBits for uniforms.");
 
 				const char* data;
 				if (copy)

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -4421,10 +4421,12 @@ namespace bgfx { namespace gl
 				}
 
 				UniformType::Enum type;
+				uint8_t typeBits;
 				uint16_t ignore;
 				uint16_t num;
 				uint16_t copy;
-				UniformBuffer::decodeOpcode(opcode, type, ignore, num, copy);
+				UniformBuffer::decodeOpcode(opcode, type, typeBits, ignore, num, copy);
+				BX_ASSERT(typeBits == 0);
 
 				const char* data;
 				if (copy)
@@ -5313,7 +5315,7 @@ namespace bgfx { namespace gl
 					}
 
 					UniformType::Enum type = convertGlType(gltype);
-					m_constantBuffer->writeUniformHandle(type, 0, info->m_handle, uint16_t(num) );
+					m_constantBuffer->writeUniformHandle(type, 0, 0, info->m_handle, uint16_t(num) );
 					m_constantBuffer->write(loc);
 					BX_TRACE("store %s %d", name, info->m_handle);
 				}

--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -1748,10 +1748,11 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 				}
 
 				UniformType::Enum type;
+				uint8_t typeBits;
 				uint16_t loc;
 				uint16_t num;
 				uint16_t copy;
-				UniformBuffer::decodeOpcode(opcode, type, loc, num, copy);
+				UniformBuffer::decodeOpcode(opcode, type, typeBits, loc, num, copy);
 
 				const char* data;
 				if (copy)
@@ -1765,10 +1766,9 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 					data = (const char*)m_uniforms[handle.idx];
 				}
 
-				switch ( (uint32_t)type)
+				switch (type)
 				{
 				case UniformType::Mat3:
-				case UniformType::Mat3|kUniformFragmentBit:
 					{
 						float* value = (float*)data;
 						for (uint32_t ii = 0, count = num/3; ii < count; ++ii,  loc += 3*16, value += 9)
@@ -1786,19 +1786,16 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 							mtx.un.val[ 9] = value[7];
 							mtx.un.val[10] = value[8];
 							mtx.un.val[11] = 0.0f;
-							setShaderUniform(uint8_t(type), loc, &mtx.un.val[0], 3);
+							setShaderUniform(uint8_t(type | typeBits), loc, &mtx.un.val[0], 3);
 						}
 					}
 					break;
 
 				case UniformType::Sampler:
-				case UniformType::Sampler | kUniformFragmentBit:
 				case UniformType::Vec4:
-				case UniformType::Vec4 | kUniformFragmentBit:
 				case UniformType::Mat4:
-				case UniformType::Mat4 | kUniformFragmentBit:
 					{
-						setShaderUniform(uint8_t(type), loc, data, num);
+						setShaderUniform(uint8_t(type | typeBits), loc, data, num);
 					}
 					break;
 
@@ -1806,7 +1803,7 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 					break;
 
 				default:
-					BX_TRACE("%4d: INVALID 0x%08x, t %d, l %d, n %d, c %d", _uniformBuffer.getPos(), opcode, type, loc, num, copy);
+					BX_TRACE("%4d: INVALID 0x%08x, t %d|%d, l %d, n %d, c %d", _uniformBuffer.getPos(), opcode, type, typeBits, loc, num, copy);
 					break;
 				}
 			}
@@ -2225,7 +2222,7 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 												}
 
 												UniformType::Enum type = convertMtlType(dataType);
-												constantBuffer->writeUniformHandle( (UniformType::Enum)(type|fragmentBit), uint32_t(uniform.offset), info->m_handle, uint16_t(num) );
+												constantBuffer->writeUniformHandle(type, fragmentBit, uint32_t(uniform.offset), info->m_handle, uint16_t(num) );
 												BX_TRACE("store %s %d offset:%d", name, info->m_handle, uint32_t(uniform.offset) );
 											}
 										}


### PR DESCRIPTION
This is an alternative PR for #3398, which seperates out the extra type bits and the actual enum in some of the APIs.

Tested on examples with Vulkan and Metal. Pick whichever you like best.