### PR TITLE
gl renderer: Fixed BGFX_RESET_MAXANISOTROPY change

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -3757,10 +3757,16 @@ namespace bgfx { namespace gl
 
 		void updateResolution(const Resolution& _resolution)
 		{
-			m_maxAnisotropy = !!(_resolution.reset & BGFX_RESET_MAXANISOTROPY)
+			float maxAnisotropy = !!(_resolution.reset & BGFX_RESET_MAXANISOTROPY)
 				? m_maxAnisotropyDefault
 				: 0.0f
 				;
+			
+			if (m_maxAnisotropy != maxAnisotropy)
+			{
+				m_maxAnisotropy = maxAnisotropy;
+				invalidateCache();
+			}
 
 			if (s_extension[Extension::ARB_depth_clamp].m_supported)
 			{


### PR DESCRIPTION
m_maxAnisotropy is used when creating samplers and stored in sampler cache. But value change didn't invalidate sampler cache.

NOTE: this is handled with invalidation in vk and d3d11 renderer. 
https://github.com/bkaradzic/bgfx/blob/master/src/renderer_d3d11.cpp#L2451
https://github.com/bkaradzic/bgfx/blob/master/src/renderer_vk.cpp#L2865
This has problem with metal renderer too. I will send PR later.
I am unsure about d3d12.

Might be good idea to add some extra functionality to one of the examples to test this.