### PR TITLE
Fix for Metal: persist new window handle (Metal layer) when swapping view

### DIFF
--- a/src/renderer_mtl.mm
+++ b/src/renderer_mtl.mm
@@ -3513,9 +3513,9 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 		else
 #endif // BX_PLATFORM_VISIONOS
 		{
-			if (m_metalLayer)
+			if (NULL != m_metalLayer)
 			{
-				release(m_metalLayer);
+				MTL_RELEASE(m_metalLayer);
 			}
 
 #if !BX_PLATFORM_VISIONOS


### PR DESCRIPTION
## Scope 

* When using the Metal rendering backend and updating the window handle via setPlatformData(), the passed in Metal layer was not stored. Instead, the old window handle (Metal layer) was still used.
* The fix addresses a scenario where two BGFX-backed Metal views on iOS are created and rendering needs to happen either on one view or the other.

## Details
* `m_metalLayer` is not cleared/set no `NULL`, only released: https://github.com/bkaradzic/bgfx/blob/23baae9e0010ee03edd8904fc7e176c76f4f8e2c/src/renderer_mtl.mm#L3518
* When `m_metalLayer` is not cleared, the check here fails: https://github.com/bkaradzic/bgfx/blob/23baae9e0010ee03edd8904fc7e176c76f4f8e2c/src/renderer_mtl.mm#L3536
* As a result the new handle is not stored in `m_metalLayer`: https://github.com/bkaradzic/bgfx/blob/23baae9e0010ee03edd8904fc7e176c76f4f8e2c/src/renderer_mtl.mm#L3547

## Testing
* I tested the fix successfully in my company's project setup. 
* Unfortunately, I do not have the time to create a minimal example or tweak an existing one demonstrating the problem and the fix.
* The change is minimal, should have no side effects and the fix is pretty obvious.