### PR TITLE
Fix a detected race condition in initialization.

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -1950,8 +1950,8 @@ namespace bgfx
 		else
 		{
 			BX_TRACE("Creating rendering thread.");
-			m_thread.init(renderThread, this, 0, "bgfx - renderer backend thread");
 			m_singleThreaded = false;
+			m_thread.init(renderThread, this, 0, "bgfx - renderer backend thread");
 		}
 #else
 		BX_TRACE("Multithreaded renderer is disabled.");


### PR DESCRIPTION
This was found by compiling and running a toy project using clang's ThreadSanitizer (`--tsan`) feature.

I haven't investigated it in detail but from the looks of it, `renderthread` can in theory access `m_singleThreaded` before its correct value (`false`) is set. After this change, ThreadSanitizer no longer complains.