### PR TITLE
Fixed issue when gl_PrimitiveID and gl_FrontFacing are used together. Issue #3509.

### DIFF
--- a/tools/shaderc/shaderc.cpp
+++ b/tools/shaderc/shaderc.cpp
@@ -1977,6 +1977,22 @@ namespace bgfx
 								);
 						}
 
+						if (hasPrimitiveId)
+						{
+							if (profile->id >= 400)
+							{
+								preprocessor.writef(
+									" \\\n\t%suint gl_PrimitiveID : SV_PrimitiveID"
+									, arg++ > 0 ? ", " : "  "
+									);
+							}
+							else
+							{
+								bx::write(_messageWriter, &messageErr, "gl_PrimitiveID builtin is not supported by D3D9 HLSL.\n");
+								return false;
+							}
+						}
+
 						if (hasFrontFacing)
 						{
 							if (profile->id < 400)
@@ -1992,22 +2008,6 @@ namespace bgfx
 									" \\\n\t%sbool gl_FrontFacing : SV_IsFrontFace"
 									, arg++ > 0 ? ", " : "  "
 									);
-							}
-						}
-
-						if (hasPrimitiveId)
-						{
-							if (profile->id >= 400)
-							{
-								preprocessor.writef(
-									" \\\n\t%suint gl_PrimitiveID : SV_PrimitiveID"
-									, arg++ > 0 ? ", " : "  "
-									);
-							}
-							else
-							{
-								bx::write(_messageWriter, &messageErr, "gl_PrimitiveID builtin is not supported by D3D9 HLSL.\n");
-								return false;
 							}
 						}
 


### PR DESCRIPTION
Reorder gl_PrimitiveID and gl_FrontFacing main arguments to not cause error:

`error X4576: Non system-generated input signature parameter () cannot appear after a system generated value.`