### PR TITLE
Re-capitalised "nVidia" to "NVIDIA"

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -265,7 +265,7 @@ Debugging and profiling
 
 ``BGFX_CONFIG_DEBUG_TEXT_MAX_SCALE`` - Debug text maximum scale factor for ``bgfx::dbgTextPrintf``. Default is 4.
 
-``BGFX_CONFIG_DEBUG_PERFHUD`` - Enable nVidia PerfHUD integration. Default is 0.
+``BGFX_CONFIG_DEBUG_PERFHUD`` - Enable NVIDIA PerfHUD integration. Default is 0.
 
 ``BGFX_CONFIG_DEBUG_ANNOTATION`` - Enable annotation for graphics debuggers (e.g. RenderDoc, PIX). Default matches ``BGFX_CONFIG_DEBUG``.
 
@@ -288,4 +288,4 @@ Miscellaneous
 
 ``BGFX_CONFIG_DRAW_INDIRECT_STRIDE`` - Stride in bytes of each draw indirect command. Fixed at 32 bytes. Not configurable.
 
-``BGFX_CONFIG_PREFER_DISCRETE_GPU`` - On laptops with integrated and discrete GPU, prefer selection of the discrete GPU (nVidia and AMD). Default is 1 on Windows, 0 elsewhere.
+``BGFX_CONFIG_PREFER_DISCRETE_GPU`` - On laptops with integrated and discrete GPU, prefer selection of the discrete GPU (NVIDIA and AMD). Default is 1 on Windows, 0 elsewhere.

--- a/examples/common/example-glue.cpp
+++ b/examples/common/example-glue.cpp
@@ -173,7 +173,7 @@ static const char* getPciIdName(uint16_t _pciId)
 	case BGFX_PCI_ID_ARM:                 return "ARM";
 	case BGFX_PCI_ID_INTEL:               return "Intel";
 	case BGFX_PCI_ID_MICROSOFT:           return "Microsoft";
-	case BGFX_PCI_ID_NVIDIA:              return "Nvidia";
+	case BGFX_PCI_ID_NVIDIA:              return "NVIDIA";
 	case BGFX_PCI_ID_SOFTWARE_RASTERIZER: return "Software Rasterizer";
 	default: break;
 	}

--- a/include/bgfx/defines.h
+++ b/include/bgfx/defines.h
@@ -549,7 +549,7 @@
 #define BGFX_PCI_ID_AMD                           UINT16_C(0x1002) //!< AMD adapter.
 #define BGFX_PCI_ID_APPLE                         UINT16_C(0x106b) //!< Apple adapter.
 #define BGFX_PCI_ID_INTEL                         UINT16_C(0x8086) //!< Intel adapter.
-#define BGFX_PCI_ID_NVIDIA                        UINT16_C(0x10de) //!< nVidia adapter.
+#define BGFX_PCI_ID_NVIDIA                        UINT16_C(0x10de) //!< NVIDIA adapter.
 #define BGFX_PCI_ID_MICROSOFT                     UINT16_C(0x1414) //!< Microsoft adapter.
 #define BGFX_PCI_ID_ARM                           UINT16_C(0x13b5) //!< ARM adapter.
 

--- a/scripts/bgfx.idl
+++ b/scripts/bgfx.idl
@@ -460,7 +460,7 @@ flag.PciId { bits = 16, const, section = "Initialization and Shutdown" }
 	.Amd                 (0x1002) --- AMD adapter.
 	.Apple               (0x106b) --- Apple adapter.
 	.Intel               (0x8086) --- Intel adapter.
-	.Nvidia              (0x10de) --- nVidia adapter.
+	.Nvidia              (0x10de) --- NVIDIA adapter.
 	.Microsoft           (0x1414) --- Microsoft adapter.
 	.Arm                 (0x13b5) --- ARM adapter.
 	()

--- a/src/config.h
+++ b/src/config.h
@@ -257,7 +257,7 @@
 #	define BGFX_CONFIG_DEBUG_TEXT_MAX_SCALE 4
 #endif // BGFX_CONFIG_DEBUG_TEXT_MAX_SCALE
 
-/// Enable nVidia PerfHUD integration.
+/// Enable NVIDIA PerfHUD integration.
 #ifndef BGFX_CONFIG_DEBUG_PERFHUD
 #	define BGFX_CONFIG_DEBUG_PERFHUD 0
 #endif // BGFX_CONFIG_DEBUG_NVPERFHUD
@@ -615,7 +615,7 @@ static_assert(BGFX_CONFIG_MAX_VERTEX_STREAMS < 32, "Must be less than 32!");
 #endif // BGFX_CONFIG_MAX_FRAME_LATENCY
 
 /// On laptops with integrated and discrete GPU, prefer selection of the
-/// discrete GPU. Applies to nVidia and AMD on Windows only.
+/// discrete GPU. Applies to NVIDIA and AMD on Windows only.
 /// Default is 1 on Windows, 0 elsewhere.
 #ifndef BGFX_CONFIG_PREFER_DISCRETE_GPU
 #	define BGFX_CONFIG_PREFER_DISCRETE_GPU BX_PLATFORM_WINDOWS

--- a/src/glcontext_wgl.cpp
+++ b/src/glcontext_wgl.cpp
@@ -360,7 +360,7 @@ namespace bgfx { namespace gl
 				m_context = wglCreateContextAttribsARB(m_hdc, 0, contextAttrs);
 				if (NULL == m_context)
 				{
-					// nVidia doesn't like context profile mask for contexts below 3.2?
+					// NVIDIA doesn't like context profile mask for contexts below 3.2?
 					contextAttrs[6] = WGL_CONTEXT_PROFILE_MASK_ARB == contextAttrs[6] ? 0 : contextAttrs[6];
 					m_context = wglCreateContextAttribsARB(m_hdc, 0, contextAttrs);
 				}


### PR DESCRIPTION
Re-capitalised "nVidia" to "NVIDIA" where applicable. A minor change, but it aids consistency and is now in-line with NVIDIA's own naming policy. You're welcome Jensen.