### PR TITLE
Improvement to the shadowmaps example for cascades and stability.

### DIFF
--- a/examples/16-shadowmaps/shadowmaps.cpp
+++ b/examples/16-shadowmaps/shadowmaps.cpp
@@ -2348,24 +2348,6 @@ public:
 		
 					// Update cascade far distance uniform (use original split distance for shader blend)
 					s_uniforms.m_csmFarDistances[ii] = cascadeFar;
-		
-					// Compute frustum corners for this cascade in world space
-					const float nw = cascadeNear * projWidth;
-					const float nh = cascadeNear * projHeight;
-					const float fw = cascadeFar * projWidth;
-					const float fh = cascadeFar * projHeight;
-		
-					// Frustum corners in view space (camera looking along +Z)
-					const bx::Vec3 viewSpaceCorners[8] = {
-						{-nw,  nh, cascadeNear},  // near top-left
-						{ nw,  nh, cascadeNear},  // near top-right
-						{ nw, -nh, cascadeNear},  // near bottom-right
-						{-nw, -nh, cascadeNear},  // near bottom-left
-						{-fw,  fh, cascadeFar},   // far top-left
-						{ fw,  fh, cascadeFar},   // far top-right
-						{ fw, -fh, cascadeFar},   // far bottom-right
-						{-fw, -fh, cascadeFar},   // far bottom-left
-					};
 
 					// Compute frustum corners for one split in world space.
 					worldSpaceFrustumCorners((float*)frustumCorners[ii], cascadeNear, cascadeFar, projWidth, projHeight, mtxViewInv);


### PR DESCRIPTION
# Improved Cascade Shadow Map Calculation for Directional Lights

## Summary

This PR introduces an alternative cascade shadow map (CSM) calculation for directional lights in the `16-shadowmaps` example. The new method resolves **shadow edge flickering** when the camera moves or rotates with static geometry/lighting, and **extends shadow coverage** to scenes whose geometry lives far from the world origin.

Both approaches share the same high-level structure — split the camera frustum into cascades, fit an orthographic projection around each split — but they differ in several critical geometric details.

---

## Key Differences

### 1. Light View Matrix Construction

| Aspect | Old | New |
|---|---|---|
| **Eye position** | `-lightDir` (negative of light direction vector) | `{0, 0, 0}` (origin) |
| **Look-at target** | `{0, 0, 0}` (world origin) | `lightDir` (along light direction) |
| **Up vector** | Default (implicit, unhandled degeneracy) | Explicit `+Y`, with fallback to `+Z` when the light is nearly vertical (`dot > 0.99`) |

**Why it matters:**

The old code places the light "eye" at `-lightDir` looking at the origin. This means the light view is **anchored to the world origin**. Because a directional light has no position (it represents parallel rays), the view matrix should only encode the light's *orientation*, not a position relative to any world point. The new code constructs a pure orientation-only view matrix at the origin looking along the light direction, making it **independent of any particular world position**. This means shadow maps remain valid regardless of how far the scene geometry is from the origin.

The explicit up-vector fallback in the new code also prevents a degenerate matrix when the light points straight down (a common sun configuration).

### 2. Cascade Split Calculation

| Aspect | Old (`splitFrustum`) | New (`calculateCascadeSplits`) |
|---|---|---|
| **Output format** | Interleaved `[near0, far0, near1, far1, ...]` pairs with a small overlap factor (`far = near * 1.005f`) | Normalized depths `[0..1]` relative to clip range |
| **Distribution** | `numSlices = numSplits * 2`, iterates even/odd indices | `numSlicesF = numSplits * 2.5`, iterates odd indices `(i*2+1)` for GPU Gems 3–style weighting |
| **Cascade near/far** | Read directly from interleaved array; each cascade's near is a hard value from the array | Computed as `nearClip + splitDist * clipRange`; cascade near of split `i` equals cascade far of split `i-1` (tracked via `lastSplitDist`) — seamless, gap-free |

**Why it matters:**

The old split function produces small intentional overlaps (`1.005f` multiplier) between cascades, which can cause slight discontinuities at cascade boundaries. The new method produces seamless, gap-free cascades and uses a GPU Gems 3–inspired logarithmic/uniform blend that distributes resolution more evenly across the view range.

### 3. Frustum Fitting — AABB vs. Bounding Sphere Scale

| Aspect | Old | New |
|---|---|---|
| **Bounding volume** | Tight axis-aligned bounding box (AABB) in light space | AABB for centering, but **bounding sphere radius** for scale |
| **Scale derivation** | `scalex = 2.0 / (maxproj.x - minproj.x)` per-axis | `scalex = scaley = 1.0 / frustum_radius` (uniform, sphere-based) |

**Why it matters — this is the core stability improvement:**

With a tight AABB, the bounding box dimensions **change as the camera rotates**, because the 8 frustum corners trace different extents in light space depending on the camera orientation. This causes the orthographic projection bounds to expand and contract frame-to-frame, which shifts shadow texels and produces **edge shimmer/flickering**.

Using the bounding sphere radius gives a **rotation-invariant** extent. No matter how the camera rotates, a sphere enclosing the frustum corners has the same radius, so the projection scale remains constant. Combined with the existing texel-snapping stabilization, this eliminates sub-texel jitter entirely.

### 4. Depth (Z) Centering via `mtxCrop[14]`

| Aspect | Old | New |
|---|---|---|
| **Z offset in crop matrix** | Not applied (`mtxCrop[14]` is 0, identity) | `mtxCrop[14] = -lightSpaceCenter.z` — re-centers the depth range on the cascade frustum's light-space center |

**Why it matters:**

The old code uses a fixed depth range (`-far .. +far`) for all cascades with no per-cascade Z adjustment. If the camera is far from the origin, the actual shadow casters may fall outside this fixed range, causing shadow clipping or lost precision. The new code shifts the depth origin to the center of each cascade's frustum *in light space*, ensuring the depth range is always centered on the geometry that matters for that cascade. This is critical for scenes with **large world coordinates** — the shadows simply don't work in the old method when geometry is far from `{0, 0, 0}`.

### 5. Frustum Corner Calculation

| Aspect | Old | New |
|---|---|---|
| **Method** | Calls `worldSpaceFrustumCorners()` utility with absolute near/far values | Inline computation: builds view-space corners, transforms to world space via `mtxViewInv`, then to light space |
| **Frustum center** | Not computed | Explicitly computed as average of 8 world-space corners; used for sphere radius and Z centering |

The inline approach is functionally equivalent for the corner positions themselves, but the explicit frustum center computation is essential for the bounding-sphere and Z-centering improvements.

---

## Visual Impact Summary

| Scenario | Old Behavior | New Behavior |
|---|---|---|
| Camera rotation (static scene) | Shadow edges flicker/shimmer due to AABB resizing | Stable shadows — sphere radius is rotation-invariant |
| Camera translation (static scene) | Moderate shimmer from AABB shifts | Stable — uniform scale + texel snapping |
| Geometry far from world origin | Shadows break — light view is anchored at `{0,0,0}`, depth range misses distant geometry | Works correctly — orientation-only view matrix + per-cascade Z centering |
| Near-vertical directional light | Potential degenerate view matrix (no up-vector fallback) | Handled gracefully with `+Z` up fallback |

---
