### PR TITLE
shaderlib: Fixed pack/unpack float to rgba.

### DIFF
--- a/examples/common/shaderlib.sh
+++ b/examples/common/shaderlib.sh
@@ -336,8 +336,11 @@ vec3 adjustHue(vec3 _rgb, float _hue)
 
 vec4 packFloatToRgba(float _value)
 {
-	const vec4 shift = vec4(256 * 256 * 256, 256 * 256, 256, 1.0);
-	const vec4 mask = vec4(0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);
+	// Reference(s):
+	// - Encoding floats to RGBA - the final?
+	//   https://web.archive.org/web/20250914131649/https://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/
+	const vec4 shift = vec4(255 * 255 * 255, 255 * 255, 255, 1.0);
+	const vec4 mask = vec4(0, 1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0);
 	vec4 comp = fract(_value * shift);
 	comp -= comp.xxyz * mask;
 	return comp;
@@ -345,14 +348,14 @@ vec4 packFloatToRgba(float _value)
 
 float unpackRgbaToFloat(vec4 _rgba)
 {
-	const vec4 shift = vec4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);
+	const vec4 shift = vec4(1.0 / (255.0 * 255.0 * 255.0), 1.0 / (255.0 * 255.0), 1.0 / 255.0, 1.0);
 	return dot(_rgba, shift);
 }
 
 vec2 packHalfFloat(float _value)
 {
-	const vec2 shift = vec2(256, 1.0);
-	const vec2 mask = vec2(0, 1.0 / 256.0);
+	const vec2 shift = vec2(255, 1.0);
+	const vec2 mask = vec2(0, 1.0 / 255.0);
 	vec2 comp = fract(_value * shift);
 	comp -= comp.xx * mask;
 	return comp;
@@ -360,7 +363,7 @@ vec2 packHalfFloat(float _value)
 
 float unpackHalfFloat(vec2 _rg)
 {
-	const vec2 shift = vec2(1.0 / 256.0, 1.0);
+	const vec2 shift = vec2(1.0 / 255.0, 1.0);
 	return dot(_rg, shift);
 }
 


### PR DESCRIPTION
I ran into some artifacts after switching my shadow maps from R32F to RGBA8. It turns out there’s a more accurate method for packing floats into RGBA, which fixed my issues: https://web.archive.org/web/20250914131649/https://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/

Before/after:

<img width="1404" height="835" alt="crown-omni-256" src="https://github.com/user-attachments/assets/d8802858-761a-4e1b-90ec-bfafd8826104" />
 <img width="1404" height="835" alt="crown-omni-255" src="https://github.com/user-attachments/assets/c7788bbc-ef62-460a-954c-af71c6a810d3" />


Also visible on 16-shadowmaps with small bias/offset values:

<img width="1280" height="720" alt="16-sm-after" src="https://github.com/user-attachments/assets/0d9d52d0-2973-4772-9f0b-e58423a9b149" />
<img width="1280" height="720" alt="16-sm-before" src="https://github.com/user-attachments/assets/b6f8d797-517f-450b-92a6-8ba188f27fb2" />


