### PR TITLE
Fix blit dstDepth calculation using src.m_numLayers instead of dst.m_numLayers

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -4037,7 +4037,7 @@ namespace bgfx
 		uint32_t dstHeight = bx::max<uint32_t>(1, dst.m_height >> _dstMip);
 
 		uint32_t srcDepth  = src.isCubeMap() ? 6 * src.m_numLayers : src.m_numLayers > 1 ? src.m_numLayers : bx::max<uint32_t>(1, src.m_depth >> _srcMip);
-		uint32_t dstDepth  = dst.isCubeMap() ? 6 * src.m_numLayers : src.m_numLayers > 1 ? src.m_numLayers : bx::max<uint32_t>(1, dst.m_depth >> _dstMip);
+		uint32_t dstDepth  = dst.isCubeMap() ? 6 * dst.m_numLayers : dst.m_numLayers > 1 ? dst.m_numLayers : bx::max<uint32_t>(1, dst.m_depth >> _dstMip);
 
 		BX_ASSERT(_srcX < srcWidth && _srcY < srcHeight && _srcZ < srcDepth
 			, "Blit src coordinates out of range (%d, %d, %d) >= (%d, %d, %d)"


### PR DESCRIPTION
A bug was introduced in https://github.com/bkaradzic/bgfx/pull/3428

The blit function uses the source properties when getting the depth value instead of the destination texture.