### PR TITLE
Fix indefinite wait on the frame semaphore in the metal render backend when using frame(FLUSH).

### DIFF
--- a/src/renderer_mtl.cpp
+++ b/src/renderer_mtl.cpp
@@ -791,6 +791,7 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 			, m_blitCommandEncoder(NULL)
 			, m_renderCommandEncoder(NULL)
 			, m_computeCommandEncoder(NULL)
+			, m_frameActive(false)
 		{
 			bx::memSet(&m_windows, 0xff, sizeof(m_windows) );
 			bx::memSet(m_uniformBuffers, 0, sizeof(m_uniformBuffers) );
@@ -1738,6 +1739,7 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 
 			m_cmd.kick(true, false);
 			m_commandBuffer = 0;
+			m_frameActive = false;
 		}
 
 		void updateResolution(const Resolution& _resolution)
@@ -3046,6 +3048,7 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 		MTL::RenderCommandEncoder*  m_renderCommandEncoder;
 		MTL::ComputeCommandEncoder* m_computeCommandEncoder;
 		FrameBufferHandle           m_renderCommandEncoderFrameBufferHandle;
+		bool m_frameActive;
 	};
 
 	RendererContextI* rendererCreate(const Init& _init)
@@ -4256,8 +4259,8 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 		if (_finishAll)
 		{
 			uint32_t count = m_activeCommandBuffer != NULL
-				? 2
-				: 3
+				? BGFX_CONFIG_MAX_FRAME_LATENCY - 1
+				: BGFX_CONFIG_MAX_FRAME_LATENCY
 				;
 
 			for (uint32_t ii = 0; ii < count; ++ii)
@@ -4500,7 +4503,16 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 
 	void RendererContextMtl::submit(Frame* _render, const ClearQuad& _clearQuad, const MipGen& /*_mipGen*/, TextVideoMemBlitter& _textVideoMemBlitter)
 	{
-		m_cmd.finish(false);
+		if (!m_frameActive)
+		{
+			m_cmd.finish(false);
+			m_frameActive = true;
+
+			m_uniformBuffer = m_uniformBuffers[m_bufferIndex];
+			m_bufferIndex = (m_bufferIndex + 1) % BGFX_CONFIG_MAX_FRAME_LATENCY;
+			m_uniformBufferVertexOffset = 0;
+			m_uniformBufferFragmentOffset = 0;
+		}
 
 		if (NULL == m_commandBuffer)
 		{
@@ -4586,11 +4598,6 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 		{
 			MTL_RELEASE(m_screenshotTarget, 0);
 		}
-
-		m_uniformBuffer = m_uniformBuffers[m_bufferIndex];
-		m_bufferIndex = (m_bufferIndex + 1) % BGFX_CONFIG_MAX_FRAME_LATENCY;
-		m_uniformBufferVertexOffset = 0;
-		m_uniformBufferFragmentOffset = 0;
 
 		if (0 < _render->m_iboffset)
 		{


### PR DESCRIPTION
This was solved by Gemini Pro 3.1. Please review with care, but at least it solved the hang I was experiencing in SilverNode. The hardcoded constants 3 and 2 also were suggested to be replaced by `MAX_FRAME_LATENCY` and `MAX_FRAME_LATENCY - 1` in another chat session. It seemed plausible to me. @bkaradzic @attilaz PTAL.

Gemini Pro 3.1's response below:

---

> 
> An issue with the Metal backend's semaphore logic causes this deadlock. The `bgfx::mtl::RendererContextMtl::submit` function unconditionally consumes a semaphore token (via `m_cmd.finish(false)`) every time it is called. However, it only schedules a token to be posted back when the command buffer is submitted with `_endFrame=true`, which happens exclusively inside `RendererContextMtl::flip`.
> 
> When you issue a `bgfx::frame(BGFX_FRAME_FLUSH)` and use `BGFX_RESET_FLIP_AFTER_RENDER`, the `flip()` call is skipped for that frame. Because `flip()` is skipped, the current frame's command buffer is not "kicked" as an end-of-frame, preventing the completion handler from being attached. The result is that `submit()` consumes a semaphore token without `flip()` ever returning it, permanently leaking tokens. After `BGFX_CONFIG_MAX_FRAME_LATENCY` (usually 3) flushes, the semaphore counter drops to 0, causing the renderer to wait forever on the next `submit()`.
> 
> To fix this, we can introduce a boolean flag `m_frameActive` to ensure that we only start a new GPU frame (and therefore consume a semaphore token and increment the uniform buffer index) if the previous frame has actually been flipped.
> 
> 
> 1. Add a `bool m_frameActive;` member to `RendererContextMtl`.
> 2. Initialize `m_frameActive` to `false` in the constructor.
> 3. In `RendererContextMtl::submit()`, guard the frame-initialization logic (which consumes the semaphore and gets a new uniform buffer) behind `if (!m_frameActive)`.
> 4. In `RendererContextMtl::flip()`, set `m_frameActive = false` after kicking the command buffer to mark the frame as done.
> 

Co-authored-by: Gemini Pro 3.1 <gemini@aistudio.google.com>