### PR TITLE
Metal: Honor BGFX_RESET_DEPTH_CLAMP via setDepthClipMode:.

### DIFF
--- a/src/renderer_mtl.cpp
+++ b/src/renderer_mtl.cpp
@@ -785,6 +785,8 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 			, m_capture(NULL)
 			, m_captureSize(0)
 			, m_variableRateShadingSupported(false)
+			, m_supportsDepthClipMode(false)
+			, m_depthClamp(false)
 			, m_screenshotTarget(NULL)
 			, m_screenshotBlitRenderPipelineState(NULL)
 			, m_commandBuffer(NULL)
@@ -891,6 +893,9 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 #endif // BX_PLATFORM_OSX
 
 			m_variableRateShadingSupported = false; //m_device.supportsVariableRasterizationRate();
+
+			m_supportsDepthClipMode = BX_ENABLED(BX_PLATFORM_OSX)
+				|| m_device->supportsFamily(MTL::GPUFamilyApple4);
 
 			g_caps.numGPUs = 1;
 			g_caps.gpu[0].vendorId = g_caps.vendorId;
@@ -1619,6 +1624,11 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 				m_renderCommandEncoderFrameBufferHandle = fbh;
 				MTL_RELEASE(renderPassDescriptor, 0);
 
+				if (m_depthClamp)
+				{
+					rce->setDepthClipMode(MTL::DepthClipModeClamp);
+				}
+
 				{
 					MTL::Viewport viewport = { 0.0f, 0.0f, (float)width, (float)height, 0.0f, 1.0f };
 					rce->setViewport(viewport);
@@ -1742,6 +1752,9 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 					: 1
 					;
 			}
+
+			m_depthClamp = m_supportsDepthClipMode
+				&& !!(_resolution.reset & BGFX_RESET_DEPTH_CLAMP);
 
 			const uint32_t maskFlags = ~(0
 				| BGFX_RESET_MAXANISOTROPY
@@ -1884,6 +1897,11 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 
 				m_renderCommandEncoder = m_commandBuffer->renderCommandEncoder(renderPassDescriptor);
 				MTL_RELEASE(renderPassDescriptor, 0);
+
+				if (m_depthClamp)
+				{
+					m_renderCommandEncoder->setDepthClipMode(MTL::DepthClipModeClamp);
+				}
 			}
 		}
 
@@ -3008,6 +3026,8 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 		uint32_t m_captureSize;
 
 		bool m_variableRateShadingSupported;
+		bool m_supportsDepthClipMode;
+		bool m_depthClamp;
 
 		MTL::RenderPipelineDescriptor* m_renderPipelineDescriptor;
 		MTL::DepthStencilDescriptor*   m_depthStencilDescriptor;
@@ -4847,6 +4867,11 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 							m_renderCommandEncoderFrameBufferHandle = fbh;
 
 							MTL_RELEASE(renderPassDescriptor, 0);
+
+							if (m_depthClamp)
+							{
+								rce->setDepthClipMode(MTL::DepthClipModeClamp);
+							}
 						}
 						else if (BX_ENABLED(BGFX_CONFIG_DEBUG_ANNOTATION) )
 						{
@@ -5735,6 +5760,11 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 			rce = m_commandBuffer->renderCommandEncoder(renderPassDescriptor);
 
 			MTL_RELEASE(renderPassDescriptor, 0);
+
+			if (m_depthClamp)
+			{
+				rce->setDepthClipMode(MTL::DepthClipModeClamp);
+			}
 
 			rce->setCullMode( (MTL::CullMode)MTL::CullModeNone);
 


### PR DESCRIPTION
The flag was already in `maskFlags` but never wired to any rasterizer state, so it was a no-op on Metal. Set MTLDepthClipModeClamp on each render command encoder when requested. Capability-gated: macOS always, Apple-GPU platforms gated by GPUFamilyApple4+. Let me know if you want some more granular gating on macOS, but I _think_ it's fine. It holds true on any Mac that can run a Metal binary.

## To reproduce

Apply this temporary patch to `examples/01-cubes/cubes.cpp`, build, run, and toggle the new "Depth clamp" checkbox in the Settings panel:

```diff
diff --git a/examples/01-cubes/cubes.cpp b/examples/01-cubes/cubes.cpp
--- a/examples/01-cubes/cubes.cpp
+++ b/examples/01-cubes/cubes.cpp
@@ -132,6 +132,7 @@ public:
 		, m_g(true)
 		, m_b(true)
 		, m_a(true)
+		, m_depthClamp(false)
 	{
 	}
 
@@ -270,6 +271,13 @@ public:
 			ImGui::Checkbox("Write B", &m_b);
 			ImGui::Checkbox("Write A", &m_a);
 
+			if (ImGui::Checkbox("Depth clamp", &m_depthClamp) )
+			{
+				m_reset = (m_reset & ~BGFX_RESET_DEPTH_CLAMP)
+					| (m_depthClamp ? BGFX_RESET_DEPTH_CLAMP : 0);
+				bgfx::reset(m_width, m_height, m_reset);
+			}
+
 			ImGui::Text("Primitive topology:");
 			ImGui::Combo("##topology", (int*)&m_pt, s_ptNames, BX_COUNTOF(s_ptNames) );
 
@@ -285,8 +293,9 @@ public:
 				float view[16];
 				bx::mtxLookAt(view, eye, at);
 
+				// Wide near plane so the depth-clamp zone is visible.
 				float proj[16];
-				bx::mtxProj(proj, 60.0f, float(m_width)/float(m_height), 0.1f, 100.0f, bgfx::getCaps()->homogeneousDepth);
+				bx::mtxProj(proj, 60.0f, float(m_width)/float(m_height), 8.0f, 100.0f, bgfx::getCaps()->homogeneousDepth);
 				bgfx::setViewTransform(0, view, proj);
 
 				// Set view 0 default viewport.
@@ -319,7 +328,8 @@ public:
 					bx::mtxRotateXY(mtx, time + xx*0.21f, time + yy*0.37f);
 					mtx[12] = -15.0f + float(xx)*3.0f;
 					mtx[13] = -15.0f + float(yy)*3.0f;
-					mtx[14] = 0.0f;
+					// Slide each cube through the near plane.
+					mtx[14] = -27.0f + bx::sin(time*0.5f + (xx + yy)*0.2f) * 5.0f;
 
 					// Set model matrix for rendering.
 					bgfx::setTransform(mtx);
@@ -364,6 +374,7 @@ public:
 	bool m_g;
 	bool m_b;
 	bool m_a;
+	bool m_depthClamp;
 };
```

**Without depth clamp**: cubes vanish whenever they cross the near plane (entirely-clipped state).
**With depth clamp**: cubes keep rasterizing, with the trailing edge collapsed onto z=near. The expected z-ordering breakdown inside the clamped region is also visible (overlap artifacts), confirming the GPU is honoring the new mode.

## Use case

Cascade shadow maps want to clamp out-of-frame casters to the near plane so they still write valid depth into the atlas. The alternatives are losing those casters (visible holes in shadows) or paying for a tessellated near-plane "pancake" projection in the vertex shader (which mis-interpolates triangles that span the near plane and produces visible striping).