### PR TITLE
Compare layout handle in vertex-stream rebind gate

### DIFF
--- a/src/renderer.h
+++ b/src/renderer.h
@@ -788,8 +788,9 @@ namespace bgfx
 			{
 				const uint8_t idx = it.idx;
 
-				if (_current.m_stream[idx].m_handle.idx  != _new.m_stream[idx].m_handle.idx
-				||  _current.m_stream[idx].m_startVertex != _new.m_stream[idx].m_startVertex)
+				if (_current.m_stream[idx].m_handle.idx       != _new.m_stream[idx].m_handle.idx
+				||  _current.m_stream[idx].m_startVertex      != _new.m_stream[idx].m_startVertex
+				||  _current.m_stream[idx].m_layoutHandle.idx != _new.m_stream[idx].m_layoutHandle.idx)
 				{
 					return true;
 				}

--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -8480,6 +8480,12 @@ namespace bgfx { namespace gl
 									currentState.m_stream[idx].m_startVertex = draw.m_stream[idx].m_startVertex;
 									bindAttribs = true;
 								}
+
+								if (currentState.m_stream[idx].m_layoutHandle.idx != draw.m_stream[idx].m_layoutHandle.idx)
+								{
+									currentState.m_stream[idx].m_layoutHandle = draw.m_stream[idx].m_layoutHandle;
+									bindAttribs = true;
+								}
 							}
 						}
 


### PR DESCRIPTION
`hasVertexStreamChanged()` (`src/renderer.h`) and OpenGL's inline copy in `renderer_gl.cpp` gate the vertex-buffer rebind on the stream's `m_handle` and `m_startVertex`, but not `m_layoutHandle`.

The bind offset is `m_startVertex * layout.m_stride`. All transient vertex buffers share one buffer handle, so two same-program draws that collide on `m_startVertex` but use different-stride layouts look unchanged: the rebind is skipped and the second draw inherits the first's offset/stride, producing corrupt geometry.

The shared gate feeds Vulkan, D3D11, Metal, and WebGPU; OpenGL has its own copy of the same logic. All five skip the rebind, so it is not backend-specific.

**Fix:** compare `m_layoutHandle.idx` in both gates.

**Repro:** [`vrimar:repro/transient-layout-bug`](https://github.com/vrimar/bgfx/tree/repro/transient-layout-bug), two transient draws (stride 16 vs 24) colliding on `startVertex 6`. The blue triangle is missing on every backend and renders with this fix. Kept out of this PR.

Possibly related to #2562 (reported on OpenGL and Vulkan).