### PR TITLE
VK: recreate window swap chains flagged for recreation

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -8538,6 +8538,19 @@ VK_DESTROY
 		BX_ASSERT(NULL != m_nwh, "FrameBufferVK::acquire is only valid for swap-chain framebuffers.");
 		BGFX_PROFILER_SCOPE("FrameBufferVK::acquire", kColorFrame);
 
+		// Window frame buffers are not recreated by updateResolution like the main back
+		// buffer is, so recreate here when the swap chain was flagged, e.g. with
+		// VK_SUBOPTIMAL_KHR after the window moved to another display.
+		if (this != &s_renderVK->m_backBuffer
+		&&  VK_NULL_HANDLE != m_swapChain.m_swapChain
+		&& (m_swapChain.m_needToRecreateSwapchain || m_swapChain.m_needToRecreateSurface) )
+		{
+			update(_commandBuffer, m_swapChain.m_resolution);
+
+			// update may kick the queue and rotate the command buffer, refresh the local handle
+			_commandBuffer = s_renderVK->m_commandBuffer;
+		}
+
 		const bool acquired = m_swapChain.acquire(_commandBuffer);
 		m_needPresent = m_swapChain.m_needPresent;
 		m_currentFramebuffer = m_swapChain.m_backBufferFrameBuffer[m_swapChain.m_backBufferColorIdx];


### PR DESCRIPTION
A window frame buffer permanently stops updating once acquiring its swap chain returns `VK_SUBOPTIMAL_KHR` or `VK_ERROR_OUT_OF_DATE_KHR`. Reproducible with examples/22-windows on native Wayland: newly created windows can come up already flagged and never render a single frame, and a live window stops as soon as it moves to another display (any output difference - scale, refresh rate, orientation - makes the surface go out of date).

The acquire flags the swap chain with `m_needToRecreateSwapchain` and then refuses forever: only the main back buffer is ever recreated (by `updateResolution`), window frame buffers have no recreation path at all.

Recreate a flagged window swap chain when acquiring it. `SwapChainVK::update` already synchronizes internally, and the main back buffer is excluded so it keeps going through `updateResolution` with its full pre/post reset.

With this change the example windows render and survive moving across displays. Found in Visual Pinball (a multi window bgfx application), where the freeze reproduced deterministically on every cross display move and is gone with this change.
