### PR TITLE
Vulkan: Fixed capture buffer size.

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -3004,7 +3004,7 @@ VK_IMPORT_DEVICE
 			{
 				const uint8_t  bpp         = bimg::getBitsPerPixel(bimg::TextureFormat::Enum(m_backBuffer.m_swapChain.m_colorFormat) );
 				const uint32_t pitch       = m_backBuffer.m_width * bpp / 8;
-				const uint32_t captureSize = m_backBuffer.m_width * pitch;
+				const uint32_t captureSize = m_backBuffer.m_height * pitch;
 
 				if (captureSize > m_captureSize)
 				{


### PR DESCRIPTION
`captureSize` is computed as `m_width * pitch`, but the swap-chain readback
copies `m_height` rows. `capture()` reports `_size = _height * _pitch`, and
`ReadbackVK::pitch()` is `width * bpp/8`. When the backbuffer is taller than
wide the readback buffer is under-allocated and overrun (crash in the capture
path). `m_height` makes it `width*height*bpp/8`, matching the GL backend's
`width*height*4`.

Repro: `BGFX_RESET_CAPTURE` with a portrait (height > width) window.
