### PR TITLE
Fix blitting between texture array layers

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4036,8 +4036,8 @@ namespace bgfx
 		uint32_t dstWidth  = bx::max<uint32_t>(1, dst.m_width  >> _dstMip);
 		uint32_t dstHeight = bx::max<uint32_t>(1, dst.m_height >> _dstMip);
 
-		uint32_t srcDepth  = src.isCubeMap() ? 6 : bx::max<uint32_t>(1, src.m_depth >> _srcMip);
-		uint32_t dstDepth  = dst.isCubeMap() ? 6 : bx::max<uint32_t>(1, dst.m_depth >> _dstMip);
+		uint32_t srcDepth  = src.isCubeMap() ? 6 * src.m_numLayers : src.m_numLayers > 1 ? src.m_numLayers : bx::max<uint32_t>(1, src.m_depth >> _srcMip);
+		uint32_t dstDepth  = dst.isCubeMap() ? 6 * src.m_numLayers : src.m_numLayers > 1 ? src.m_numLayers : bx::max<uint32_t>(1, dst.m_depth >> _dstMip);
 
 		BX_ASSERT(_srcX < srcWidth && _srcY < srcHeight && _srcZ < srcDepth
 			, "Blit src coordinates out of range (%d, %d, %d) >= (%d, %d, %d)"


### PR DESCRIPTION
This PR is meant to solve https://github.com/bkaradzic/bgfx/issues/3301

As described in the issue, the current implementation validates blit for cubemap and 3D texture but does not handle layered cubemaps or layered 2D textures which are supported otherwise (in `createTexture2D` / `createTextureCube`).

The proposed changes is as minimal as possible to:
- fix blitting for layered cubemaps (allow z to access 6 x numlayers)
- fix blitting for layered texture 2D (allow non 0 z)
- don't change anything for texture 3D as they are not layered.

This has been tested with the examples (but none uses this feature) and validated in our project (https://github.com/vpinball/vpinball which is a pinball simulator that runs on a lot of platforms, but only uses layered rendering & blitting on Windows for stereo rendering, so deep testing has only been done on this one).