### PR TITLE
Fix UBSan undefined-behavior hits in bgfx_p.h

### DIFF
--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -852,13 +852,8 @@ namespace bgfx
 			: mask(0)
 			, idx(0)
 		{
-			if (0 == _mask)
-			{
-				return;
-			}
-
 			const uint8_t ntz = bx::countTrailingZeros<MaskT>(_mask);
-			mask = MaskT(_mask >> ntz);
+			mask = 0 == _mask ? MaskT(0) : MaskT(_mask >> ntz);
 			idx  = ntz;
 		}
 
@@ -867,13 +862,8 @@ namespace bgfx
 			mask = MaskT(mask >> 1);
 			idx += 1;
 
-			if (0 == mask)
-			{
-				return;
-			}
-
 			const uint8_t ntz = bx::countTrailingZeros<MaskT>(mask);
-			mask = MaskT(mask >> ntz);
+			mask = 0 == mask ? MaskT(0) : MaskT(mask >> ntz);
 			idx += ntz;
 		}
 
@@ -1435,12 +1425,12 @@ namespace bgfx
 			m_hasAlphaRef = false;
 		}
 
-		uint32_t      m_depth       = 0;
-		uint32_t      m_seq         = 0;
-		ProgramHandle m_program     = {0};
-		ViewId        m_view        = 0;
-		uint8_t       m_blend       = 0;
-		bool          m_hasAlphaRef = false;
+		uint32_t      m_depth;
+		uint32_t      m_seq;
+		ProgramHandle m_program;
+		ViewId        m_view;
+		uint8_t       m_blend;
+		bool          m_hasAlphaRef;
 	};
 #undef SORT_KEY_RENDER_DRAW
 
@@ -2763,6 +2753,7 @@ namespace bgfx
 			// clear all bytes (inclusively the padding) before we start.
 			bx::memSet(&m_bind, 0, sizeof(m_bind) );
 
+			m_key.reset();
 			m_discard = false;
 			m_draw.clear(BGFX_DISCARD_ALL);
 			m_compute.clear(BGFX_DISCARD_ALL);

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -849,18 +849,32 @@ namespace bgfx
 	struct BitMaskToIndexIteratorT
 	{
 		BitMaskToIndexIteratorT(MaskT _mask)
+			: mask(0)
+			, idx(0)
 		{
-			const uint8_t ntz = bx::countTrailingZeros(_mask);
-			mask = _mask >> ntz;
+			if (0 == _mask)
+			{
+				return;
+			}
+
+			const uint8_t ntz = bx::countTrailingZeros<MaskT>(_mask);
+			mask = MaskT(_mask >> ntz);
 			idx  = ntz;
 		}
 
 		void next()
 		{
-			// operator>> promotes to int, so we need to cast back:
-			const uint8_t ntzPlus1 = bx::countTrailingZeros<MaskT>(mask>>1) + 1;
-			mask >>= ntzPlus1;
-			idx   += ntzPlus1;
+			mask = MaskT(mask >> 1);
+			idx += 1;
+
+			if (0 == mask)
+			{
+				return;
+			}
+
+			const uint8_t ntz = bx::countTrailingZeros<MaskT>(mask);
+			mask = MaskT(mask >> ntz);
+			idx += ntz;
 		}
 
 		bool isDone() const

--- a/src/bgfx_p.h
+++ b/src/bgfx_p.h
@@ -1421,12 +1421,12 @@ namespace bgfx
 			m_hasAlphaRef = false;
 		}
 
-		uint32_t      m_depth;
-		uint32_t      m_seq;
-		ProgramHandle m_program;
-		ViewId        m_view;
-		uint8_t       m_blend;
-		bool          m_hasAlphaRef;
+		uint32_t      m_depth       = 0;
+		uint32_t      m_seq         = 0;
+		ProgramHandle m_program     = {0};
+		ViewId        m_view        = 0;
+		uint8_t       m_blend       = 0;
+		bool          m_hasAlphaRef = false;
 	};
 #undef SORT_KEY_RENDER_DRAW
 


### PR DESCRIPTION
[Created by Copilot on behalf of @bghgary]

## Problem

BabylonNative's sanitized macOS CI, running with `-fno-sanitize-recover=all` so UBSan findings become hard failures, reports three UndefinedBehaviorSanitizer hits in `src/bgfx_p.h`:

```
bgfx_p.h:1339:42: runtime error: load of value 190, which is not a valid value for type 'bool'
bgfx_p.h:854:17:  runtime error: shift exponent 32 is too large for 32-bit type 'unsigned int'
bgfx_p.h:862:9:   runtime error: shift exponent 33 is too large for 32-bit type 'unsigned int'
```

Line numbers reference the current `master` tree. UBSan has always caught these; they were previously silent only because UBSan defaults to recoverable mode.

### 1. `SortKey` read before first `reset()` / `setState()`

`EncoderImpl` contains a `SortKey m_key` member. The `EncoderImpl()` constructor clears `m_bind`/`m_draw`/`m_compute` but does not call `m_key.reset()`. `EncoderImpl::submit()` (`bgfx.cpp:1451-1464`) writes `m_key.m_program`, `m_key.m_view`, and one of `m_depth`/`m_seq`, then calls `m_key.encodeDraw()` which reads `m_hasAlphaRef` and `m_blend`. Those two fields are only written by `m_key.setState()`, so any app that calls `bgfx::submit(view, program)` before ever calling `bgfx::setState(...)` reads `m_hasAlphaRef` uninitialized — UBSan's bool-validity check fires.

### 2. `BitMaskToIndexIteratorT` shifts by the type width

`bx::countTrailingZeros` deliberately returns the type width for a zero argument (e.g. 32 for `uint32_t`, 8 for `uint8_t`). The iterator feeds that value straight into a shift:

```cpp
const uint8_t ntz = bx::countTrailingZeros(_mask);
mask = _mask >> ntz;                              // UB when _mask == 0
...
const uint8_t ntzPlus1 = bx::countTrailingZeros<MaskT>(mask>>1) + 1;
mask >>= ntzPlus1;                                // UB when mask == 1
```

The ctor path hits UB when the iterator is constructed from a zero mask; `next()` hits UB on the last iteration (when `mask == 1`, `mask>>1 == 0`, and `ntzPlus1 = width + 1`).

## Fix

### `SortKey`

Call `m_key.reset()` in `EncoderImpl()`:

```cpp
EncoderImpl()
{
    bx::memSet(&m_bind, 0, sizeof(m_bind) );

    m_key.reset();
    m_discard = false;
    m_draw.clear(BGFX_DISCARD_ALL);
    m_compute.clear(BGFX_DISCARD_ALL);
    m_bind.clear(BGFX_DISCARD_ALL);
}
```

`m_key` is now initialized to a known state before any `submit()` call on the encoder. No other sites construct `SortKey` without immediately calling `reset()` or `decode()` so the single call suffices.

### `BitMaskToIndexIteratorT`

Guard each shift branchlessly so the width-valued `ntz` never reaches the shift operator:

```cpp
BitMaskToIndexIteratorT(MaskT _mask)
    : mask(0)
    , idx(0)
{
    const uint8_t ntz = bx::countTrailingZeros<MaskT>(_mask);
    mask = 0 == _mask ? MaskT(0) : MaskT(_mask >> ntz);
    idx  = ntz;
}

void next()
{
    mask = MaskT(mask >> 1);
    idx += 1;

    const uint8_t ntz = bx::countTrailingZeros<MaskT>(mask);
    mask = 0 == mask ? MaskT(0) : MaskT(mask >> ntz);
    idx += ntz;
}
```

`isDone()` returns `true` in exactly the same iterations as before — only the UB goes away.
