### PR TITLE
Fix segmentation fault in Vulkan XCB surface fallback due to missing null check

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -7856,15 +7856,20 @@ VK_DESTROY
 						typedef xcb_connection_t* (*PFN_XGETXCBCONNECTION)(Display*);
 						PFN_XGETXCBCONNECTION XGetXCBConnection = (PFN_XGETXCBCONNECTION)bx::dlsym(xcbdll, "XGetXCBConnection");
 
-						VkXcbSurfaceCreateInfoKHR sci;
-						sci.sType      = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
-						sci.pNext      = NULL;
-						sci.flags      = 0;
-						sci.connection = XGetXCBConnection( (Display*)g_platformData.ndt);
-						sci.window     = bx::narrowCast<xcb_window_t>(uintptr_t(m_nwh) );
-						result = vkCreateXcbSurfaceKHR(instance, &sci, allocatorCb, &m_surface);
-						BX_WARN(VK_SUCCESS == result, "vkCreateXcbSurfaceKHR failed %d: %s.", result, getName(result) );
-
+						if (NULL != XGetXCBConnection)
+						{
+							VkXcbSurfaceCreateInfoKHR sci;
+							sci.sType      = VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR;
+							sci.pNext      = NULL;
+							sci.flags      = 0;
+							sci.connection = XGetXCBConnection( (Display*)g_platformData.ndt);
+							if (NULL != sci.connection)
+							{
+								sci.window     = bx::narrowCast<xcb_window_t>(uintptr_t(m_nwh) );
+								result = vkCreateXcbSurfaceKHR(instance, &sci, allocatorCb, &m_surface);
+								BX_WARN(VK_SUCCESS == result, "vkCreateXcbSurfaceKHR failed %d: %s.", result, getName(result) );
+							}
+						}
 						bx::dlclose(xcbdll);
 					}
 				}


### PR DESCRIPTION
When initializing a Vulkan surface on Linux via X11, if `vkCreateXlibSurfaceKHR` fails or is unavailable, `bgfx` falls back to attempting `vkCreateXcbSurfaceKHR`. 

During this fallback process, `bgfx` dynamically loads `libX11-xcb.so.1` and uses `dlsym` to resolve the `XGetXCBConnection` symbol. However, there was no `NULL` check on the returned function pointer before invoking it. 

If `dlsym` fails to resolve the symbol (which can happen in certain execution environments due to strict library scoping or restricted `dlopen` visibility), `XGetXCBConnection` evaluates to `NULL`. This resulted in an immediate segmentation fault when `bgfx` attempted to call it.

I Added a standard `if (NULL != XGetXCBConnection)` check before invoking the function pointer, and similarly checked the resulting `sci.connection` before attempting to create the surface. This safely skips the XCB surface creation if the symbol cannot be resolved, allowing the initialization to fail gracefully or proceed to the next fallback without crashing.
