### PR TITLE
docs: clarify readTexture's READ_BACK flag is CPU-only

### DIFF
--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -1880,6 +1880,8 @@ func.updateTextureCube { section = "Textures" }
 --- Read back texture content.
 ---
 --- @attention Texture must be created with `BGFX_TEXTURE_READ_BACK` flag.
+---            It's a texture for CPU readback, and can't be a GPU resource
+---            at the same time. See `examples/30-picking`.
 --- @attention Availability depends on: `BGFX_CAPS_TEXTURE_READ_BACK`.
 ---
 func.readTexture { section = "Textures" }


### PR DESCRIPTION
Reopens [#3689](https://github.com/bkaradzic/bgfx/pull/3689) — I'd self-closed that one as inaccurate, but per @bkaradzic's [comment](https://github.com/bkaradzic/bgfx/pull/3689#issuecomment-4321151855) the doc note was correct, just over-long. (Couldn't reopen the original after force-pushing the amended commit, hence a new PR.)

## Summary

Reframes the `@attention` block on `readTexture` around what `BGFX_TEXTURE_READ_BACK` *is* (a CPU-readback texture, can't double as a GPU resource) instead of the procedural three-step explanation in the original draft. The blit-to-staging guidance for rendered content collapses to one line that points at `examples/30-picking`.

## Diff

\`\`\`diff
 --- Read back texture content.
 ---
---- @attention Texture must be created with \`BGFX_TEXTURE_READ_BACK\` flag.
+--- @attention Texture must be created with \`BGFX_TEXTURE_READ_BACK\` flag,
+---            which makes it a CPU-readback texture — it cannot also be a
+---            GPU resource (\`BGFX_TEXTURE_RT\`, framebuffer attachment, etc.).
+---            To read back rendered content, \`bgfx::blit\` from a render
+---            target into a \`BGFX_TEXTURE_READ_BACK | BGFX_TEXTURE_BLIT_DST\`
+---            staging texture first. See \`examples/30-picking\`.
 --- @attention Availability depends on: \`BGFX_CAPS_TEXTURE_READ_BACK\`.
\`\`\`

Touches `scripts/bgfx.idl` only; generated headers/bindings will fall out of `scripts/genidl` at your convenience.