### PR TITLE
Initialize color palette at start

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -3139,7 +3139,7 @@ namespace bgfx
 			, m_numFreeDynamicIndexBufferHandles(0)
 			, m_numFreeDynamicVertexBufferHandles(0)
 			, m_numFreeOcclusionQueryHandles(0)
-			, m_colorPaletteDirty(0)
+			, m_colorPaletteDirty(2)
 			, m_frames(0)
 			, m_debug(BGFX_DEBUG_NONE)
 			, m_rtMemoryUsed(0)


### PR DESCRIPTION
Currently, if user never calls `setPaletteColor`, `m_submit->m_colorPalette` is never cleared either and contains undefined data. Sampling textures configured with `SAMPLER_*_BORDER` yields weird behavior.