### PR TITLE
docs: improve Android platform requirement clarity in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Supported rendering backends:
 
 Supported platforms:
 
- * Android (14+)
+ * Android (4.0+) - API 14 or later
  * iOS/iPadOS/tvOS (16.0+)
  * Linux
  * macOS (13.0+)


### PR DESCRIPTION
Updates the Android platform support description in README to be more clear 
for Android developers.

### Changes
- Changed `Android (14+)` to `Android (4.0+) - API 14 or later`

### Why
The previous notation "14+" could be misinterpreted by Android developers as:
- Android 14.0 (API 34)
- API level 14 (Android 4.0)

This change removes ambiguity by explicitly stating both the Android version 
and API level.

### Testing
- No functional changes, documentation update only
