### PR TITLE
Metal: Fix wrong setScissor: calls after window resize

### DIFF
--- a/src/renderer_mtl.cpp
+++ b/src/renderer_mtl.cpp
@@ -5204,6 +5204,33 @@ static_assert(BX_COUNTOF(s_accessNames) == Access::Count, "Invalid s_accessNames
 
 	void FrameBufferMtl::postReset()
 	{
+		m_width  = 0;
+		m_height = 0;
+
+		for (uint32_t ii = 0; ii < m_num; ++ii)
+		{
+			const Attachment& at = m_colorAttachment[ii];
+
+			if (isValid(at.handle) )
+			{
+				const TextureMtl& texture = s_renderMtl->m_textures[at.handle.idx];
+
+				if (0 == m_width)
+				{
+					m_width  = bx::max<uint32_t>(1, texture.m_width  >> at.mip);
+					m_height = bx::max<uint32_t>(1, texture.m_height >> at.mip);
+				}
+			}
+		}
+
+		if (0 == m_width
+		&&  isValid(m_depthHandle) )
+		{
+			const Attachment& at = m_depthAttachment;
+			const TextureMtl& texture = s_renderMtl->m_textures[at.handle.idx];
+			m_width  = bx::max<uint32_t>(1, texture.m_width  >> at.mip);
+			m_height = bx::max<uint32_t>(1, texture.m_height >> at.mip);
+		}
 	}
 
 	uint16_t FrameBufferMtl::destroy()


### PR DESCRIPTION
Unlike the other backends, FrameBufferMtl::postReset was empty, so nothing was updating FrameBufferMtl::width/height on window resize, causing wrong setScissorRect: calls to be emitted.

This adds code to postReset that sets m_width/m_height from the sizes of the attached textures, like the other backends do.

<img width="2992" height="1888" alt="Screenshot 2026-08-25 at 21 30 16" src="https://github.com/user-attachments/assets/af1ceffa-1360-4e3d-88f4-ca062d01e8b1" />
