### PR TITLE
Fix vkCmdBeginRenderPass crash on unused views in headless mode

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -9051,7 +9051,7 @@ VK_DESTROY
 	bool FrameBufferVK::isRenderable() const
 	{
 		return false
-			|| (NULL == m_nwh)
+			|| (NULL == m_nwh && m_currentFramebuffer != VK_NULL_HANDLE)
 			|| m_swapChain.m_needPresent
 			;
 	}

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -768,6 +768,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 		SwapChainVK()
 			: m_nwh(NULL)
 			, m_swapChain(VK_NULL_HANDLE)
+			, m_needPresent(false)
 			, m_lastImageRenderedSemaphore(VK_NULL_HANDLE)
 			, m_lastImageAcquiredSemaphore(VK_NULL_HANDLE)
 			, m_backBufferDepthStencilImageView(VK_NULL_HANDLE)
@@ -857,6 +858,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 			, m_nwh(NULL)
 			, m_needPresent(false)
 			, m_framebuffer(VK_NULL_HANDLE)
+			, m_currentFramebuffer(VK_NULL_HANDLE)
 		{
 		}
 


### PR DESCRIPTION
In the Vulkan renderer, `FrameBufferVK::isRenderable()` incorrectly returned `true` for the default backbuffer when running in headless mode (`m_nwh == NULL`), even though the underlying Vulkan framebuffer handle (`m_currentFramebuffer`) was `VK_NULL_HANDLE`.

If an application submits a draw call to a high-index view (e.g., view 255), BGFX iterates through all views up to that index. For any intermediate, unused views that fall back to the default backbuffer, the Vulkan renderer evaluates `isFrameBufferValid = fb.isRenderable()`. Because `isRenderable()` wrongly returned `true`, the renderer attempted to start a render pass with a null framebuffer, causing an immediate segmentation fault inside the Vulkan driver at `vkCmdBeginRenderPass`.

**Fix:**
Updated `FrameBufferVK::isRenderable()` to ensure `m_currentFramebuffer != VK_NULL_HANDLE` before returning `true` when `m_nwh` is `NULL`. This safely causes unused views in headless applications to be skipped without triggering empty render passes on invalid Vulkan handles.