### PR TITLE
Added macOS x86_64 build target (osx-x64).

### DIFF
--- a/makefile
+++ b/makefile
@@ -42,6 +42,7 @@ projgen: ## Generate project files for all configurations.
 	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --gcc=linux-gcc       gmake
 	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --gcc=linux-clang     gmake
 	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --gcc=osx-arm64       gmake
+	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --gcc=osx-x64         gmake
 	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --xcode=osx           xcode9
 	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --xcode=ios           xcode9
 	$(GENIE)              --with-combined-examples --with-shared-lib --gcc=android-arm64   gmake
@@ -127,6 +128,14 @@ osx-arm64-debug: .build/projects/gmake-osx-arm64 ## Build - macOS ARM Debug
 osx-arm64-release: .build/projects/gmake-osx-arm64 ## Build - macOS ARM Release
 	$(MAKE) -C .build/projects/gmake-osx-arm64 config=release
 osx-arm64: osx-arm64-debug osx-arm64-release ## Build - macOS ARM Debug and Release
+
+.build/projects/gmake-osx-x64:
+	$(GENIE) --with-tools --with-combined-examples --with-shared-lib --gcc=osx-x64 gmake
+osx-x64-debug: .build/projects/gmake-osx-x64 ## Build - macOS x64 Debug
+	$(MAKE) -C .build/projects/gmake-osx-x64 config=debug
+osx-x64-release: .build/projects/gmake-osx-x64 ## Build - macOS x64 Release
+	$(MAKE) -C .build/projects/gmake-osx-x64 config=release
+osx-x64: osx-x64-debug osx-x64-release ## Build - macOS x64 Debug and Release
 
 .build/projects/gmake-ios-arm64:
 	$(GENIE) --gcc=ios-arm64 gmake


### PR DESCRIPTION
## Title

Added macOS x86_64 build target (osx-x64).

## Body

**Problem**

The bgfx makefile only provides `osx-arm64` gmake targets. There is no gmake target for building x86_64 binaries on macOS, which is needed for creating universal binaries (`lipo`-merged fat binaries) that support both Intel and Apple Silicon Macs.

**Root cause**

The makefile's `projgen` and build sections were only populated with ARM64 macOS targets.

**Fix**

Add `gmake-osx-x64` project generation and debug/release build targets, mirroring the existing `osx-arm64` structure.

- `projgen`: add `$(GENIE) --gcc=osx-x64 gmake`
- Build targets: `osx-x64-debug`, `osx-x64-release`, `osx-x64`

**Test**

- Run `make projgen` on macOS and verify `.build/projects/gmake-osx-x64` is generated.
- Run `make osx-x64` and verify both debug and release configurations compile successfully on an Intel Mac (or via Rosetta).
- Use `lipo -create` to merge `osx-arm64` and `osx-x64` outputs into a universal binary.
