### PR TITLE
Fix D3D12 fragment shader constant buffer misalignment

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -2547,7 +2547,7 @@ namespace bgfx { namespace d3d12
 			};
 			m_commandList->SetDescriptorHeaps(BX_COUNTOF(heaps), heaps);
 			m_commandList->SetGraphicsRootConstantBufferView(RenderRp::CBV, gpuAddress);
-			m_commandList->SetGraphicsRootConstantBufferView(RenderRp::CBF, gpuAddress + m_program[_blitter.m_program.idx].m_vsh->m_size);
+			m_commandList->SetGraphicsRootConstantBufferView(RenderRp::CBF, gpuAddress + bx::strideAlign(m_program[_blitter.m_program.idx].m_vsh->m_size, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT) );
 
 			TextureD3D12& texture = m_textures[_blitter.m_texture.idx];
 			const uint32_t samplerFlags[] = { uint32_t(texture.m_flags & BGFX_SAMPLER_BITS_MASK) };
@@ -2928,17 +2928,19 @@ namespace bgfx { namespace d3d12
 		void commitShaderConstants(ProgramHandle _program, D3D12_GPU_VIRTUAL_ADDRESS& _gpuAddress)
 		{
 			const ProgramD3D12& program = m_program[_program.idx];
-			uint32_t total = bx::strideAlign(0
-				+ program.m_vsh->m_size
-				+ (NULL != program.m_fsh ? program.m_fsh->m_size : 0)
+			uint32_t vsAlignedSize = bx::strideAlign(program.m_vsh->m_size
 				, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT
 				);
+			uint32_t total = vsAlignedSize
+				+ (NULL != program.m_fsh
+					? bx::strideAlign(program.m_fsh->m_size, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT)
+					: 0)
+				;
 			uint8_t* data = (uint8_t*)m_scratchBuffer[m_backBufferColorIdx].allocCbv(_gpuAddress, total);
 
 			{
-				uint32_t size = program.m_vsh->m_size;
-				bx::memCopy(data, m_vsScratch, size);
-				data += size;
+				bx::memCopy(data, m_vsScratch, program.m_vsh->m_size);
+				data += vsAlignedSize;
 			}
 
 			if (NULL != program.m_fsh)
@@ -7564,7 +7566,7 @@ namespace bgfx { namespace d3d12
 						commitShaderConstants(key.m_program, gpuAddress);
 					}
 
-					uint32_t numIndices        = m_batch.draw(m_commandList, gpuAddress, gpuAddress + m_program[currentProgram.idx].m_vsh->m_size, draw);
+					uint32_t numIndices        = m_batch.draw(m_commandList, gpuAddress, gpuAddress + bx::strideAlign(m_program[currentProgram.idx].m_vsh->m_size, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT), draw);
 					uint32_t numPrimsSubmitted = numIndices / prim.m_div - prim.m_sub;
 					uint32_t numPrimsRendered  = numPrimsSubmitted*draw.m_numInstances;
 


### PR DESCRIPTION
Fix D3D12 fragment shader constant buffer misalignment

The fragment shader CBV address is computed as `gpuAddress + m_vsh->m_size`, but D3D12 requires CBV addresses to be aligned to `D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT` (256 bytes). When the vertex shader constant buffer is not a multiple of 256 bytes, the fragment shader reads from a misaligned address and receives corrupt uniform values.

This causes black output on D3D12 for any shader program where VS constants exceed 256 bytes. Other backends are unaffected.

### Reproduction

Modify `examples/01-cubes` to use shaders with >256 bytes of VS constants and a FS uniform:

**vs_cubes_many_uniforms.sc** adds 17 padding `vec4` uniforms to push the VS constant buffer past 256 bytes:
```cpp
$input a_position, a_color0
$output v_color0

#include "../common/common.sh"

uniform vec4 u_pad0;
uniform vec4 u_pad1;
uniform vec4 u_pad2;
uniform vec4 u_pad3;
uniform vec4 u_pad4;
uniform vec4 u_pad5;
uniform vec4 u_pad6;
uniform vec4 u_pad7;
uniform vec4 u_pad8;
uniform vec4 u_pad9;
uniform vec4 u_pad10;
uniform vec4 u_pad11;
uniform vec4 u_pad12;
uniform vec4 u_pad13;
uniform vec4 u_pad14;
uniform vec4 u_pad15;
uniform vec4 u_pad16;

void main()
{
    gl_Position = mul(u_modelViewProj, vec4(a_position + u_pad0.xyz * 0.0001, 1.0) );
    v_color0 = a_color0;
}
```

**fs_cubes_many_uniforms.sc** multiplies output by `u_tintColor`:
```cpp
$input v_color0

#include "../common/common.sh"

uniform vec4 u_tintColor;

void main()
{
    gl_FragColor = v_color0 * u_tintColor;
}
```

**Changes to cubes.cpp:**
- Load `vs_cubes_many_uniforms` / `fs_cubes_many_uniforms` instead of `vs_cubes` / `fs_cubes`
- Create and set 17 pad uniforms (zero) and `u_tintColor` (white) per draw

**Result without fix:** `--d3d12` shows black cubes (FS reads corrupt `u_tintColor` from VS constant region). `--gl` renders correctly.
<img width="1902" height="1121" alt="image" src="https://github.com/user-attachments/assets/db3d94ab-7214-4a61-a108-6b252dcf3707" />

**Result with fix:** `--d3d12` renders correctly, matching `--gl`.
<img width="1912" height="1121" alt="image" src="https://github.com/user-attachments/assets/e4a8e552-055c-418d-ae82-70cb825116cf" />

### Fix

Three locations in `src/renderer_d3d12.cpp`:

1. **`commitShaderConstants`** align VS constant size to 256 bytes before placing FS constants in the scratch buffer, and use the aligned size as the data write offset.

2. **Main render loop** (`m_batch.draw()` call) use `bx::strideAlign(m_vsh->m_size, D3D12_CONSTANT_BUFFER_DATA_PLACEMENT_ALIGNMENT)` for the FS CBV address offset.

3. **Blitter path** (`SetGraphicsRootConstantBufferView(CBF)`) same alignment fix.

### Why existing examples are unaffected

The built-in examples use shaders with VS constants that fit within 256 bytes, so `gpuAddress + m_vsh->m_size` happens to already be 256-byte aligned.

### Verified on

- Windows 11, NVIDIA RTX 5070 Ti
- Root cause confirmed via RenderDoc: VS output positions correct, but FS constant buffer contained VS data at wrong offset due to misaligned CBV address
