### PR TITLE
DX12: use discard instead of sequential flip

### DIFF
--- a/src/renderer_d3d12.cpp
+++ b/src/renderer_d3d12.cpp
@@ -1288,7 +1288,7 @@ namespace bgfx { namespace d3d12
 					? DXGI_SCALING_NONE
 					: DXGI_SCALING_STRETCH
 					;
-				m_scd.swapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+				m_scd.swapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 				m_scd.alphaMode  = DXGI_ALPHA_MODE_IGNORE;
 				m_scd.flags      = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
 


### PR DESCRIPTION
Sequential & discard flip models each have their use cases, but for games it should usually be discard.
This change aligns the DirectX 12 backend to the behavior of the DirectX 11 backend.