### PR TITLE
VK: do not block acquiring window swap chain images

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3224,7 +3224,10 @@ VK_IMPORT_DEVICE
 			else
 			{
 				int64_t start = bx::getHPCounter();
-				newFrameBuffer.acquire(m_commandBuffer);
+				// Only block acquiring the main back buffer: window swap chains may not be
+				// served anymore (e.g. fully occluded window on Wayland compositors without
+				// fifo-v1) and must not stall the whole frame.
+				newFrameBuffer.acquire(m_commandBuffer, &newFrameBuffer == &m_backBuffer);
 				m_presentElapsed += bx::getHPCounter() - start;
 			}
 
@@ -8297,7 +8300,7 @@ VK_DESTROY
 		return idx;
 	}
 
-	bool SwapChainVK::acquire(VkCommandBuffer _commandBuffer)
+	bool SwapChainVK::acquire(VkCommandBuffer _commandBuffer, bool _block)
 	{
 		BGFX_PROFILER_SCOPE("SwapChainVK::acquire", kColorFrame);
 
@@ -8321,13 +8324,22 @@ VK_DESTROY
 				result = vkAcquireNextImageKHR(
 					  device
 					, m_swapChain
-					, UINT64_MAX
+					, _block ? UINT64_MAX : 0
 					, m_lastImageAcquiredSemaphore
 					, VK_NULL_HANDLE
 					, &m_backBufferColorIdx
 					);
 			}
 
+			if (!_block
+			&& (VK_NOT_READY == result || VK_TIMEOUT == result) )
+			{
+				// No image available without blocking, e.g. a fully occluded window the
+				// compositor stopped serving; skip this swap chain for this frame instead
+				// of stalling all swap chains. The semaphore was not used, undo the rotation.
+				m_currentSemaphore = (m_currentSemaphore + kMaxBackBuffers - 1) % kMaxBackBuffers;
+				return false;
+			}
 
 			if (result != VK_SUCCESS)
 			{
@@ -8686,7 +8698,7 @@ VK_DESTROY
 		return denseIdx;
 	}
 
-	bool FrameBufferVK::acquire(VkCommandBuffer _commandBuffer)
+	bool FrameBufferVK::acquire(VkCommandBuffer _commandBuffer, bool _block)
 	{
 		BX_ASSERT(NULL != m_nwh, "FrameBufferVK::acquire is only valid for swap-chain framebuffers.");
 		BGFX_PROFILER_SCOPE("FrameBufferVK::acquire", kColorFrame);
@@ -8704,7 +8716,7 @@ VK_DESTROY
 			_commandBuffer = s_renderVK->m_commandBuffer;
 		}
 
-		const bool acquired = m_swapChain.acquire(_commandBuffer);
+		const bool acquired = m_swapChain.acquire(_commandBuffer, _block);
 		m_needPresent = m_swapChain.m_needPresent;
 		m_currentFramebuffer = m_swapChain.m_backBufferFrameBuffer[m_swapChain.m_backBufferColorIdx];
 

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -796,7 +796,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 		uint32_t findPresentMode(bool _vsync);
 		TextureFormat::Enum findSurfaceFormat(TextureFormat::Enum _format, VkColorSpaceKHR _colorSpace, bool _srgb);
 
-		bool acquire(VkCommandBuffer _commandBuffer);
+		bool acquire(VkCommandBuffer _commandBuffer, bool _block = true);
 		void present();
 
 		void transitionImage(VkCommandBuffer _commandBuffer);
@@ -875,7 +875,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 
 		void resolve();
 
-		bool acquire(VkCommandBuffer _commandBuffer);
+		bool acquire(VkCommandBuffer _commandBuffer, bool _block = true);
 		void present();
 
 		void markDirty() { m_needResolve = true; }


### PR DESCRIPTION
This is the Vulkan counterpart of #3732: the same occluded-window freeze, reproduced the same way in examples/22-windows (create a child window, then fully cover it with the main window - everything freezes). Where the Metal fix asks `NSWindow` for its `occlusionState` and skips `nextDrawable`, Vulkan has no portable occlusion query, but image availability is the same signal.

All swap chains are acquired with an infinite wait from the single submit thread, so one window the compositor has stopped serving stalls every window. The concrete trigger is a fully occluded window on a Wayland compositor without the fifo-v1 protocol (COSMIC today, older mutter/kwin/sway): it stops getting its buffers released, the acquire blocks forever, and the whole application drops to that window's ~1Hz frame-callback cadence (or deadlocks outright in mailbox mode).

It needs #3751 applied first to see it: on current master the child window never renders a frame because its swap chain comes up flagged for recreation, so acquire short-circuits before it ever reaches the blocking wait. Once the window actually renders, occluding it exposes the block. This is why it could not be reproduced on stock master earlier.

Window swap chains now acquire with a zero timeout and are simply skipped for the frame when no image is available (the unused acquire semaphore rotation is undone). Only the main back buffer may still block, since that wait is the frame pacing. Image availability acts as natural back pressure: a hidden window stops updating, everything else keeps running, and it resumes by itself once the compositor serves it again - no compositor specific behavior needed.

This addresses the acquire side; FIFO emulation on such compositors can also block in `vkQueuePresentKHR`, which is out of scope here and avoided by using mailbox for window swap chains.

Verified in examples/22-windows on native Wayland (COSMIC, RADV): with #3751 applied, fully covering a child window freezes the whole app on stock acquire and keeps everything running with this change. Also confirmed in Visual Pinball through its bundled bgfx: a fully covered score window went from ~1 fps (or a full deadlock in mailbox mode) to full frame rate, resuming on expose.

Stacked on #3751
