### PR TITLE
Fix wasm tinystl compile error

### DIFF
--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -31,8 +31,9 @@ namespace bgfx { namespace gl
 		SwapChainGL(int _context, const char* _canvas)
 			: m_context(_context)
 		{
-			m_canvas = (char*)bx::alloc(g_allocator, bx::strLen(_canvas) + 1);
-			strcpy(m_canvas, _canvas);
+			size_t length = bx::strLen(_canvas) + 1;
+			m_canvas = (char*)bx::alloc(g_allocator, length);
+			bx::strCopy(m_canvas, length, _canvas);
 
 			makeCurrent();
 			GL_CHECK(glClearColor(0.0f, 0.0f, 0.0f, 0.0f) );

--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -31,7 +31,7 @@ namespace bgfx { namespace gl
 		SwapChainGL(int _context, const char* _canvas)
 			: m_context(_context)
 		{
-			m_canvas = (char*)bx::alloc(g_allocator, strlen(_canvas) + 1);
+			m_canvas = (char*)bx::alloc(g_allocator, bx::strLen(_canvas) + 1);
 			strcpy(m_canvas, _canvas);
 
 			makeCurrent();


### PR DESCRIPTION
## Summary

This PR fixes a compile error for `wasm` that is related to the TinySTL refactors