### PR TITLE
d3d11: Fix UAV cache to handle texture arrays correctly

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -3186,8 +3186,18 @@ namespace bgfx { namespace d3d11
 				switch (texture.m_type)
 				{
 				case TextureD3D11::Texture2D:
-					desc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
-					desc.Texture2D.MipSlice = _mip;
+					if (1 < texture.m_numLayers)
+					{
+						desc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2DARRAY;
+						desc.Texture2DArray.MipSlice = _mip;
+						desc.Texture2DArray.FirstArraySlice = 0;
+						desc.Texture2DArray.ArraySize = texture.m_numLayers;
+					}
+					else
+					{
+						desc.ViewDimension = D3D11_UAV_DIMENSION_TEXTURE2D;
+						desc.Texture2D.MipSlice = _mip;
+					}
 					break;
 
 				case TextureD3D11::TextureCube:


### PR DESCRIPTION
On D3D11 there is a problem with binding a texture array via bgfx::setImage with non-zero mip level for compute shader access:

```cpp
// Create texture array with NUM_CASCADES slices
shadowMapArray = bgfx::createTexture2D(
    m_wShadowMapSize, m_wShadowMapSize, true, NUM_CASCADES,
    bgfx::TextureFormat::RG32F, BGFX_TEXTURE_COMPUTE_WRITE
);

// Generate mips through compute shader
for (uint32_t mip = 1; mip < mipLevels; ++mip)
{
    bgfx::setImage(0, shadowMapArray, mip - 1, bgfx::Access::Read, bgfx::TextureFormat::RG32F);
    bgfx::setImage(1, shadowMapArray, mip, bgfx::Access::Write, bgfx::TextureFormat::RG32F);
    
    // Dispatch across all slices (NUM_CASCADES in Z dimension)
    bgfx::dispatch(..., numGroupsX, numGroupsY, NUM_CASCADES);
}
```
Only slice 0 of the texture array was accessible to the compute shader, making NUM_CASCADES dispatch ineffective.

The issue was in getCachedUav() which incorrectly created/cached UAVs for texture arrays as D3D11_UAV_DIMENSION_TEXTURE2D instead of D3D11_UAV_DIMENSION_TEXTURE2DARRAY, and didn't set the array slice parameters.

With fix all slices are accessible, enabling proper mipmap generation across the entire texture array.

I tested on vulkan and this problem doesnt exist.