### PR TITLE
[emscripten] Fix MEMORY64 mode

### DIFF
--- a/src/glcontext_html5.cpp
+++ b/src/glcontext_html5.cpp
@@ -28,7 +28,7 @@ namespace bgfx { namespace gl
 
 	struct SwapChainGL
 	{
-		SwapChainGL(int _context, const char* _canvas)
+		SwapChainGL(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE _context, const char* _canvas)
 			: m_context(_context)
 		{
 			size_t length = bx::strLen(_canvas) + 1;
@@ -60,7 +60,7 @@ namespace bgfx { namespace gl
 			// to the browser.
 		}
 
-		int m_context;
+		EMSCRIPTEN_WEBGL_CONTEXT_HANDLE m_context;
 		char* m_canvas;
 	};
 


### PR DESCRIPTION
EMSCRIPTEN_WEBGL_CONTEXT_HANDLE is 64bit when using MEMORY64 but it's stored as an int 32 bit causing overflow