### PR TITLE
VK: Fixed non-blocking swap chain starving forever after a recreate

### DIFF
--- a/src/renderer_vk.cpp
+++ b/src/renderer_vk.cpp
@@ -8554,6 +8554,7 @@ VK_DESTROY
 
 		m_needPresent = false;
 		m_needToRecreateSwapchain = false;
+		m_primingAcquires = kPrimingAcquires;
 
 		return result;
 	}
@@ -8826,6 +8827,25 @@ VK_DESTROY
 			m_lastImageAcquiredSemaphore = m_presentDoneSemaphore[m_currentSemaphore];
 			m_currentSemaphore = (m_currentSemaphore + 1) % kMaxBackBuffers;
 
+			// Right after a (re)create no image is available until the first present
+			// commits the surface. With a zero timeout a non-blocking swap chain never
+			// gets past that: acquire returns VK_NOT_READY, so nothing is presented, so
+			// the compositor never hands an image back, and the window stays frozen.
+			// Spending a small wait budget primes the pump; once it is spent this is a
+			// plain non-blocking acquire again, so a window the compositor genuinely
+			// stopped serving is still skipped rather than stalling the other swap chains.
+			uint64_t timeout = 0;
+
+			if (_block)
+			{
+				timeout = UINT64_MAX;
+			}
+			else if (0 < m_primingAcquires)
+			{
+				--m_primingAcquires;
+				timeout = kPrimingAcquireWait;
+			}
+
 			VkResult result;
 			{
 				BGFX_PROFILER_SCOPE("vkAcquireNextImageKHR", kColorFrame);
@@ -8833,7 +8853,7 @@ VK_DESTROY
 				result = vkAcquireNextImageKHR(
 					  device
 					, m_swapChain
-					, _block ? UINT64_MAX : 0
+					, timeout
 					, m_lastImageAcquiredSemaphore
 					, VK_NULL_HANDLE
 					, &m_backBufferColorIdx
@@ -8858,6 +8878,7 @@ VK_DESTROY
 			switch (result)
 			{
 			case VK_SUCCESS:
+				m_primingAcquires = 0;
 				break;
 
 			case VK_ERROR_SURFACE_LOST_KHR:

--- a/src/renderer_vk.h
+++ b/src/renderer_vk.h
@@ -765,6 +765,11 @@ VK_DESTROY_FUNC(DescriptorSet);
 
 	constexpr uint32_t kMaxBackBuffers = bx::max(BGFX_CONFIG_MAX_BACK_BUFFERS, 10);
 
+	// How long a non-blocking swap chain is allowed to wait for its first image
+	// after a (re)create, and for how many acquires. See SwapChainVK::acquire.
+	constexpr uint32_t kPrimingAcquires    = 10;
+	constexpr uint64_t kPrimingAcquireWait = 10000000; // 10ms
+
 	struct SwapChainVK
 	{
 		SwapChainVK()
@@ -773,6 +778,7 @@ VK_DESTROY_FUNC(DescriptorSet);
 			, m_lastImageRenderedSemaphore(VK_NULL_HANDLE)
 			, m_lastImageAcquiredSemaphore(VK_NULL_HANDLE)
 			, m_needPresent(false)
+			, m_primingAcquires(0)
 			, m_backBufferDepthStencilImageView(VK_NULL_HANDLE)
 			, m_backBufferColorMsaaImageView(VK_NULL_HANDLE)
 		{
@@ -836,6 +842,10 @@ VK_DESTROY_FUNC(DescriptorSet);
 		bool m_needPresent;
 		bool m_needToRecreateSwapchain;
 		bool m_needToRecreateSurface;
+
+		// Non-blocking acquires still allowed to wait for the compositor to hand
+		// back the first image after a (re)create. See SwapChainVK::acquire.
+		uint32_t m_primingAcquires;
 
 		TextureVK   m_backBufferDepthStencil;
 		VkImageView m_backBufferDepthStencilImageView;


### PR DESCRIPTION
### The problem

A window swap chain that has just been created has no image available until the first
present commits the surface. On the non-blocking path the timeout is zero, so
`vkAcquireNextImageKHR` returns `VK_NOT_READY`, the frame is skipped, nothing is
presented — and because nothing is presented, the compositor never hands an image back.
The swap chain never recovers and the window stays frozen for the rest of the run.

I hit this on Linux/Wayland (GNOME/Mutter, NVIDIA) in a multi-window app: the compositor
reconfigures the secondary windows shortly after startup, the resulting swap chain
recreate lands on the non-blocking path, and from then on that window is dead. About 4700
consecutive `VK_NOT_READY` before I stopped counting. The primary swap chain is fine
because it takes the blocking path.

It is not Wayland-specific in principle — any compositor that hands the first image back
lazily can produce it — but Wayland is where it reproduces easily.

### The fix

Give a swap chain a small wait budget for its first few acquires after a (re)create
(10 acquires, 10ms each), and clear it as soon as an image actually comes through.

Once the budget is spent, or after the first success, this is a plain non-blocking
acquire again — so the case the zero timeout is there for still behaves as before:

> No image available without blocking, e.g. a fully occluded window the compositor
> stopped serving; skip this swap chain for this frame instead of stalling all swap chains.

The budget is deliberately spread across acquires rather than spent in one long wait: a
window the compositor has genuinely stopped serving pays at most 10ms in any single frame,
and 100ms in total, once, at create time — nothing after that.

### Notes

- `constexpr` budget lives next to `kMaxBackBuffers`; the counter sits with the other
  per-swap-chain state flags.
- Builds clean with `-Wall -Wextra`.
- The diagnosis comes from a cabinet build that has been running a variant of this for
  weeks, first carried as a patch in the Visual Pinball fork
  ([vbousquet/bgfx#6](https://github.com/vbousquet/bgfx/pull/6), now closed in favour of
  this). Worth mentioning because that fork's own fix to the same block — undoing the
  semaphore rotation when a non-blocking swap chain is skipped — has since landed here, so
  the surrounding code is identical in both places and the patch applies unchanged.
- The budget itself (10 x 10ms) is a judgement call — I have no way to characterise it
  against a slow compositor here, so I picked numbers that keep the worst case small.
  Happy to change them.