### PR TITLE
docs: clarify readTexture requires blit-to-staging for rendered content

### DIFF
--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -1880,6 +1880,13 @@ func.updateTextureCube { section = "Textures" }
 --- Read back texture content.
 ---
 --- @attention Texture must be created with `BGFX_TEXTURE_READ_BACK` flag.
+---            This flag is mutually exclusive with `BGFX_TEXTURE_RT` and is
+---            rejected on framebuffer attachments, so reading back rendered
+---            content requires a two-step copy: render into a regular
+---            `BGFX_TEXTURE_RT` texture, then `bgfx::blit` it into a staging
+---            texture flagged `BGFX_TEXTURE_READ_BACK | BGFX_TEXTURE_BLIT_DST`,
+---            then `readTexture` from the staging texture. See
+---            `examples/30-picking/picking.cpp` for the canonical pattern.
 --- @attention Availability depends on: `BGFX_CAPS_TEXTURE_READ_BACK`.
 ---
 func.readTexture { section = "Textures" }


### PR DESCRIPTION
## Summary

The `readTexture` IDL docstring tells users that the source texture must be created with `BGFX_TEXTURE_READ_BACK`, but doesn't mention that `BGFX_TEXTURE_READ_BACK` is mutually exclusive with `BGFX_TEXTURE_RT` (enforced at `bgfx.cpp:4811-4815`) and rejected on framebuffer attachments (`bgfx.cpp:4725-4728`). So for the common case of reading back rendered content, the documented contract isn't directly satisfiable — you have to render to an `RT` and `bgfx::blit` into a separate staging texture flagged `BGFX_TEXTURE_READ_BACK | BGFX_TEXTURE_BLIT_DST`, then read back the staging.

That pattern is already in the codebase as `examples/30-picking/picking.cpp` (lines 120-143 and 392-393), but the `readTexture` docstring doesn't point at it.

## Why now

A user following only the public-API doc may attempt `BGFX_TEXTURE_RT` alone, which:
- Works in release builds (the `BX_ASSERT(ref.isReadBack(), ...)` in `Context::readTexture` compiles out)
- Works on `bgfx-Metal` and `bgfx-OpenGL` because their `readTexture` implementations handle RT-flagged textures permissively
- Trips the assertion in debug builds with the error *"Can't read from texture which was not created with `BGFX_TEXTURE_READ_BACK`."* and no obvious migration path

Cross-linking the docstring to the picking example saves the future-debugging round.

## Scope

`scripts/bgfx.idl` only. Generated headers, `.rst` docs, and language bindings should be regenerated by the maintainer (or in a follow-up commit if you'd prefer I push a regen — happy to).

Filed as **draft** so you can sanity-check the framing before review.