### PR TITLE
Fix: reset s_renderFrameCalled in bgfx::shutdown() to allow re-init

### DIFF
--- a/src/bgfx.cpp
+++ b/src/bgfx.cpp
@@ -3956,6 +3956,7 @@ namespace bgfx
 		}
 
 		s_threadIndex = 0;
+		s_renderFrameCalled = false;
 		g_callback    = NULL;
 		g_allocator   = NULL;
 	}


### PR DESCRIPTION
## Summary

`bgfx::renderFrame()` sets the static `s_renderFrameCalled = true` on its first call ([bgfx.cpp:1541](https://github.com/bkaradzic/bgfx/blob/master/src/bgfx.cpp#L1541)) and never clears it. `bgfx::shutdown()` resets `s_threadIndex = 0` ([line 3958](https://github.com/bkaradzic/bgfx/blob/master/src/bgfx.cpp#L3958)) but leaves `s_renderFrameCalled` sticky, so on a second `renderFrame()` after shutdown the gate at [line 1534](https://github.com/bkaradzic/bgfx/blob/master/src/bgfx.cpp#L1534) still runs `BGFX_CHECK_RENDER_THREAD()`. That assertion checks `(s_ctx != NULL && single-threaded) || (~BGFX_API_THREAD_MAGIC == s_threadIndex)`; both branches fail post-shutdown (`s_ctx == NULL`, `s_threadIndex == 0`), and the assertion fires in debug builds — blocking re-init of the bgfx context within the same process.

This is the only state asymmetry between shutdown and a fresh process: every other bit of bgfx's startup-thread-tracking state is reset by `shutdown()`. Adding the symmetric `s_renderFrameCalled = false;` reset makes shutdown actually fully restore the "uninitialized" state, so a subsequent `renderFrame()` + `init()` pair behaves like the first one.

Reproducer:
```cpp
{
    bgfx::renderFrame();
    bgfx::Init init;
    /* ... fill init ... */
    bgfx::init(init);
    /* run frames */
    bgfx::shutdown();
}
{
    bgfx::renderFrame();   // <-- BGFX FATAL: Must be called from render thread.
    /* ... */
}
```

## Test plan

- [x] Verified locally with a downstream gtest that constructs an SDL+bgfx wrapper, ticks a frame, destructs it, then re-constructs another instance from the same thread.
  - Without this patch: trips `bgfx_p.h`'s `BX_ASSERT(... "Must be called from render thread.")` in debug builds (release strips the assertion, masking the issue).
  - With this patch: passes in both debug and release on macOS (Metal) and OpenGL.
- [x] Existing examples (release builds) continue to work — the change is a no-op for code paths that don't call `shutdown()` followed by another `renderFrame()`.