### PR TITLE
Fix DX11 screenshot color format

### DIFF
--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -1997,6 +1997,27 @@ namespace bgfx { namespace d3d11
 			D3D11_TEXTURE2D_DESC backBufferDesc;
 			backBuffer->GetDesc(&backBufferDesc);
 
+			TextureFormat::Enum colorFormat = TextureFormat::Enum::Count;
+			for (int i = 0; i < TextureFormat::Enum::Count; i++)
+			{
+				if (s_textureFormat[i].m_fmt == backBufferDesc.Format)
+				{
+					colorFormat = TextureFormat::Enum(i);
+					break;
+				}
+				if (s_textureFormat[i].m_fmtSrgb == backBufferDesc.Format)
+				{
+					colorFormat = TextureFormat::Enum(i);
+					break;
+				}
+			}
+			if (colorFormat == TextureFormat::Enum::Count)
+			{
+				BX_TRACE("Unable to capture screenshot %s.", _filePath);
+				DX_RELEASE(backBuffer, 0);
+				return;
+			}
+
 			D3D11_TEXTURE2D_DESC desc;
 			bx::memCopy(&desc, &backBufferDesc, sizeof(desc) );
 			desc.SampleDesc.Count = 1;
@@ -2029,22 +2050,69 @@ namespace bgfx { namespace d3d11
 
 				D3D11_MAPPED_SUBRESOURCE mapped;
 				DX_CHECK(m_deviceCtx->Map(texture, 0, D3D11_MAP_READ, 0, &mapped) );
-				bimg::imageSwizzleBgra8(
-					  mapped.pData
-					, mapped.RowPitch
-					, backBufferDesc.Width
-					, backBufferDesc.Height
-					, mapped.pData
-					, mapped.RowPitch
+				if (colorFormat == TextureFormat::RGBA8)
+				{
+					bimg::imageSwizzleBgra8(
+						  mapped.pData
+						, mapped.RowPitch
+						, backBufferDesc.Width
+						, backBufferDesc.Height
+						, mapped.pData
+						, mapped.RowPitch
+						);
+					g_callback->screenShot(
+						  _filePath
+						, backBufferDesc.Width
+						, backBufferDesc.Height
+						, mapped.RowPitch
+						, mapped.pData
+						, backBufferDesc.Height*mapped.RowPitch
+						, false
+						);
+				}
+				else if (colorFormat == TextureFormat::BGRA8)
+				{
+					g_callback->screenShot(
+						  _filePath
+						, backBufferDesc.Width
+						, backBufferDesc.Height
+						, mapped.RowPitch
+						, mapped.pData
+						, backBufferDesc.Height*mapped.RowPitch
+						, false
+						);
+				}
+				else
+				{
+					const uint8_t dstBpp = bimg::getBitsPerPixel(bimg::TextureFormat::BGRA8);
+					const uint32_t dstPitch = backBufferDesc.Width * dstBpp / 8;
+					const uint32_t dstSize = backBufferDesc.Height * dstPitch;
+
+					void* dst = bx::alloc(g_allocator, dstSize);
+					bimg::imageConvert(
+						  dst
+						, dstBpp
+						, bimg::getPack(bimg::TextureFormat::BGRA8)
+						, mapped.pData
+						, bimg::getBitsPerPixel(bimg::TextureFormat::Enum(colorFormat))
+						, bimg::getUnpack(bimg::TextureFormat::Enum(colorFormat))
+						, backBufferDesc.Width
+						, backBufferDesc.Height
+						, 1
+						, mapped.RowPitch
+						, dstPitch
 					);
-				g_callback->screenShot(_filePath
-					, backBufferDesc.Width
-					, backBufferDesc.Height
-					, mapped.RowPitch
-					, mapped.pData
-					, backBufferDesc.Height*mapped.RowPitch
-					, false
-					);
+					g_callback->screenShot(
+						  _filePath
+						, backBufferDesc.Width
+						, backBufferDesc.Height
+						, dstPitch
+						, dst
+						, backBufferDesc.Height*dstPitch
+						, false
+						);
+					bx::free(g_allocator, dst);
+				}
 				m_deviceCtx->Unmap(texture, 0);
 
 				DX_RELEASE(texture, 0);


### PR DESCRIPTION
The doc states that `Screenshot format is always 4-byte BGRA.` but the DX11 backend process the captured image not taking in account the actual framebuffer color format. This leads to incorrect results if the framebuffer is not RGBA8.

For example, this happens when running example 7-callback with a non default framebuffer color format: add `init.resolution.formatColor = bgfx::TextureFormat::RGB10A2;` at line 338 before `bgfx::init(...)` and observe that the captured frame is invalid.

The proposed change is a port of what is done in the Vulkan backend where the image is always converted to the BGRA format.