### PR TITLE
Fixes missing type bug in zig-bindings introduced on #3756

### DIFF
--- a/bindings/zig/bgfx.zig
+++ b/bindings/zig/bgfx.zig
@@ -1759,7 +1759,7 @@ pub const Init = extern struct {
     pub const VideoDecoderInit = extern struct {
         magic: u32,
         codec: VideoCodec,
-        parameterSets: [*c]const uint8_t,
+        parameterSets: [*c]const u8,
         parameterSetsSize: u32,
         cachedAuBytes: u32,
         flags: u8,
@@ -1772,7 +1772,7 @@ pub const Init = extern struct {
 
     pub const VideoDecoderFrame = extern struct {
         magic: u32,
-        bitstream: [*c]const uint8_t,
+        bitstream: [*c]const u8,
         aus: [*c]const VideoDecoderAu,
         numAus: u32,
         presentationTimeUs: i64,

--- a/scripts/bindings-zig.lua
+++ b/scripts/bindings-zig.lua
@@ -75,6 +75,8 @@ local function convert_type_0(arg)
 		return arg.ctype:gsub("float", "f32")
 	elseif arg.ctype == "const char*" then
 		return "[*c]const u8"
+	elseif arg.ctype == "const uint8_t*" then
+		return "[*c]const u8"
 	elseif hasPrefix(arg.ctype, "char") then
 		return arg.ctype:gsub("char", "u8")
 	elseif hasSuffix(arg.fulltype, "Handle") then


### PR DESCRIPTION
#3756 Added support for video decoders, in it we had the structs `VideoDecoderInit` and `VideoDecoderFrame` using `const uint8_t*` that the zig IDL wasn't ready to deal with, because so far, all u8 arrays in bgfx were added as `const char*`.

Without this fix compiling the zig bindings fail with this error:

```
bindings/zig/bgfx.zig:1762:34: error: use of undeclared identifier 'uint8_t'
        parameterSets: [*c]const uint8_t,
                                 ^~~~~~~
bindings/zig/bgfx.zig:1775:30: error: use of undeclared identifier 'uint8_t'
        bitstream: [*c]const uint8_t,
                             ^~~~~~~
```