### PR TITLE
Fix various typos

### DIFF
--- a/examples/41-tess/tess.cpp
+++ b/examples/41-tess/tess.cpp
@@ -175,7 +175,7 @@ static const uint32_t s_indexesL3[] =
 	12u, 5u, 11u,
 	12u, 11u, 10u,
 	12u, 10u, 13u,
-	12u, 13u, 14u,        //End fo first big triangle
+	12u, 13u, 14u,        //End of first big triangle
 
 	15u, 14u, 13u,
 	15u, 13u, 10u,

--- a/src/config.h
+++ b/src/config.h
@@ -335,7 +335,7 @@ static_assert(bx::isPowerOf2(BGFX_CONFIG_MAX_VIEWS), "BGFX_CONFIG_MAX_VIEWS must
 
 #ifndef BGFX_CONFIG_MAX_BYTES_CACHED_DEVICE_MEMORY_ALLOCATIONS
 /// Amount of allowed memory allocations left on device to use for recycling during
-/// later allocations. This can be benificial in case the driver is slow allocating memory
+/// later allocations. This can be beneficial in case the driver is slow allocating memory
 /// on the device.
 /// Note: Currently only used by the Vulkan backend.
 #	define BGFX_CONFIG_MAX_BYTES_CACHED_DEVICE_MEMORY_ALLOCATIONS (128 << 20)

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -4367,7 +4367,7 @@ VK_IMPORT_DEVICE
 			BGFX_PROFILER_SCOPE("RendererContextVK::allocateMemory", kColorResource);
 
 			// Forcing the use of a private device allocation for a certain memory allocation
-			// can be desireable when memory mapping the allocation. A memory allocation
+			// can be desirable when memory mapping the allocation. A memory allocation
 			// can only be mapped once. So handing out multiple subregions of one bigger
 			// allocation can lead to problems, when they get mapped multiple times.
 			// Right now, with the LRU system, we are still only handing out the full
@@ -4746,7 +4746,7 @@ VK_DESTROY
 				if (alloc.memoryTypeIndex == _memoryTypeIndex)
 				{
 					// 50% waste allowed, otherwise we'll just allocate a new one.
-					// This is to prevent we trash this cache of usefull allocations
+					// This is to prevent we trash this cache of useful allocations
 					// with a handful of tiny allocations.
 					if (alloc.size >= _size && _size * 2 >= alloc.size)
 					{
@@ -7425,7 +7425,7 @@ VK_DESTROY
 			m_backBufferColorImageLayout[ii] = VK_IMAGE_LAYOUT_UNDEFINED;
 		}
 
-		BX_TRACE("Succesfully created swapchain (%dx%d) with %d images.", width, height, m_numSwapChainImages);
+		BX_TRACE("Successfully created swapchain (%dx%d) with %d images.", width, height, m_numSwapChainImages);
 
 		VkSemaphoreCreateInfo sci;
 		sci.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;


### PR DESCRIPTION
Found via `codespell -q 3 -S "./3rdparty,*.ttf,*.bin,*.bin.h,./examples/common/imgui,./examples/common/font,./examples/runtime/text/sherlock_holmes_a_scandal_in_bohemia_arthur_conan_doyle.txt" -L attribut,ba,clude,conly,constan,dne,espace,hashin,hart,indext,inout,lod,nclude,reduct,retur,ser,sroll,statics,struc,te,tolen,truct,unknwn,usin,utput,varyin`