### PR TITLE
fix(android): glPolygonMode override

### DIFF
--- a/src/renderer_gl.cpp
+++ b/src/renderer_gl.cpp
@@ -2937,7 +2937,7 @@ namespace bgfx { namespace gl
 					;
 
 				if (BX_ENABLED(BX_PLATFORM_EMSCRIPTEN)
-				||  NULL == glPolygonMode)
+				|| BX_ENABLED(BX_PLATFORM_ANDROID) || NULL == glPolygonMode)
 				{
 					glPolygonMode = stubPolygonMode;
 				}


### PR DESCRIPTION
OpenGL ES does not support the glPolygonMode function