### PR TITLE
Remove FloatFast option for glsl-optimizer

### DIFF
--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -451,7 +451,7 @@ project "glsl-optimizer"
 	}
 
 	removeflags {
-		"FloatFast",	-- clang 17 has issues optimization errors originating in glsl-lang when float optimizations are enabled
+		"FloatFast",	-- clang 17 has issues errors originating in glsl-optimizer when float optimizations are enabled
 	}
 
 	configuration { "Release" }

--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -595,6 +595,10 @@ project "shaderc"
 		path.join(BGFX_DIR, "src/shader**"),
 	}
 
+	removeflags {
+		"FloatFast",	-- clang 17 has issues optimization errors originating in glsl-lang when float optimizations are enabled
+	}
+
 	configuration { "mingw-*" }
 		targetextension ".exe"
 

--- a/scripts/shaderc.lua
+++ b/scripts/shaderc.lua
@@ -450,6 +450,10 @@ project "glsl-optimizer"
 		path.join(GLSL_OPTIMIZER, "src/glsl/builtin_stubs.cpp"),
 	}
 
+	removeflags {
+		"FloatFast",	-- clang 17 has issues optimization errors originating in glsl-lang when float optimizations are enabled
+	}
+
 	configuration { "Release" }
 		flags {
 			"Optimize",
@@ -593,10 +597,6 @@ project "shaderc"
 		path.join(BGFX_DIR, "tools/shaderc/**.h"),
 		path.join(BGFX_DIR, "src/vertexlayout.**"),
 		path.join(BGFX_DIR, "src/shader**"),
-	}
-
-	removeflags {
-		"FloatFast",	-- clang 17 has issues optimization errors originating in glsl-lang when float optimizations are enabled
 	}
 
 	configuration { "mingw-*" }


### PR DESCRIPTION
## Summary

When I use `clang` version 17 to compile `shaderc`, the resulting `essl`/`glsl` shaders have all constants replaced with the value `(-1.0/0.0)`. Removing `FloatFast` for the `glsl-optimizer` target resolved the issue for me.

## Minimum Reproducible Example

```
$input a_position

void main()
{
    gl_Postition = vec4(0.0, 0.0, 0.0, 1.0);
}
```

```
precision highp int;
precision highp float;
void main()
{
    gl_Position = vec4((-1.0/0.0), (-1.0/0.0), (-1.0/0.0), (-1.0/0.0));
}
```