### PR TITLE
Do not load RenderDoc on Wayland

### DIFF
--- a/src/debug_renderdoc.cpp
+++ b/src/debug_renderdoc.cpp
@@ -24,13 +24,13 @@ namespace bgfx
 		// Skip loading RenderDoc when IntelGPA is present to avoid RenderDoc crash.
 		if (findModule(BX_ARCH_32BIT ? "shimloader32.dll" : "shimloader64.dll") )
 		{
+			BX_TRACE("IntelGPA is present, not loading RenderDoc.");
 			return NULL;
 		}
 
-		// Skip loading RenderDoc on Wayland: https://github.com/baldurk/renderdoc/issues/853
-		if (g_platformData.type == bgfx::NativeWindowHandleType::Wayland)
+		if (bgfx::NativeWindowHandleType::Wayland == g_platformData.type)
 		{
-			BX_WARN(0, "RenderDoc is not available on Wayland.");
+			BX_TRACE("RenderDoc is not available on Wayland. https://github.com/baldurk/renderdoc/issues/853");
 			return NULL;
 		}
 


### PR DESCRIPTION
Otherwise it would disable VK_KHR_wayland_surface causing BGFX to fail initialization:

```
BGFX Create surface error: vkCreate[Platform]SurfaceKHR failed -7: VK_ERROR_EXTENSION_NOT_PRESENT.
BGFX Create swap chain error: creating surface failed -7: VK_ERROR_EXTENSION_NOT_PRESENT.
BGFX errorState 0
BGFX Init error: creating swap chain failed -7: VK_ERROR_EXTENSION_NOT_PRESENT.
BGFX errorState 4
```