### PR TITLE
Metal: Set input primitive topology and only add point_size when needed.

### DIFF
--- a/3rdparty/spirv-cross/spirv_msl.hpp
+++ b/3rdparty/spirv-cross/spirv_msl.hpp
@@ -605,6 +605,13 @@ public:
 		return used_swizzle_buffer;
 	}
 
+	// Provide feedback to calling API to determine if shader writes to point size.
+	// This allows shaderc to only add point_size when actually needed.
+	bool get_writes_to_point_size() const
+	{
+		return writes_to_point_size;
+	}
+
 	// Provide feedback to calling API to allow it to pass a buffer
 	// containing STORAGE_BUFFER buffer sizes to support OpArrayLength.
 	bool needs_buffer_size_buffer() const

--- a/src/renderer_mtl.cpp
+++ b/src/renderer_mtl.cpp
@@ -2617,6 +2617,7 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 				| BGFX_STATE_BLEND_INDEPENDENT
 				| BGFX_STATE_MSAA
 				| BGFX_STATE_BLEND_ALPHA_TO_COVERAGE
+				| BGFX_STATE_PT_MASK
 				);
 
 			const bool independentBlendEnable = !!(BGFX_STATE_BLEND_INDEPENDENT & _state);
@@ -2823,6 +2824,20 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 					? program.m_fsh->m_function
 					: NULL
 					);
+
+				switch (_state & BGFX_STATE_PT_MASK)
+				{
+					case BGFX_STATE_PT_POINTS:
+						pd->setInputPrimitiveTopology(MTL::PrimitiveTopologyClassPoint);
+						break;
+					case BGFX_STATE_PT_LINES:
+					case BGFX_STATE_PT_LINESTRIP:
+						pd->setInputPrimitiveTopology(MTL::PrimitiveTopologyClassLine);
+						break;
+					default:
+						pd->setInputPrimitiveTopology(MTL::PrimitiveTopologyClassTriangle);
+						break;
+				}
 
 				MTL::VertexDescriptor* vertexDesc = m_vertexDescriptor;
 				reset(vertexDesc);
@@ -5653,6 +5668,7 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 				   | BGFX_STATE_BLEND_INDEPENDENT
 				   | BGFX_STATE_MSAA
 				   | BGFX_STATE_BLEND_ALPHA_TO_COVERAGE
+				   | BGFX_STATE_PT_MASK
 				   ) & changedFlags
 				|| ( (blendFactor != draw.m_rgba) && !!(newFlags & BGFX_STATE_BLEND_INDEPENDENT) ) )
 				{

--- a/tools/shaderc/shaderc_metal.cpp
+++ b/tools/shaderc/shaderc_metal.cpp
@@ -755,13 +755,19 @@ namespace bgfx { namespace metal
 					// insert struct member which declares point size, defaulted to 1
 					if ('v' == _options.shaderType)
 					{
-						const bx::StringView xlatMtlMainOut("xlatMtlMain_out\n{");
-						size_t pos = source.find(xlatMtlMainOut.getPtr() );
-
-						if (pos != std::string::npos)
+						if (msl.get_writes_to_point_size())
 						{
-							pos += xlatMtlMainOut.getLength();
-							source.insert(pos, "\n\tfloat bgfx_metal_pointSize [[point_size]] = 1;");
+							if (source.find("[[point_size]]") == std::string::npos)
+							{
+								const bx::StringView xlatMtlMainOut("xlatMtlMain_out\n{");
+								size_t pos = source.find(xlatMtlMainOut.getPtr());
+
+								if (pos != std::string::npos)
+								{
+									pos += xlatMtlMainOut.getLength();
+									source.insert(pos, "\n\tfloat bgfx_metal_pointSize [[point_size]] = 1;");
+								}
+							}
 						}
 					}
 


### PR DESCRIPTION
To work around #2822, shaderc adds a `[[point_size]]` line to every Metal vertex shader.

Metal does not allow a vertex shader output to contain both `[[point_size]]` and `[[render_target_array_index]]`.

When using layered rendering on macOS, that always-on `[[point_size]]` injection caused a Metal compile error.

With this PR, we only inject `[[point_size]]` when the shader actually writes to point size. spirv-cross already tracks this internally with a `writes_to_point_size` flag, but it wasn't exposed — so we added a `get_writes_to_point_size()` accessor to read it.

We also set the pipeline's `inputPrimitiveTopology` from the draw's primitive type (point, line, or triangle). Metal needs this to draw points correctly, and it's also required when a shader writes `[[render_target_array_index]]` for layered rendering.