### PR TITLE
Fix Raspberry Pi Build - EGL_DISPMANX_WINDOW_T not defined

### DIFF
--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -250,6 +250,12 @@ WL_EGL_IMPORT
 	};
 
 #	if BX_PLATFORM_RPI
+	typedef uint32_t DISPMANX_ELEMENT_HANDLE_T;
+	typedef struct {
+		DISPMANX_ELEMENT_HANDLE_T element;
+		int width;   /* This is necessary because dispmanx elements are not queriable. */
+		int height;
+		} EGL_DISPMANX_WINDOW_T;
 	static EGL_DISPMANX_WINDOW_T s_dispmanWindow;
 #	endif // BX_PLATFORM_RPI
 
@@ -384,7 +390,7 @@ WL_EGL_IMPORT
 			s_dispmanWindow.element = dispmanElement;
 			s_dispmanWindow.width   = _width;
 			s_dispmanWindow.height  = _height;
-			nwh = &s_dispmanWindow;
+			nwh = (EGLNativeWindowType) &s_dispmanWindow;
 
 			vc_dispmanx_update_submit_sync(dispmanUpdate);
 #	endif // BX_PLATFORM_ANDROID


### PR DESCRIPTION
EGL_DISPMANX_WINDOW_T is not defined for modern Raspberry Pi. To fix it you must define a replacement struct, and use raw casting to EGLNativeWindowType

See: https://forum.qt.io/topic/88588/qtbase-compilation-error-with-device-linux-rasp-pi3-g-qeglfskmsgbmwindow-cpp/9 for details of the fix