### PR TITLE
Metal: Fixed NULL pointer dereference in BufferMtl::update.

### DIFF
--- a/src/renderer_mtl.cpp
+++ b/src/renderer_mtl.cpp
@@ -3241,6 +3241,11 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 
 	void BufferMtl::update(uint32_t _offset, uint32_t _size, void* _data, bool _discard)
 	{
+		if (NULL == m_ptr)
+		{
+			return;
+		}
+
 		MTL::BlitCommandEncoder* bce = s_renderMtl->getBlitCommandEncoder();
 
 		if (!m_vertex


### PR DESCRIPTION
## Title

Metal: Fixed NULL pointer dereference in BufferMtl::update.

## Body

**Problem**

`BufferMtl::update()` can crash with a NULL pointer dereference when the underlying `m_ptr` (the Metal buffer object) is null. This happens if the buffer was created but backing storage allocation failed, or if `update()` is called after the buffer has been destroyed but before the handle is invalidated.

**Root cause**

The method assumes `m_ptr` is always valid and immediately calls `s_renderMtl->getBlitCommandEncoder()` without checking.

**Fix**

Add an early return if `m_ptr` is NULL, matching the defensive pattern used elsewhere in the renderer.

**Test**

- Build bgfx examples with the Metal renderer on macOS.
- Run examples that create and update dynamic buffers (e.g. `07-callback`, `18-ibl`).
- No functional change for valid buffers; avoids crashes for edge-case buffer lifecycles.
