### PR TITLE
BGFX_RESET_VSYNC toggle doesn't affect secondary swap chains on D3D11, Vulkan, and OpenGL (works on D3D12)

### DIFF
--- a/src/glcontext_egl.cpp
+++ b/src/glcontext_egl.cpp
@@ -617,7 +617,8 @@ WL_EGL_IMPORT
 			BGFX_FATAL(success, Fatal::UnableToInitialize, "Failed to set context.");
 			m_current = NULL;
 
-			eglSwapInterval(m_display, 0);
+			m_swapInterval = !!(_resolution.reset & BGFX_RESET_VSYNC) ? 1 : 0;
+			eglSwapInterval(m_display, m_swapInterval);
 		}
 
 		import();
@@ -703,7 +704,11 @@ WL_EGL_IMPORT
 		if (NULL != m_display)
 		{
 			const bool vsync = !!(_resolution.reset & BGFX_RESET_VSYNC);
-			EGL_CHECK(eglSwapInterval(m_display, vsync ? 1 : 0) );
+			m_swapInterval = vsync ? 1 : 0;
+			// Apply to the currently-bound (main) surface. Secondary SwapChainGL surfaces
+			// get the value applied lazily in makeCurrent() when they become current, since
+			// eglSwapInterval is per-surface.
+			EGL_CHECK(eglSwapInterval(m_display, m_swapInterval) );
 		}
 	}
 
@@ -762,6 +767,14 @@ WL_EGL_IMPORT
 			else
 			{
 				_swapChain->makeCurrent();
+			}
+
+			// eglSwapInterval is per-surface, so re-apply the cached interval every time a
+			// different surface becomes current. Without this, secondary swap chains keep
+			// their driver default (typically vsync ON) even after resize().
+			if (NULL != m_display)
+			{
+				EGL_CHECK(eglSwapInterval(m_display, m_swapInterval) );
 			}
 		}
 	}

--- a/src/glcontext_egl.h
+++ b/src/glcontext_egl.h
@@ -47,6 +47,7 @@ namespace bgfx { namespace gl
 			, m_eglWindow(NULL)
 #endif
 			, m_msaaContext(false)
+			, m_swapInterval(0)
 		{
 		}
 
@@ -81,6 +82,9 @@ namespace bgfx { namespace gl
 
 		// true when MSAA is handled by the context instead of using MSAA FBO
 		bool m_msaaContext;
+		// Desired eglSwapInterval value, cached so it can be re-applied whenever a swap
+		// chain's surface becomes current (eglSwapInterval is per-surface).
+		int m_swapInterval;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -295,9 +295,10 @@ namespace bgfx { namespace gl
 			BGFX_FATAL(0 != result, Fatal::UnableToInitialize, "wglMakeCurrent failed!");
 			m_current = NULL;
 
+			m_swapInterval = !!(_resolution.reset & BGFX_RESET_VSYNC) ? 1 : 0;
 			if (NULL != wglSwapIntervalEXT)
 			{
-				wglSwapIntervalEXT(0);
+				wglSwapIntervalEXT(m_swapInterval);
 			}
 		}
 
@@ -329,10 +330,15 @@ namespace bgfx { namespace gl
 
 	void GlContext::resize(const Resolution& _resolution)
 	{
+		const bool vsync = !!(_resolution.reset & BGFX_RESET_VSYNC);
+		m_swapInterval = vsync ? 1 : 0;
+
 		if (NULL != wglSwapIntervalEXT)
 		{
-			const bool vsync = !!(_resolution.reset & BGFX_RESET_VSYNC);
-			wglSwapIntervalEXT(vsync ? 1 : 0);
+			// Apply to the currently-bound (main) context. Secondary SwapChainGL contexts
+			// get the value applied lazily in makeCurrent() when they become current, since
+			// wglSwapIntervalEXT is per-context on Windows.
+			wglSwapIntervalEXT(m_swapInterval);
 		}
 	}
 
@@ -392,6 +398,14 @@ namespace bgfx { namespace gl
 			else
 			{
 				_swapChain->makeCurrent();
+			}
+
+			// wglSwapIntervalEXT is per-context on Windows, so re-apply the cached interval
+			// every time a different context becomes current. Without this, secondary swap
+			// chains keep their driver default (typically vsync ON) even after resize().
+			if (NULL != wglSwapIntervalEXT)
+			{
+				wglSwapIntervalEXT(m_swapInterval);
 			}
 		}
 	}

--- a/src/glcontext_wgl.h
+++ b/src/glcontext_wgl.h
@@ -66,6 +66,7 @@ typedef void (APIENTRYP PFNGLSTENCILOPPROC) (GLenum fail, GLenum zfail, GLenum z
 			, m_context(NULL)
 			, m_hdc(NULL)
 			, m_msaaContext(false)
+			, m_swapInterval(0)
 		{
 		}
 
@@ -95,6 +96,9 @@ typedef void (APIENTRYP PFNGLSTENCILOPPROC) (GLenum fail, GLenum zfail, GLenum z
 		HDC m_hdc;
 		// true when MSAA is handled by the context instead of using MSAA FBO
 		bool m_msaaContext;
+		// Desired wglSwapIntervalEXT value, cached so it can be re-applied whenever a swap
+		// chain's context becomes current (wglSwapIntervalEXT is per-context on Windows).
+		int m_swapInterval;
 	};
 } /* namespace gl */ } // namespace bgfx
 

--- a/src/renderer_d3d11.cpp
+++ b/src/renderer_d3d11.cpp
@@ -2386,9 +2386,16 @@ namespace bgfx { namespace d3d11
 					: !!(m_resolution.reset & BGFX_RESET_VSYNC)
 					;
 
+				uint32_t presentFlags = 0;
+				if (!syncInterval
+				&&  m_dxgi.tearingSupported() )
+				{
+					presentFlags |= DXGI_PRESENT_ALLOW_TEARING;
+				}
+
 				for (uint32_t ii = 1, num = m_numWindows; ii < num && SUCCEEDED(hr); ++ii)
 				{
-					hr = m_frameBuffers[m_windows[ii].idx].present(syncInterval);
+					hr = m_frameBuffers[m_windows[ii].idx].present(syncInterval, presentFlags);
 				}
 
 				if (SUCCEEDED(hr) )
@@ -2396,14 +2403,6 @@ namespace bgfx { namespace d3d11
 					if (NULL != m_swapChain
 					&&  m_needPresent)
 					{
-						uint32_t presentFlags = 0;
-
-						if (!syncInterval
-						&&  m_dxgi.tearingSupported() )
-						{
-							presentFlags |= DXGI_PRESENT_ALLOW_TEARING;
-						}
-
 						hr = m_swapChain->Present(syncInterval, presentFlags);
 
 						m_needPresent = false;
@@ -5286,11 +5285,11 @@ namespace bgfx { namespace d3d11
 		s_renderD3D11->m_currentDepthStencil = m_dsv;
 	}
 
-	HRESULT FrameBufferD3D11::present(uint32_t _syncInterval)
+	HRESULT FrameBufferD3D11::present(uint32_t _syncInterval, uint32_t _flags)
 	{
 		if (m_needPresent)
 		{
-			HRESULT hr = m_swapChain->Present(_syncInterval, 0);
+			HRESULT hr = m_swapChain->Present(_syncInterval, _flags);
 			hr = !isLost(hr) ? S_OK : hr;
 			m_needPresent = false;
 			return hr;

--- a/src/renderer_d3d11.h
+++ b/src/renderer_d3d11.h
@@ -345,7 +345,7 @@ namespace bgfx { namespace d3d11
 		void resolve();
 		void clear(const Clear& _clear, const float _palette[][4]);
 		void set();
-		HRESULT present(uint32_t _syncInterval);
+		HRESULT present(uint32_t _syncInterval, uint32_t _flags);
 
 		ID3D11RenderTargetView*    m_rtv[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS-1];
 		ID3D11UnorderedAccessView* m_uav[BGFX_CONFIG_MAX_FRAME_BUFFER_ATTACHMENTS-1];

--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3005,6 +3005,22 @@ VK_IMPORT_DEVICE
 				m_resolution.width = m_backBuffer.m_width;
 				m_resolution.height = m_backBuffer.m_height;
 
+				// Propagate reset flags (e.g. BGFX_RESET_VSYNC) to secondary window swapchains,
+				// otherwise they'd keep their original present mode and ignore the reset.
+				for (uint16_t ii = 0; ii < m_numWindows; ++ii)
+				{
+					if (!isValid(m_windows[ii]) )
+					{
+						continue;
+					}
+
+					FrameBufferVK& fb = m_frameBuffers[m_windows[ii].idx];
+					Resolution fbResolution = m_resolution;
+					fbResolution.width  = fb.m_width;
+					fbResolution.height = fb.m_height;
+					fb.update(m_commandBuffer, fbResolution);
+				}
+
 				postReset();
 			}
 


### PR DESCRIPTION
Hi.

When an app creates secondary swap chains via createFrameBuffer(nwh, ...) (a common pattern for editors that initialize bgfx with a hidden dummy window and then render into one or more real windows), toggling BGFX_RESET_VSYNC through bgfx::reset() has no effect on those secondary swap chains. Should also be the same issue in the example-22-windows. The framerate stays capped at the display refresh rate no matter what flags are passed. The only backend where this works correctly is D3D12.

Reproduction
Initialize bgfx with a hidden init window.
Create a real window and make a frame buffer with createFrameBuffer(nwh, w, h, ...).
Render exclusively into that frame buffer.
Call bgfx::reset(w, h, flags_without_BGFX_RESET_VSYNC).
Observe: framerate still locked at refresh rate on D3D11, Vulkan, and OpenGL. Works correctly on D3D12.
Root cause per backend
D3D11 — RendererContextD3D11::flip() computes DXGI_PRESENT_ALLOW_TEARING only for the main swap chain. FrameBufferD3D11::present(uint32_t _syncInterval) has no flags parameter and hard-codes m_swapChain->Present(_syncInterval, 0). With a FLIP_DISCARD swap chain, Present(0, 0) still syncs to the compositor; you need DXGI_PRESENT_ALLOW_TEARING in the Present call. D3D12 already does the right thing — its FrameBufferD3D12::present(uint32_t, uint32_t) takes and forwards the flags.

Vulkan — updateResolution() only calls m_backBuffer.update(...). It never iterates m_windows[] to update secondary FrameBufferVK instances, so their SwapChainVK::m_resolution.reset is stale and recreateSwapchain never triggers on vsync change. The secondary swapchains keep their original VK_PRESENT_MODE_FIFO_KHR until something else (e.g. a resize causing SUBOPTIMAL_KHR) forces recreation.

OpenGL — wglSwapIntervalEXT is per-context on Windows and eglSwapInterval is per-surface on EGL. GlContext::resize() applies the new interval only to whatever context is currently bound (the main one). Secondary SwapChainGL instances have their own contexts/surfaces and keep the driver default (typically vsync on) until someone explicitly makes them current and calls the swap-interval function again.

Suggested fix
D3D11: change FrameBufferD3D11::present signature to present(uint32_t _syncInterval, uint32_t _flags) and forward _flags to Present. In flip(), compute presentFlags once (including DXGI_PRESENT_ALLOW_TEARING when syncInterval == 0 and m_dxgi.tearingSupported()) and pass it to both the secondary framebuffers and the main swap chain. This mirrors the existing D3D12 implementation.

Vulkan: in updateResolution(), after m_backBuffer.update(), loop over m_windows[] and call fb.update(m_commandBuffer, resolution) on each valid secondary FrameBufferVK, using the framebuffer's own width/height but the updated reset flags. SwapChainVK::update() will then detect the BGFX_RESET_VSYNC delta and recreate the swapchain with the correct present mode.

OpenGL (WGL/EGL): cache the desired swap interval in GlContext (e.g. int m_swapInterval), set it in resize(), and re-apply it in makeCurrent(SwapChainGL*) every time a different context/surface becomes current. This way secondary swap chains pick up the current value the first time they're made current after a reset. Also read the initial vsync state from _resolution.reset in create() instead of hard-coding 0.